### PR TITLE
feat: 支持 macOS（Apple Silicon）桌面端

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   [![License: MIT](https://img.shields.io/github/license/lingcang728/ZeppBridge?color=69b48b)](LICENSE)
   [![Tauri 2](https://img.shields.io/badge/Tauri-2-24C8DB?logo=tauri&logoColor=white)](https://tauri.app/)
   [![Windows](https://img.shields.io/badge/platform-Windows-0078D4?logo=windows11&logoColor=white)](#下载与安装)
-  [![macOS](https://img.shields.io/badge/platform-macOS-333333?logo=apple&logoColor=white)](#下载与安装)
+  [![macOS](https://img.shields.io/badge/macOS-自行构建-333333?logo=apple&logoColor=white)](#从源码构建)
 </div>
 
 > [!IMPORTANT]
@@ -82,9 +82,16 @@ curl.exe "http://127.0.0.1:43921/workouts/<WORKOUT_ID>/series"
 
 **macOS（Apple Silicon）**
 
-1. 在 [Releases](https://github.com/lingcang728/ZeppBridge/releases) 页面下载 `ZeppBridge_<版本>_aarch64.dmg`，双击打开后把 `ZeppBridge.app` 拖入「应用程序」。
-2. 应用尚未签名/公证，首次打开会提示「无法验证开发者」。右键（或按住 Control 点按）应用 → 打开 → 再点「打开」即可；也可在终端执行 `xattr -dr com.apple.quarantine /Applications/ZeppBridge.app`。
-3. 升级时覆盖旧的 `ZeppBridge.app` 即可，本地数据保留在 `~/Library/Application Support/com.zeppbridge.ZeppBridge/data`。
+1. 当前 Releases 暂不提供 macOS 安装包，需自行构建（见下方[从源码构建](#从源码构建)）。
+2. 构建产物为 ad-hoc 签名，首次打开会提示「无法验证开发者」。右键（或按住 Control 点按）应用 → 打开 → 再点「打开」即可；也可在终端执行 `xattr -dr com.apple.quarantine /Applications/ZeppBridge.app`。
+3. 本地数据保留在 `~/Library/Application Support/com.zeppbridge.ZeppBridge/data`，覆盖升级不影响数据。
+
+## 从源码构建
+
+需要 Node 20+ 与 Rust 工具链（macOS 还需 Xcode Command Line Tools）。安装依赖后：
+
+- **macOS（Apple Silicon）**：`npm run build:mac`，产物在 `src-tauri/target/release/bundle/`（ZeppBridge.app 与 .dmg）
+- **Windows**：见 `scripts/windows/` 下的打包脚本
 
 ## 第一次连接
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 <div align="center">
   <img src="src-tauri/icons/icon.png" width="96" height="96" alt="ZeppBridge">
   <h1>ZeppBridge</h1>
-  <p><strong>把 Zepp 穿戴设备的健康数据，同步到你自己的 Windows 电脑。</strong></p>
+  <p><strong>把 Zepp 穿戴设备的健康数据，同步到你自己的 Windows / macOS 电脑。</strong></p>
   <p>Local-first desktop bridge for Zepp / Amazfit health data.</p>
 
   [![CI](https://github.com/lingcang728/ZeppBridge/actions/workflows/ci.yml/badge.svg)](https://github.com/lingcang728/ZeppBridge/actions/workflows/ci.yml)
   [![License: MIT](https://img.shields.io/github/license/lingcang728/ZeppBridge?color=69b48b)](LICENSE)
   [![Tauri 2](https://img.shields.io/badge/Tauri-2-24C8DB?logo=tauri&logoColor=white)](https://tauri.app/)
   [![Windows](https://img.shields.io/badge/platform-Windows-0078D4?logo=windows11&logoColor=white)](#下载与安装)
+  [![macOS](https://img.shields.io/badge/platform-macOS-333333?logo=apple&logoColor=white)](#下载与安装)
 </div>
 
 > [!IMPORTANT]
@@ -18,7 +19,7 @@
 Zepp 手机 App 把数据放在区域云端。ZeppBridge 在电脑上登录你的账号，把心率、睡眠、运动等记录拉到本机 SQLite，用桌面界面核对，再按需通过桌面界面、本机 REST API 或 JSON 导出交给你自己的工具。
 
 - **电脑直接读云**：设置里点「连接」，在弹出的官方登录页登入。不装证书，不改 Wi-Fi 代理。
-- **数据只在本机**：没有 ZeppBridge 自建云，也没有产品遥测。token 进 Windows Credential Manager。
+- **数据只在本机**：没有 ZeppBridge 自建云，也没有产品遥测。token 存系统凭据管理器（Windows Credential Manager / macOS 钥匙串）。
 - **不编造**：没有样本就不画曲线；没有设备信息就写「未提供」；云端拉取时间和健康样本时间分开显示。
 - **分析外置**：应用不做解读。到「交给 AI」复制标准化 JSON，或另存为 JSON / CSV / GPX。
 - **本机 API 网关**：其他本机程序可直接请求标准化的运动 samples、route、pauses 和 summary，无需理解 Zepp 原始差分字符串。
@@ -73,9 +74,17 @@ curl.exe "http://127.0.0.1:43921/workouts/<WORKOUT_ID>/series"
 
 ## 下载与安装
 
+**Windows**
+
 1. 在 [Releases](https://github.com/lingcang728/ZeppBridge/releases) 页面下载最新版安装包：`ZeppBridge_<版本>_x64-setup.exe` 或 `.msi`。
 2. 安装包尚未签名，Windows 可能提示「未知发布者」，选择「仍要运行」即可。
 3. 直接覆盖安装即可升级，本地数据会保留。
+
+**macOS（Apple Silicon）**
+
+1. 在 [Releases](https://github.com/lingcang728/ZeppBridge/releases) 页面下载 `ZeppBridge_<版本>_aarch64.dmg`，双击打开后把 `ZeppBridge.app` 拖入「应用程序」。
+2. 应用尚未签名/公证，首次打开会提示「无法验证开发者」。右键（或按住 Control 点按）应用 → 打开 → 再点「打开」即可；也可在终端执行 `xattr -dr com.apple.quarantine /Applications/ZeppBridge.app`。
+3. 升级时覆盖旧的 `ZeppBridge.app` 即可，本地数据保留在 `~/Library/Application Support/com.zeppbridge.ZeppBridge/data`。
 
 ## 第一次连接
 
@@ -90,7 +99,7 @@ curl.exe "http://127.0.0.1:43921/workouts/<WORKOUT_ID>/series"
 
 - 同步时会访问你授权的 Zepp 区域服务，所以这不是离线软件。
 - `auth.json` 只留用户 ID、区域主机等元数据，不含 token。
-- 健康库目前是本机明文 SQLite。共用电脑请使用独立的 Windows 账户。
+- 健康库目前是本机明文 SQLite。共用电脑请使用独立的系统账户。
 - 本机 REST API 只监听 `127.0.0.1` 且不开放浏览器跨域，但电脑上的其他本机进程仍可读取接口返回的健康数据与精确路线。
 - 应用没有自建云、没有产品遥测，数据只保存在你的电脑上。
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -528,9 +528,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -632,9 +629,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -649,9 +643,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -666,9 +657,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -683,9 +671,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -700,9 +685,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -717,9 +699,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -734,9 +713,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -751,9 +727,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -768,9 +741,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -785,9 +755,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -802,9 +769,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -819,9 +783,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -836,9 +797,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1028,9 +986,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1048,9 +1003,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1068,9 +1020,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1088,9 +1037,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1108,9 +1054,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -528,6 +528,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -629,6 +632,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -643,6 +649,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -657,6 +666,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -671,6 +683,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -685,6 +700,9 @@
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -699,6 +717,9 @@
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -713,6 +734,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -727,6 +751,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -741,6 +768,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -755,6 +785,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -769,6 +802,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -783,6 +819,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -797,6 +836,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -986,6 +1028,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1003,6 +1048,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1020,6 +1068,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1037,6 +1088,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1054,6 +1108,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview",
     "tauri": "tauri",
     "package:release": "pwsh -NoProfile -File scripts/windows/package-release.ps1",
+    "build:mac": "bash scripts/macos/build-release.sh",
     "publish:local": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/windows/publish-local.ps1 -UserEntryOnly",
     "icons:generate": "node scripts/icon/generate-icons.mjs",
     "icons:verify": "python scripts/icon/verify-icons.py || py -3 scripts/icon/verify-icons.py"

--- a/scripts/macos/build-release.sh
+++ b/scripts/macos/build-release.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Build the macOS (Apple Silicon) release bundle: ZeppBridge.app + .dmg.
+#
+# Usage:
+#   scripts/macos/build-release.sh          # local verification build
+#   TAURI_SIGNING_PRIVATE_KEY=... \
+#   TAURI_SIGNING_PRIVATE_KEY_PASSWORD=... \
+#   scripts/macos/build-release.sh          # publishable build (updater-signed)
+#
+# Without a signing key the updater artifacts are skipped, so a local build
+# never fails just because the private key is missing.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+if ! command -v cargo >/dev/null 2>&1; then
+  echo "错误：未找到 cargo，请先安装 Rust（https://rustup.rs）" >&2
+  exit 1
+fi
+if ! command -v npm >/dev/null 2>&1; then
+  echo "错误：未找到 npm" >&2
+  exit 1
+fi
+
+echo "==> 前端构建"
+npm run build
+
+echo "==> 图标校验"
+if ! command -v python3 >/dev/null 2>&1 || ! python3 -c 'import PIL' 2>/dev/null; then
+  echo "（跳过 icons:verify：需要 python3 + Pillow）"
+else
+  npm run icons:verify
+fi
+
+echo "==> Rust 格式与测试"
+cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check
+cargo test --manifest-path src-tauri/Cargo.toml --locked
+
+BUNDLES="app,dmg"
+EXTRA_ARGS=()
+if [[ -z "${TAURI_SIGNING_PRIVATE_KEY:-}" && -z "${TAURI_SIGNING_PRIVATE_KEY_PATH:-}" ]]; then
+  echo "==> 未检测到 updater 签名私钥，跳过 updater artifacts（本地验证构建）"
+  EXTRA_ARGS+=(--config '{"bundle":{"createUpdaterArtifacts":false}}')
+else
+  echo "==> 检测到 updater 签名私钥，生成可发布产物"
+fi
+
+echo "==> Tauri 打包（aarch64-apple-darwin）"
+npx tauri build --bundles "$BUNDLES" "${EXTRA_ARGS[@]}"
+
+echo
+echo "构建完成，产物："
+echo "  app: src-tauri/target/release/bundle/macos/ZeppBridge.app"
+echo "  dmg: src-tauri/target/release/bundle/dmg/ZeppBridge_*.dmg"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5908,7 +5908,6 @@ dependencies = [
  "regex",
  "reqwest 0.12.28",
  "rusqlite",
- "security-framework 3.7.0",
  "serde",
  "serde_json",
  "sha2",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2170,6 +2170,8 @@ checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
 dependencies = [
  "byteorder",
  "log",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
  "windows-sys 0.60.2",
  "zeroize",
 ]
@@ -2368,7 +2370,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "tempfile",
 ]
@@ -3341,7 +3343,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -3368,7 +3370,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki",
- "security-framework",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -3477,6 +3479,19 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
 
 [[package]]
 name = "security-framework"
@@ -5893,6 +5908,7 @@ dependencies = [
  "regex",
  "reqwest 0.12.28",
  "rusqlite",
+ "security-framework 3.7.0",
  "serde",
  "serde_json",
  "sha2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -39,3 +39,7 @@ url = "2.5"
 
 [target.'cfg(windows)'.dependencies]
 keyring = { version = "3.6.3", default-features = false, features = ["windows-native"] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+keyring = { version = "3.6.3", default-features = false, features = ["apple-native"] }
+security-framework = "3"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -42,4 +42,3 @@ keyring = { version = "3.6.3", default-features = false, features = ["windows-na
 
 [target.'cfg(target_os = "macos")'.dependencies]
 keyring = { version = "3.6.3", default-features = false, features = ["apple-native"] }
-security-framework = "3"

--- a/src-tauri/src/auth/mod.rs
+++ b/src-tauri/src/auth/mod.rs
@@ -63,22 +63,56 @@ impl CredentialBackend for WindowsCredentialBackend {
     }
 }
 
-#[cfg(not(windows))]
+#[cfg(target_os = "macos")]
+#[derive(Debug, Default)]
+pub struct MacOsCredentialBackend;
+
+#[cfg(target_os = "macos")]
+impl CredentialBackend for MacOsCredentialBackend {
+    fn set(&self, user_id: &str, token: &str) -> std::result::Result<(), String> {
+        let entry = keyring::Entry::new(CREDENTIAL_SERVICE, user_id)
+            .map_err(|_| "无法打开 macOS 钥匙串条目".to_string())?;
+        entry
+            .set_password(token)
+            .map_err(|_| "无法写入 macOS 钥匙串".to_string())
+    }
+
+    fn get(&self, user_id: &str) -> std::result::Result<Option<String>, String> {
+        let entry = keyring::Entry::new(CREDENTIAL_SERVICE, user_id)
+            .map_err(|_| "无法打开 macOS 钥匙串条目".to_string())?;
+        match entry.get_password() {
+            Ok(value) => Ok(Some(value)),
+            Err(keyring::Error::NoEntry) => Ok(None),
+            Err(_) => Err("无法读取 macOS 钥匙串".to_string()),
+        }
+    }
+
+    fn delete(&self, user_id: &str) -> std::result::Result<(), String> {
+        let entry = keyring::Entry::new(CREDENTIAL_SERVICE, user_id)
+            .map_err(|_| "无法打开 macOS 钥匙串条目".to_string())?;
+        match entry.delete_credential() {
+            Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
+            Err(_) => Err("无法删除 macOS 钥匙串条目".to_string()),
+        }
+    }
+}
+
+#[cfg(all(not(windows), not(target_os = "macos")))]
 #[derive(Debug, Default)]
 struct UnavailableCredentialBackend;
 
-#[cfg(not(windows))]
+#[cfg(all(not(windows), not(target_os = "macos")))]
 impl CredentialBackend for UnavailableCredentialBackend {
     fn set(&self, _user_id: &str, _token: &str) -> std::result::Result<(), String> {
-        Err("Windows 凭据管理器仅在 Windows 上可用；测试请注入 CredentialBackend".to_string())
+        Err("凭据管理器仅在 Windows/macOS 上可用；测试请注入 CredentialBackend".to_string())
     }
 
     fn get(&self, _user_id: &str) -> std::result::Result<Option<String>, String> {
-        Err("Windows 凭据管理器仅在 Windows 上可用；测试请注入 CredentialBackend".to_string())
+        Err("凭据管理器仅在 Windows/macOS 上可用；测试请注入 CredentialBackend".to_string())
     }
 
     fn delete(&self, _user_id: &str) -> std::result::Result<(), String> {
-        Err("Windows 凭据管理器仅在 Windows 上可用；测试请注入 CredentialBackend".to_string())
+        Err("凭据管理器仅在 Windows/macOS 上可用；测试请注入 CredentialBackend".to_string())
     }
 }
 
@@ -419,7 +453,11 @@ fn default_credential_backend() -> Arc<dyn CredentialBackend> {
     {
         Arc::new(WindowsCredentialBackend)
     }
-    #[cfg(not(windows))]
+    #[cfg(target_os = "macos")]
+    {
+        Arc::new(MacOsCredentialBackend)
+    }
+    #[cfg(all(not(windows), not(target_os = "macos")))]
     {
         Arc::new(UnavailableCredentialBackend)
     }

--- a/src-tauri/src/commands/data.rs
+++ b/src-tauri/src/commands/data.rs
@@ -1630,7 +1630,7 @@ mod tests {
     }
 }
 
-/// Open the application's local data directory in Windows Explorer.
+/// Open the application's local data directory in the platform file manager.
 #[tauri::command]
 pub fn open_data_folder(state: tauri::State<'_, AppState>) -> std::result::Result<(), String> {
     #[cfg(target_os = "windows")]
@@ -1642,9 +1642,18 @@ pub fn open_data_folder(state: tauri::State<'_, AppState>) -> std::result::Resul
             .map_err(|error| format!("打开数据文件夹失败: {error}"))
     }
 
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(target_os = "macos")]
+    {
+        std::process::Command::new("open")
+            .arg(&state.data_dir)
+            .spawn()
+            .map(|_| ())
+            .map_err(|error| format!("打开数据文件夹失败: {error}"))
+    }
+
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
     {
         let _ = state;
-        Err("打开数据文件夹仅支持 Windows".to_string())
+        Err("打开数据文件夹仅支持 Windows/macOS".to_string())
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -44,6 +44,7 @@ fn show_main_window(app: &AppHandle) {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    #[cfg(target_os = "windows")]
     if let Ok(data_dir) = paths::resolve_data_dir() {
         let webview_dir = paths::webview_user_data_dir(&data_dir);
         let _ = std::fs::create_dir_all(&webview_dir);

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,4 +1,5 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
+// On macOS, .app bundles have no console window by default.
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {

--- a/src-tauri/src/paths.rs
+++ b/src-tauri/src/paths.rs
@@ -17,6 +17,10 @@ const LEGACY_DIRS: [&str; 2] = ["exports", "backups"];
 /// Build-cache binaries (`cargo-target`, rustc `target/`) never own user data.
 /// Those fall back to the repository `data/` folder so `tauri dev` does not
 /// drop a 1GB library into `G:\build_cache`.
+///
+/// macOS: `.app` bundles live in `/Applications`, which is not writable, so
+/// the install-local layout falls back to the user Application Support
+/// directory (`~/Library/Application Support/com.zeppbridge.ZeppBridge/data`).
 pub fn resolve_data_dir() -> io::Result<PathBuf> {
     let exe = std::env::current_exe()?;
     let exe_dir = exe.parent().ok_or_else(|| {
@@ -30,8 +34,29 @@ pub fn resolve_data_dir() -> io::Result<PathBuf> {
     } else {
         exe_dir.join("data")
     };
-    ensure_writable_dir(&data_dir)?;
-    Ok(data_dir)
+    match ensure_writable_dir(&data_dir) {
+        Ok(()) => Ok(data_dir),
+        #[cfg(target_os = "macos")]
+        Err(_) => {
+            // /Applications/ZeppBridge.app/Contents/MacOS is read-only; store
+            // user data under the user's Application Support instead.
+            let base = user_support_data_dir()?;
+            ensure_writable_dir(&base)?;
+            Ok(base)
+        }
+        #[cfg(not(target_os = "macos"))]
+        Err(error) => Err(error),
+    }
+}
+
+/// User-writable data directory for macOS: `~/Library/Application Support/
+/// com.zeppbridge.ZeppBridge/data` (same `data/` layout as the Windows
+/// install-local folder).
+#[cfg(target_os = "macos")]
+fn user_support_data_dir() -> io::Result<PathBuf> {
+    let project = directories::ProjectDirs::from("com", "zeppbridge", "ZeppBridge")
+        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "无法确定用户数据目录"))?;
+    Ok(project.data_dir().join("data"))
 }
 
 pub fn webview_user_data_dir(data_dir: &Path) -> PathBuf {

--- a/src-tauri/src/updates.rs
+++ b/src-tauri/src/updates.rs
@@ -1,6 +1,12 @@
-use std::{path::PathBuf, process::Command, thread, time::Duration};
 use tauri::AppHandle;
 
+#[cfg(windows)]
+use std::{path::PathBuf, process::Command, thread, time::Duration};
+
+/// The portable-update migration path is a Windows-only concept: the portable
+/// build lives in a user-writable folder next to a future install, while
+/// macOS ships a single `.app` bundle with no portable variant.
+#[cfg(windows)]
 fn installed_path() -> Result<PathBuf, String> {
     let local = std::env::var_os("LOCALAPPDATA")
         .ok_or_else(|| "Windows LOCALAPPDATA 路径不可用".to_string())?;
@@ -11,25 +17,43 @@ fn installed_path() -> Result<PathBuf, String> {
 
 #[tauri::command]
 pub(crate) fn is_portable_update() -> Result<bool, String> {
-    let current = std::env::current_exe().map_err(|error| error.to_string())?;
-    let installed = installed_path()?;
-    Ok(!current
-        .to_string_lossy()
-        .eq_ignore_ascii_case(&installed.to_string_lossy()))
+    #[cfg(windows)]
+    {
+        let current = std::env::current_exe().map_err(|error| error.to_string())?;
+        let installed = installed_path()?;
+        Ok(!current
+            .to_string_lossy()
+            .eq_ignore_ascii_case(&installed.to_string_lossy()))
+    }
+    // macOS/.app and other platforms are never portable builds.
+    #[cfg(not(windows))]
+    {
+        Ok(false)
+    }
 }
 
 #[tauri::command]
 pub(crate) fn launch_migrated_install(app: AppHandle) -> Result<(), String> {
-    let installed = installed_path()?;
-    for _ in 0..30 {
-        if installed.is_file() {
-            Command::new(&installed)
-                .spawn()
-                .map_err(|error| format!("无法启动更新后的安装版：{error}"))?;
-            app.exit(0);
-            return Ok(());
+    #[cfg(windows)]
+    {
+        let installed = installed_path()?;
+        for _ in 0..30 {
+            if installed.is_file() {
+                Command::new(&installed)
+                    .spawn()
+                    .map_err(|error| format!("无法启动更新后的安装版：{error}"))?;
+                app.exit(0);
+                return Ok(());
+            }
+            thread::sleep(Duration::from_millis(500));
         }
-        thread::sleep(Duration::from_millis(500));
+        Err("安装完成后未找到新的 ZeppBridge 安装版".into())
     }
-    Err("安装完成后未找到新的 ZeppBridge 安装版".into())
+    // Never reached on non-Windows: the frontend only calls this when
+    // `is_portable_update()` returned true.
+    #[cfg(not(windows))]
+    {
+        let _ = app;
+        Err("便携版安装迁移仅支持 Windows".into())
+    }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -47,6 +47,9 @@
     "shortDescription": "Local-first Zepp health data bridge",
     "longDescription": "ZeppBridge is a local-first desktop companion for syncing and exploring Zepp wearable health data.",
     "copyright": "Copyright © 2026 ZeppBridge contributors",
+    "macOS": {
+      "minimumSystemVersion": "11.0"
+    },
     "windows": {
       "wix": {
         "language": "en-US"


### PR DESCRIPTION
## 概述

为 ZeppBridge 增加 macOS（Apple Silicon）桌面端支持：可构建 `.app` + `.dmg`，适配 M 芯片原生运行。

## 改动内容

- **bundle 配置**：`tauri.conf.json` 增加 `bundle.macOS.minimumSystemVersion = "11.0"`
- **数据目录**：`paths.rs` 在安装目录（/Applications，只读）不可写时，回退到 `~/Library/Application Support/com.zeppbridge.ZeppBridge/data`，保持与 Windows 端一致的 `data/` 布局
- **打开数据文件夹**：`open_data_folder` 增加 macOS 分支（`open` 命令）
- **更新流程**：`is_portable_update` / `launch_migrated_install` 用 `#[cfg(windows)]` 隔离，macOS 直接走 `relaunch`（无便携版概念）
- **WebView**：WEBVIEW2 数据目录设置限定 Windows，避免 macOS 误用
- **凭据存储**：`auth/mod.rs` 新增 macOS 钥匙串后端（`MacOsCredentialBackend`），`Cargo.toml` 增加对应 target 依赖（keyring apple-native）
- **构建脚本**：新增 `scripts/macos/build-release.sh`（npm run build:mac），无 TAURI_SIGNING_PRIVATE_KEY 时自动跳过 updater artifacts，方便本地验证构建
- **README**：补充 macOS 说明（需自行构建，Releases 暂不提供 dmg 产物）

## 验证情况

- 已 rebase 到最新 main（含 CSV/GPX 导出），Rust 测试 **81 个用例全部通过**，release 编译无警告
- 产物为 `aarch64-apple-darwin` 原生二进制（M 芯片）
- 已在本机 M 芯片上冒烟验证：/Applications 只读场景下数据目录回退正常、应用可启动并建库

## 备注

- macOS 端未做 Apple Developer 签名/公证（ad-hoc 签名），正式分发前需补充
- 更新发布需 TAURI_SIGNING_PRIVATE_KEY（可与 Windows 端复用同一把 key）