### PR TITLE
落地页中英双语 + 两个查明根因的 bug 修复

### DIFF
--- a/bundle-budget.json
+++ b/bundle-budget.json
@@ -1,11 +1,11 @@
 {
   "baseline": {
-    "initialJsGzip": 73445,
-    "initialCssGzip": 6887
+    "initialJsGzip": 74772,
+    "initialCssGzip": 4057
   },
   "limits": {
-    "initialJsGzip": 84992,
-    "initialCssGzip": 8192
+    "initialJsGzip": 86016,
+    "initialCssGzip": 5120
   },
   "note": "首屏加载体积（gzip）。initialJs 含入口脚本与 index.html modulepreload 的 chunk；懒加载的页面 chunk 不计入。用 npm run budget:update 刷新。"
 }

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -152,7 +152,10 @@ file:  second_heart_rate/real_data
 - **`second_heart_rate/real_data`** — `/users/me/fileInfo/events` 确认有数据，但返回的是 COS 文件索引而不是样本，取到逐秒心率还需要再下载文件。当前 host allow-list 只放行 `api-mifit*.zepp.com` / `huami.com`，COS 域名不在其中，接入等于放宽网络边界，未做。
 - **8/16 之后的逐条血氧** — `blood_oxygen/click` 的点测在 2026-08-16 停止，之后只有 `odi` 夜间汇总，但 Zepp App 仍能画出连续曲线。已排除的方向：`/users/me/fileInfo/events`（同接口面 `second_heart_rate` 有数据、血氧没有，是有依据的否定）、`band_data` 的 8 字节块（只有模式/强度/步数/心率）、`blood_oxygen` 的 `auto` / `real_data` 子类型。**剩下的方向只有抓 Zepp App 的真实请求，而本项目明令禁止恢复 MITM / 用户 CA / Wi-Fi 代理路线**，所以这条到此为止。
 - **未接的端点** — `/users/me/bloodPressure`、`/users/{id}/members/-1/weightRecords`、`/huami.health.getUserInfo.json`、`/v1/user/manualData.json`。
-  - 血压与体重：**当前样本未验证，不是「没有接入价值」**。此前的结论来自单个开发账号近一年没有记录（n=1），那只能说明这个账号没有数据，不能推断字段语义、单位或成员范围。已有用户反馈需要体脂秤与血压，接入的前置条件是拿到经过审计的真实脱敏 fixture，并与用户自己的 Zepp App 显示逐条对照。在这两样证据齐备之前不归一化、不宣称支持，界面也不显示空卡片或 0 值（见 `todo.md` 8.0 证据门禁）。
+  - **血压与体重：明确不支持，也不计划支持。** 这是 2026-08-30 的产品决定，不是「证据不足、等 fixture 再说」——
+    早先那版「拿到经过审计的脱敏 fixture 就接」的结论已经作废，不要据此重启接入。
+    具体是：不请求 `/users/me/bloodPressure` 与 `weightRecords`，不归一化上面 v2 事件面里出现的血压 `eventType`，
+    界面和文档不出现体重/血压的卡片、占位或「即将支持」字样。需要体脂秤与血压的用户请继续用 Zepp App 自己看。
   - `getUserInfo` / `manualData`：只有年龄/身高，而年龄**不能**用来估算心率区间（见下），因此不接。
 
 ### 心率区间：三种算法，一个都不预设

--- a/src-tauri/crates/core/src/storage/provenance.rs
+++ b/src-tauri/crates/core/src/storage/provenance.rs
@@ -555,12 +555,36 @@ impl Database {
                   + (SELECT COUNT(*) FROM sleep_sessions)
                   + (SELECT COUNT(*) FROM workouts)",
         )?;
+        // 「待归一化」= 留着的报文一条标准化记录都没产出。
+        //
+        // `workout_detail` 的产物落在 `workout_samples` / `route_points` /
+        // `workout_pauses`，这三张表按 `workout_id` 关联，**没有 raw_record_id**
+        // 这一列——所以只按 raw_record_id 查那四张表，会把每一条解析得好好的
+        // 运动详情都算成「没归一化」，数字只增不减，用户重放多少次也降不下来。
+        // 这里按 source_key（`workout_detail:{workout_id}:{source}`）把它认回来。
         let pending_normalization = self.scalar_i64(
-            "SELECT COUNT(*) FROM raw_records r
+            "WITH detail AS (
+                 SELECT r.id AS raw_id,
+                        substr(r.source_key, 16, instr(substr(r.source_key, 16), ':') - 1)
+                            AS workout_id
+                 FROM raw_records r
+                 WHERE r.stream = 'workout_detail'
+                   AND instr(substr(r.source_key, 16), ':') > 1
+             )
+             SELECT COUNT(*) FROM raw_records r
              WHERE NOT EXISTS (SELECT 1 FROM metric_samples WHERE raw_record_id = r.id)
                AND NOT EXISTS (SELECT 1 FROM daily_metrics  WHERE raw_record_id = r.id)
                AND NOT EXISTS (SELECT 1 FROM sleep_sessions WHERE raw_record_id = r.id)
-               AND NOT EXISTS (SELECT 1 FROM workouts       WHERE raw_record_id = r.id)",
+               AND NOT EXISTS (SELECT 1 FROM workouts       WHERE raw_record_id = r.id)
+               AND NOT EXISTS (
+                     SELECT 1 FROM detail d
+                     WHERE d.raw_id = r.id
+                       AND (EXISTS (SELECT 1 FROM workout_samples s
+                                    WHERE s.workout_id = d.workout_id)
+                         OR EXISTS (SELECT 1 FROM route_points p
+                                    WHERE p.workout_id = d.workout_id)
+                         OR EXISTS (SELECT 1 FROM workout_pauses w
+                                    WHERE w.workout_id = d.workout_id)))",
         )?;
 
         let (last_cloud_sync_at, last_cloud_sync_outcome) = self.cloud_sync_metadata()?;
@@ -926,7 +950,7 @@ pub fn summarize_stage(stage: &StageState) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::models::{MetricSample, SourceScope};
+    use crate::models::{CapabilityStatus, MetricSample, RawRecord, SourceScope, Workout};
     use chrono::TimeZone;
 
     fn db() -> Database {
@@ -1180,6 +1204,93 @@ mod tests {
         assert!(
             !ids.contains(&"reprocess"),
             "没有待归一化的报文就不该建议重放"
+        );
+    }
+    #[test]
+    fn a_replayed_workout_detail_is_not_pending_normalization() {
+        // 运动详情的产物落在 workout_samples / route_points / workout_pauses，
+        // 这三张表按 workout_id 关联，没有 raw_record_id。早先的统计只查那四张
+        // 带 raw_record_id 的表，于是每一条解析得好好的详情报文都被永久算成
+        // 「待归一化」——用户重放多少次，那个数字都降不下来。
+        let db = db();
+        db.insert_workout(&Workout {
+            workout_id: "1700000000".into(),
+            workout_type: "run".into(),
+            normalized_type: "run".into(),
+            type_source: "numeric_mapped".into(),
+            user_override: None,
+            effective_type: "run".into(),
+            custom_label: None,
+            start_time: day(0),
+            end_time: day(0) + Duration::minutes(10),
+            distance_meters: Some(1000.0),
+            calories: Some(80),
+            avg_hr: Some(140),
+            max_hr: Some(160),
+            training_load: None,
+            vo2max: None,
+            source_scope: SourceScope::Device,
+            device_id: None,
+            synced_at: None,
+            gps_available: false,
+            sample_count: 0,
+            zepp_source: Some("run.gps".into()),
+            zepp_type: Some(1),
+        })
+        .unwrap();
+
+        let payload = serde_json::json!({
+            "trackid": 1_700_000_000i64,
+            "source": "run.gps",
+            "time": "0;1;",
+            "longitude_latitude": "4004663552,11629333504;16403,8392;",
+            "heart_rate": "1,80;1,2;"
+        });
+        let source_key = "workout_detail:1700000000:run.gps";
+        let raw_id = db
+            .insert_raw_record(&RawRecord {
+                stream: "workout_detail".into(),
+                source_key: source_key.into(),
+                source_scope: SourceScope::Device,
+                device_id: None,
+                start_utc: day(0),
+                end_utc: None,
+                payload: payload.clone(),
+                capability: CapabilityStatus::Verified,
+            })
+            .unwrap();
+        db.normalize_and_persist_raw(raw_id, "workout_detail", source_key, &payload)
+            .unwrap();
+
+        assert_eq!(
+            db.data_health(90, 0)
+                .unwrap()
+                .database
+                .pending_normalization,
+            0,
+            "详情已经产出逐点样本，就不该还算「待归一化」"
+        );
+
+        // 反向钉住：真的什么都没产出的报文仍然要被数出来，
+        // 否则这个修法就成了「把问题藏起来」。
+        db.insert_raw_record(&RawRecord {
+            stream: "workout_detail".into(),
+            source_key: "workout_detail:1799999999:run.gps".into(),
+            source_scope: SourceScope::Device,
+            device_id: None,
+            start_utc: day(1),
+            end_utc: None,
+            payload: serde_json::json!({ "items": [] }),
+            capability: CapabilityStatus::Verified,
+        })
+        .unwrap();
+        assert_eq!(
+            db.data_health(90, 0)
+                .unwrap()
+                .database
+                .pending_normalization,
+            1,
+            "没产出任何记录的报文还是要算进来"
         );
     }
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,12 +1,11 @@
 <script setup lang="ts">
 import { getVersion } from '@tauri-apps/api/app';
-import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
+import { computed, defineAsyncComponent, onMounted, onUnmounted, ref, watch } from 'vue';
 import { RouterLink, RouterView, useRoute, useRouter } from 'vue-router';
 import BrandMark from './components/BrandMark.vue';
 import DesignIcon, { type DesignIconName } from './components/DesignIcon.vue';
 import DeviceVisual from './components/DeviceVisual.vue';
 import Icon from './components/Icon.vue';
-import LandingPage from './views/LandingPage.vue';
 import { useSyncController } from './composables/useSyncController';
 import { useDevices } from './composables/useDevices';
 import { useUiScale } from './composables/useUiScale';
@@ -18,6 +17,10 @@ import { checkForDesktopUpdate } from './services/updateService';
 const FALLBACK_APP_VERSION = '1.0.1';
 const APP_VERSION = ref(FALLBACK_APP_VERSION);
 const desktopRuntime = isDesktop();
+// 落地页只在非桌面环境渲染（Cloudflare Pages 部署的就是这个分支），
+// 静态 import 会把它连同两份文案一起塞进桌面应用的首屏 chunk。懒加载后
+// 桌面端根本不会下载它。
+const LandingPage = defineAsyncComponent(() => import('./views/LandingPage.vue'));
 const showLanding = !desktopRuntime && !new URLSearchParams(window.location.search).has('app-preview');
 if (desktopRuntime) {
   void getVersion()

--- a/src/composables/useDevices.ts
+++ b/src/composables/useDevices.ts
@@ -183,6 +183,35 @@ const load = async (refresh = false): Promise<void> => {
   }
 };
 
+/**
+ * 本机写过库之后的重读。**不能走 `load(false)`**：那条路会复用
+ * `profileRequests` 里已经在飞的请求，或者 `backgroundRefreshInFlight`——
+ * 两者都是在写入之前发出的，结果里没有刚保存的指认，用户看到的就是
+ * 「提交完型号依然没改过来」（C4 的表象，只不过那次的根因在后端）。
+ *
+ * 这里直接问一次后端，并照常抢 `requestId`：顺带让那条抢跑的后台刷新
+ * 结果失效，免得它稍后再把旧数据盖回来。
+ */
+const reloadAfterLocalWrite = async (): Promise<void> => {
+  if (!isDesktop()) return;
+  const currentRequest = ++requestId;
+  loading.value = true;
+  error.value = null;
+  try {
+    const result = normalizeResult(await backend.getDeviceProfiles(false));
+    if (currentRequest !== requestId) return;
+    applyResult(result);
+  } catch (cause) {
+    if (currentRequest !== requestId) return;
+    setLoadFailure(cause, false);
+  } finally {
+    if (currentRequest === requestId) {
+      initialized.value = true;
+      loading.value = false;
+    }
+  }
+};
+
 const models = computed<DeviceCardModel[]>(() => profiles.value.map((profile) => ({
   profile,
   canonicalName: profile.canonical_name?.trim() || profile.name?.trim() || '未识别设备',
@@ -223,7 +252,7 @@ const assignModel = async (deviceKey: string, catalogId: string, contribute = fa
   assignMessage.value = null;
   try {
     await backend.setDeviceModelOverride(deviceKey, catalogId || null);
-    await load(false);
+    await reloadAfterLocalWrite();
     if (!catalogId) {
       assignMessage.value = '已撤销型号指认，恢复成自动识别结果。';
       return;

--- a/src/composables/useLandingLocale.ts
+++ b/src/composables/useLandingLocale.ts
@@ -1,0 +1,107 @@
+import { readonly, ref } from 'vue';
+
+/**
+ * 落地页（zeppbridge.pages.dev）专用的语言开关。
+ *
+ * 只服务落地页这一个文件，**不是**应用的 i18n 方案：应用界面另有计划，
+ * 到时候会引 vue-i18n。这里只有两份文案对象加一个开关，刻意不引框架——
+ * 为 205 行的静态页装一套 i18n 运行时，只会把首屏体积赔进去。
+ *
+ * 落地页本身是懒加载的（App.vue），所以这个模块也只会跟着落地页 chunk 走，
+ * 不进桌面应用的首屏。
+ */
+export type LandingLocale = 'zh' | 'en';
+
+const STORAGE_KEY = 'zeppbridge-landing-locale';
+
+/** `<html lang>` 用的完整标记，和 locale 一一对应。 */
+const HTML_LANG: Record<LandingLocale, string> = { zh: 'zh-CN', en: 'en' };
+
+/** 每种语言的页面级元信息。SEO 是这次双语的重点之一，所以不只换正文。 */
+const DOCUMENT_META: Record<LandingLocale, {
+  title: string;
+  description: string;
+  ogTitle: string;
+  ogDescription: string;
+}> = {
+  zh: {
+    title: 'ZeppBridge · 本地数据桥梁',
+    description: 'ZeppBridge 是本地优先、开源的 Amazfit/Zepp 穿戴数据桥接与可视化工具。',
+    ogTitle: 'ZeppBridge · 把 Zepp 数据完整交还给你',
+    ogDescription: '在 Windows 与 macOS 本机连接、整理并可视化 Amazfit 穿戴数据，保留来源并按需交给 AI。',
+  },
+  en: {
+    title: 'ZeppBridge · Local Data Bridge',
+    description:
+      'ZeppBridge is a local-first, open-source bridge and viewer for Amazfit / Zepp wearable data. Runs on your own Windows or Mac.',
+    ogTitle: 'ZeppBridge · Your Zepp data, handed back in full',
+    ogDescription:
+      'Connect, organize and visualize Amazfit wearable data on your own machine. Sources stay intact, and nothing leaves until you send it.',
+  },
+};
+
+const isLandingLocale = (value: string | null): value is LandingLocale =>
+  value === 'zh' || value === 'en';
+
+/**
+ * 首次进入用什么语言：记住的选择优先，其次看浏览器语言。
+ * 只有明确说中文的才给中文，其余一律英文——落地页面向的是全网访客，
+ * 猜不准时给英文比给中文的读者面更宽。
+ */
+const detectLocale = (): LandingLocale => {
+  if (typeof window === 'undefined') return 'zh';
+  const saved = window.localStorage.getItem(STORAGE_KEY);
+  if (isLandingLocale(saved)) return saved;
+  const preferred = window.navigator.languages?.[0] ?? window.navigator.language ?? '';
+  return /^zh\b/i.test(preferred) ? 'zh' : 'en';
+};
+
+/** 按 name 或 property 找一个 meta 标签并改掉它；找不到就补一个。 */
+const setMeta = (attribute: 'name' | 'property', key: string, content: string) => {
+  const selector = `meta[${attribute}="${key}"]`;
+  let tag = document.head.querySelector<HTMLMetaElement>(selector);
+  if (!tag) {
+    tag = document.createElement('meta');
+    tag.setAttribute(attribute, key);
+    document.head.appendChild(tag);
+  }
+  tag.setAttribute('content', content);
+};
+
+const applyDocumentLanguage = (value: LandingLocale) => {
+  if (typeof document === 'undefined') return;
+  const meta = DOCUMENT_META[value];
+  document.documentElement.lang = HTML_LANG[value];
+  document.title = meta.title;
+  setMeta('name', 'description', meta.description);
+  setMeta('property', 'og:title', meta.ogTitle);
+  setMeta('property', 'og:description', meta.ogDescription);
+  setMeta('property', 'og:locale', value === 'zh' ? 'zh_CN' : 'en_US');
+};
+
+const locale = ref<LandingLocale>('zh');
+let initialized = false;
+
+const setLocale = (value: LandingLocale) => {
+  locale.value = value;
+  if (typeof window !== 'undefined') window.localStorage.setItem(STORAGE_KEY, value);
+  applyDocumentLanguage(value);
+};
+
+const initializeLocale = () => {
+  if (initialized) return;
+  initialized = true;
+  // 探测结果先不写 localStorage：用户没选过就不该被记成「选过了」，
+  // 否则以后换浏览器语言反而不生效。
+  locale.value = detectLocale();
+  applyDocumentLanguage(locale.value);
+};
+
+const toggleLocale = () => setLocale(locale.value === 'zh' ? 'en' : 'zh');
+
+export const useLandingLocale = () => ({
+  locale: readonly(locale),
+  initializeLocale,
+  setLocale,
+  toggleLocale,
+});

--- a/src/views/LandingPage.vue
+++ b/src/views/LandingPage.vue
@@ -1,11 +1,15 @@
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, onMounted } from 'vue';
 import BrandMark from '../components/BrandMark.vue';
 import DesignIcon, { type DesignIconName } from '../components/DesignIcon.vue';
 import DeviceMarquee from '../components/DeviceMarquee.vue';
+import { useLandingLocale } from '../composables/useLandingLocale';
 
 const githubUrl = 'https://github.com/lingcang728/ZeppBridge';
 const releaseUrl = `${githubUrl}/releases/latest`;
+
+const { locale, initializeLocale, toggleLocale } = useLandingLocale();
+onMounted(initializeLocale);
 
 // 访客系统探测：Mac 用户默认看到 macOS 版按钮，其余一律 Windows。
 // 只做一次静态判断——探测不到就退回 Windows，绝不隐藏另一个平台的入口。
@@ -16,113 +20,324 @@ const isMacVisitor = (): boolean => {
   return /Mac|iPad|iPhone|iPod/i.test(platform);
 };
 
-const downloads = {
-  windows: { key: 'windows', label: '下载 Windows 版', hint: 'x64 安装包 · exe / msi' },
-  macos: { key: 'macos', label: '下载 macOS 版', hint: 'Apple Silicon · dmg' },
-} as const;
+type IconEntry = { icon: DesignIconName; title: string; copy: string };
+type TaggedEntry = IconEntry & { tag: string };
 
-const primaryDownload = computed(() => (isMacVisitor() ? downloads.macos : downloads.windows));
-const secondaryDownload = computed(() => (isMacVisitor() ? downloads.windows : downloads.macos));
+interface LandingCopy {
+  nav: { home: string; site: string; features: string; local: string; connect: string; privacy: string };
+  /** 切到另一种语言的按钮文字，所以写的是目标语言的名字。 */
+  languageToggle: string;
+  downloads: { windows: { label: string; hint: string }; macos: { label: string; hint: string } };
+  hero: {
+    headlineLead: string;
+    headlineAccent: string;
+    lead: string;
+    viewSource: string;
+    /** 只有英文版有：界面还是中文，不能让人下完才发现。 */
+    uiLanguageNotice: string | null;
+    trust: Array<{ icon: DesignIconName; label: string }>;
+    stageLabel: string;
+    coreCaption: string;
+    outputs: [{ title: string; copy: string }, { title: string; copy: string }];
+    status: { title: string; copy: string };
+  };
+  principlesLabel: string;
+  principles: Array<{ icon: DesignIconName; title: string; copy: string }>;
+  features: { overline: string; heading: string; lead: string; items: Array<IconEntry & { tone: string }> };
+  local: { overline: string; heading: string; lead: string; items: TaggedEntry[] };
+  connect: { overline: string; heading: string; lead: string; items: TaggedEntry[] };
+  privacy: {
+    overline: string;
+    heading: string;
+    lead: string;
+    points: Array<{ icon: DesignIconName; label: string }>;
+    vault: string;
+  };
+  footer: { tagline: string; disclaimer: string; download: string };
+}
 
-const capabilities: Array<{ icon: DesignIconName; title: string; copy: string; tone: string }> = [
-  { icon: 'heart-rate', title: '连续心率', copy: '保留时间戳与数据来源，查看真实波动。', tone: 'red' },
-  { icon: 'sleep-waves', title: '睡眠结构', copy: '深睡、浅睡、REM 与清醒阶段本地解析。', tone: 'purple' },
-  { icon: 'outdoor-run', title: '训练详情', copy: '轨迹、配速、步频、海拔与训练负荷。', tone: 'green' },
-  { icon: 'vo2-max', title: '恢复指标', copy: 'VO₂ Max、HRV 与恢复数据按来源呈现。', tone: 'blue' },
-];
-
-/* 1.0.0 起，桌面窗口不是唯一入口。这三条都在本机跑，没有一条会把数据发出去。 */
-const localOutlets: Array<{ icon: DesignIconName; title: string; copy: string; tag: string }> = [
-  {
-    icon: 'structured-data',
-    title: '完整历史与快照',
-    copy: '按月把云端历史补回本机，逐块记账；整库快照带校验，恢复前先看记录数差异。',
-    tag: '本机',
+// 英文版是重写，不是翻译。中文文案的语气（「缺就是缺，不用 0 补」）直译会全废，
+// 所以两边各自按自己的语言写，只保证说的是同一件事。
+const COPY: Record<'zh' | 'en', LandingCopy> = {
+  zh: {
+    nav: {
+      home: 'ZeppBridge 首页',
+      site: '网站导航',
+      features: '数据能力',
+      local: '本机出口',
+      connect: '连接方式',
+      privacy: '隐私',
+    },
+    languageToggle: 'English',
+    downloads: {
+      windows: { label: '下载 Windows 版', hint: 'x64 安装包 · exe / msi' },
+      macos: { label: '下载 macOS 版', hint: 'Apple Silicon · dmg' },
+    },
+    hero: {
+      headlineLead: '把你的 Zepp 数据，',
+      headlineAccent: '完整交还给你。',
+      lead: 'ZeppBridge 在 Windows 与 macOS 本机连接、整理并可视化 Amazfit 穿戴数据。数据来源保持清晰，既能自己看，也能安全交给 AI 分析。',
+      viewSource: '查看源代码',
+      uiLanguageNotice: null,
+      trust: [
+        { icon: 'secure', label: '本地优先' },
+        { icon: 'private', label: '隐私安全' },
+        { icon: 'structured-data', label: '结构化数据' },
+      ],
+      stageLabel: 'Amazfit 在售设备进入 ZeppBridge 并输出结构化数据',
+      coreCaption: '解码 · 整理 · 可视化',
+      outputs: [
+        { title: '结构化记录', copy: '保留来源与时间' },
+        { title: 'AI-ready', copy: '由你决定何时交付' },
+      ],
+      status: { title: '本地管道就绪', copy: '数据不经过 ZeppBridge 服务器' },
+    },
+    principlesLabel: '产品原则',
+    principles: [
+      { icon: 'secure', title: '安全 Secure', copy: '数据仅存于本机' },
+      { icon: 'private', title: '私密 Private', copy: '不上传，不泄露' },
+      { icon: 'database', title: '可追溯 Provenance', copy: '来源不混淆' },
+      { icon: 'ai-ready', title: 'AI-ready', copy: '结构清晰，按需使用' },
+    ],
+    features: {
+      overline: 'WHAT YOU CAN READ',
+      heading: '从日常状态，到每一次训练。',
+      lead: '界面只展示真实获取到的字段；缺失数据会明确标记，不用虚构数值填满仪表盘。',
+      items: [
+        { icon: 'heart-rate', title: '连续心率', copy: '保留时间戳与数据来源，查看真实波动。', tone: 'red' },
+        { icon: 'sleep-waves', title: '睡眠结构', copy: '深睡、浅睡、REM 与清醒阶段本地解析。', tone: 'purple' },
+        { icon: 'outdoor-run', title: '训练详情', copy: '轨迹、配速、步频、海拔与训练负荷。', tone: 'green' },
+        { icon: 'vo2-max', title: '恢复指标', copy: 'VO₂ Max、HRV 与恢复数据按来源呈现。', tone: 'blue' },
+      ],
+    },
+    local: {
+      overline: 'NOT ONLY A WINDOW',
+      heading: '不打开界面，也能用。',
+      lead: '桌面应用、命令行、MCP 和本机只读接口共用同一个核心，因此单位、时区、来源和缺失值的说法只有一种。缺的数据就是缺的——任何一个出口都不会用 0 填空。',
+      items: [
+        {
+          icon: 'structured-data',
+          title: '完整历史与快照',
+          copy: '按月把云端历史补回本机，逐块记账；整库快照带校验，恢复前先看记录数差异。',
+          tag: '本机',
+        },
+        {
+          icon: 'document',
+          title: '命令行',
+          copy: 'status / sync / export，无交互，退出码稳定，可挂到任务计划或 cron。',
+          tag: 'CLI',
+        },
+        {
+          icon: 'ai-ready',
+          title: '只读 MCP',
+          copy: '让 AI 直接查你的本机数据。stdio 传输，不监听端口，也不联网。',
+          tag: 'MCP',
+        },
+      ],
+    },
+    connect: {
+      overline: 'THREE PATHS, ONE LOCAL VAULT',
+      heading: '选择适合你的连接方式。',
+      lead: 'ZeppBridge 支持从简单的官方网页登录，到可审计的手动授权流程。连接状态和错误原因都会明确显示。',
+      items: [
+        { icon: 'browser-login', title: '官方网页登录', copy: '在官方登录流程中识别账户授权，凭据留在本机。', tag: '推荐' },
+        { icon: 'document', title: 'HAR 导入', copy: '面向调试与高级用户，复用已有的授权请求。', tag: '高级' },
+        { icon: 'manual-entry', title: '手动填写', copy: '明确掌控 appToken 与用户标识的输入过程。', tag: '可控' },
+      ],
+    },
+    privacy: {
+      overline: 'PRIVACY BY ARCHITECTURE',
+      heading: '你的穿戴数据，不该成为别人的云资产。',
+      lead: '本地数据库、脱敏显示和来源隔离共同构成默认保护。需要 AI 时，由你主动选择导出的内容和去向。',
+      points: [
+        { icon: 'database', label: '本地 SQLite 存储' },
+        { icon: 'profile', label: '账户标识默认脱敏' },
+        { icon: 'cloud-output', label: '导出由用户主动触发' },
+      ],
+      vault: 'ZeppBridge 没有中转健康数据的后端服务。',
+    },
+    footer: {
+      tagline: '开源的 Amazfit 数据桥接工具 · Windows 和 Mac（Apple Silicon）',
+      disclaimer: '独立的非官方开源项目，与 Zepp Health、Huami、Amazfit 无隶属或背书关系。仅用于你本人有权访问的账号和数据。',
+      download: '下载',
+    },
   },
-  {
-    icon: 'document',
-    title: '命令行',
-    copy: 'status / sync / export，无交互，退出码稳定，可挂到任务计划或 cron。',
-    tag: 'CLI',
+  en: {
+    nav: {
+      home: 'ZeppBridge home',
+      site: 'Site navigation',
+      features: 'What it reads',
+      local: 'Local outlets',
+      connect: 'Connect',
+      privacy: 'Privacy',
+    },
+    languageToggle: '中文',
+    downloads: {
+      windows: { label: 'Download for Windows', hint: 'x64 installer · exe / msi' },
+      macos: { label: 'Download for macOS', hint: 'Apple Silicon · dmg' },
+    },
+    hero: {
+      headlineLead: 'Your Zepp data,',
+      headlineAccent: 'handed back in full.',
+      lead: 'ZeppBridge connects, organizes and visualizes your Amazfit wearable data on your own Windows or Mac. Every field keeps its source, so you can read it yourself — or hand it to an AI on your terms.',
+      viewSource: 'View source',
+      // 落地页英文了、下载下来还是中文界面，等于把人骗进来。应用 i18n 做完再删掉这句。
+      uiLanguageNotice: 'The app UI is currently Chinese only — English is in progress.',
+      trust: [
+        { icon: 'secure', label: 'Local-first' },
+        { icon: 'private', label: 'Private by default' },
+        { icon: 'structured-data', label: 'Structured data' },
+      ],
+      stageLabel: 'Current Amazfit devices feeding ZeppBridge and coming out as structured data',
+      coreCaption: 'Decode · Organize · Visualize',
+      outputs: [
+        { title: 'Structured records', copy: 'Source and timestamps kept' },
+        { title: 'AI-ready', copy: 'It leaves when you say so' },
+      ],
+      status: { title: 'Local pipeline ready', copy: 'Nothing routes through a ZeppBridge server' },
+    },
+    principlesLabel: 'Product principles',
+    principles: [
+      { icon: 'secure', title: 'Secure', copy: 'Stays on your machine' },
+      { icon: 'private', title: 'Private', copy: 'Nothing uploaded, nothing leaked' },
+      { icon: 'database', title: 'Provenance', copy: 'Sources never blur together' },
+      { icon: 'ai-ready', title: 'AI-ready', copy: 'Clear structure, used on request' },
+    ],
+    features: {
+      overline: 'WHAT YOU CAN READ',
+      heading: "From today's numbers to every single session.",
+      lead: 'The interface only shows fields it actually received. Anything missing is marked as missing — no invented numbers to fill out a dashboard.',
+      items: [
+        { icon: 'heart-rate', title: 'Continuous heart rate', copy: 'Timestamps and source kept, so you see the real curve.', tone: 'red' },
+        { icon: 'sleep-waves', title: 'Sleep structure', copy: 'Deep, light, REM and awake stages, parsed locally.', tone: 'purple' },
+        { icon: 'outdoor-run', title: 'Workout detail', copy: 'Route, pace, cadence, elevation and training load.', tone: 'green' },
+        { icon: 'vo2-max', title: 'Recovery metrics', copy: 'VO₂ Max, HRV and recovery figures, shown per source.', tone: 'blue' },
+      ],
+    },
+    local: {
+      overline: 'NOT ONLY A WINDOW',
+      heading: "You don't have to open it.",
+      lead: 'The desktop app, the command line, MCP and the read-only local API share one core — so units, time zones, sources and missing values only ever have one story. Missing is missing: no outlet fills the gap with a zero.',
+      items: [
+        {
+          icon: 'structured-data',
+          title: 'Full history & snapshots',
+          copy: 'Pull cloud history back month by month with a per-chunk ledger. Whole-database snapshots are checksummed, and you see the row-count difference before restoring.',
+          tag: 'Local',
+        },
+        {
+          icon: 'document',
+          title: 'Command line',
+          copy: 'status / sync / export. No prompts, stable exit codes — safe to hang off Task Scheduler or cron.',
+          tag: 'CLI',
+        },
+        {
+          icon: 'ai-ready',
+          title: 'Read-only MCP',
+          copy: 'Let an AI query your local data itself. stdio transport: no port to listen on, no network access.',
+          tag: 'MCP',
+        },
+      ],
+    },
+    connect: {
+      overline: 'THREE PATHS, ONE LOCAL VAULT',
+      heading: 'Pick the way in that suits you.',
+      lead: 'From a plain official web login to a fully auditable manual handoff. Connection state and failure reasons are always spelled out.',
+      items: [
+        { icon: 'browser-login', title: 'Official web login', copy: 'Authorize inside the official flow. Credentials stay on your machine.', tag: 'Recommended' },
+        { icon: 'document', title: 'HAR import', copy: 'For debugging and advanced users: reuse an authorized request you already captured.', tag: 'Advanced' },
+        { icon: 'manual-entry', title: 'Manual entry', copy: 'Enter the appToken and user id yourself, in full view.', tag: 'Hands-on' },
+      ],
+    },
+    privacy: {
+      overline: 'PRIVACY BY ARCHITECTURE',
+      heading: "Your wearable data shouldn't become someone else's cloud asset.",
+      lead: 'A local database, masked identifiers and isolated sources are the default. When you want an AI involved, you choose what goes out and where it lands.',
+      points: [
+        { icon: 'database', label: 'Local SQLite storage' },
+        { icon: 'profile', label: 'Account IDs masked by default' },
+        { icon: 'cloud-output', label: 'Export only when you trigger it' },
+      ],
+      vault: 'There is no ZeppBridge backend relaying your health data.',
+    },
+    footer: {
+      tagline: 'Open-source Amazfit data bridge · Windows and Mac (Apple Silicon)',
+      disclaimer: 'An independent, unofficial open-source project, not affiliated with or endorsed by Zepp Health, Huami or Amazfit. For use only with accounts and data you are entitled to access.',
+      download: 'Download',
+    },
   },
-  {
-    icon: 'ai-ready',
-    title: '只读 MCP',
-    copy: '让 AI 直接查你的本机数据。stdio 传输，不监听端口，也不联网。',
-    tag: 'MCP',
-  },
-];
+};
 
-const authMethods: Array<{ icon: DesignIconName; title: string; copy: string; tag: string }> = [
-  { icon: 'browser-login', title: '官方网页登录', copy: '在官方登录流程中识别账户授权，凭据留在本机。', tag: '推荐' },
-  { icon: 'document', title: 'HAR 导入', copy: '面向调试与高级用户，复用已有的授权请求。', tag: '高级' },
-  { icon: 'manual-entry', title: '手动填写', copy: '明确掌控 appToken 与用户标识的输入过程。', tag: '可控' },
-];
+const t = computed(() => COPY[locale.value]);
+
+const primaryDownload = computed(() => (isMacVisitor() ? t.value.downloads.macos : t.value.downloads.windows));
+const secondaryDownload = computed(() => (isMacVisitor() ? t.value.downloads.windows : t.value.downloads.macos));
 </script>
 
 <template>
   <div class="landing-page">
     <header class="landing-nav">
-      <a class="landing-brand" href="#top" aria-label="ZeppBridge 首页"><span><BrandMark :size="34" /></span><strong>ZeppBridge</strong></a>
-      <nav aria-label="网站导航"><a href="#features">数据能力</a><a href="#local">本机出口</a><a href="#connect">连接方式</a><a href="#privacy">隐私</a></nav>
-      <a class="nav-github" :href="githubUrl" target="_blank" rel="noopener"><DesignIcon name="handoff" :size="23" />GitHub</a>
+      <a class="landing-brand" href="#top" :aria-label="t.nav.home"><span><BrandMark :size="34" /></span><strong>ZeppBridge</strong></a>
+      <nav :aria-label="t.nav.site"><a href="#features">{{ t.nav.features }}</a><a href="#local">{{ t.nav.local }}</a><a href="#connect">{{ t.nav.connect }}</a><a href="#privacy">{{ t.nav.privacy }}</a></nav>
+      <div class="nav-actions">
+        <button type="button" class="lang-toggle" @click="toggleLocale"><DesignIcon name="handoff" :size="19" />{{ t.languageToggle }}</button>
+        <a class="nav-github" :href="githubUrl" target="_blank" rel="noopener"><DesignIcon name="handoff" :size="23" />GitHub</a>
+      </div>
     </header>
 
     <main id="top">
       <section class="hero-section">
         <div class="hero-copy">
           <p class="overline"><span></span>LOCAL-FIRST · OPEN SOURCE</p>
-          <h1>把你的 Zepp 数据，<br /><em>完整交还给你。</em></h1>
-          <p class="hero-lead">ZeppBridge 在 Windows 与 macOS 本机连接、整理并可视化 Amazfit 穿戴数据。数据来源保持清晰，既能自己看，也能安全交给 AI 分析。</p>
+          <h1>{{ t.hero.headlineLead }}<br /><em>{{ t.hero.headlineAccent }}</em></h1>
+          <p class="hero-lead">{{ t.hero.lead }}</p>
           <div class="hero-actions">
             <a class="primary-cta" :href="releaseUrl" target="_blank" rel="noopener"><DesignIcon name="app-icon" :size="34" /><span><b>{{ primaryDownload.label }}</b><small>{{ primaryDownload.hint }}</small></span><DesignIcon name="chevron-right" :size="20" /></a>
             <a class="alt-cta" :href="releaseUrl" target="_blank" rel="noopener"><DesignIcon name="app-icon" :size="24" /><span><b>{{ secondaryDownload.label }}</b><small>{{ secondaryDownload.hint }}</small></span></a>
-            <a class="secondary-cta" :href="githubUrl" target="_blank" rel="noopener"><DesignIcon name="document" :size="27" />查看源代码</a>
+            <a class="secondary-cta" :href="githubUrl" target="_blank" rel="noopener"><DesignIcon name="document" :size="27" />{{ t.hero.viewSource }}</a>
           </div>
-          <div class="trust-row"><span><DesignIcon name="secure" :size="23" />本地优先</span><span><DesignIcon name="private" :size="23" />隐私安全</span><span><DesignIcon name="structured-data" :size="23" />结构化数据</span></div>
+          <p v-if="t.hero.uiLanguageNotice" class="ui-language-notice"><DesignIcon name="handoff" :size="19" />{{ t.hero.uiLanguageNotice }}</p>
+          <div class="trust-row"><span v-for="item in t.hero.trust" :key="item.label"><DesignIcon :name="item.icon" :size="23" />{{ item.label }}</span></div>
         </div>
 
-        <div class="hero-stage" aria-label="Amazfit 在售设备进入 ZeppBridge 并输出结构化数据">
+        <div class="hero-stage" :aria-label="t.hero.stageLabel">
           <div class="stage-glow"></div>
           <DeviceMarquee class="hero-marquee" />
-          <article class="bridge-core"><DesignIcon name="app-icon" :size="72" /><div><span>LOCAL BRIDGE</span><strong>ZeppBridge</strong><small>解码 · 整理 · 可视化</small></div></article>
+          <article class="bridge-core"><DesignIcon name="app-icon" :size="72" /><div><span>LOCAL BRIDGE</span><strong>ZeppBridge</strong><small>{{ t.hero.coreCaption }}</small></div></article>
           <div class="output-stack">
-            <article><DesignIcon name="structured-data" :size="37" /><span><b>结构化记录</b><small>保留来源与时间</small></span></article>
-            <article><DesignIcon name="ai-ready" :size="37" /><span><b>AI-ready</b><small>由你决定何时交付</small></span></article>
+            <article><DesignIcon name="structured-data" :size="37" /><span><b>{{ t.hero.outputs[0].title }}</b><small>{{ t.hero.outputs[0].copy }}</small></span></article>
+            <article><DesignIcon name="ai-ready" :size="37" /><span><b>{{ t.hero.outputs[1].title }}</b><small>{{ t.hero.outputs[1].copy }}</small></span></article>
           </div>
-          <div class="stage-status"><DesignIcon name="verified" :size="24" /><span><b>本地管道就绪</b><small>数据不经过 ZeppBridge 服务器</small></span></div>
+          <div class="stage-status"><DesignIcon name="verified" :size="24" /><span><b>{{ t.hero.status.title }}</b><small>{{ t.hero.status.copy }}</small></span></div>
         </div>
       </section>
 
-      <section class="principle-strip" aria-label="产品原则">
-        <div><DesignIcon name="secure" :size="30" /><span><b>安全 Secure</b><small>数据仅存于本机</small></span></div>
-        <div><DesignIcon name="private" :size="30" /><span><b>私密 Private</b><small>不上传，不泄露</small></span></div>
-        <div><DesignIcon name="database" :size="30" /><span><b>可追溯 Provenance</b><small>来源不混淆</small></span></div>
-        <div><DesignIcon name="ai-ready" :size="30" /><span><b>AI-ready</b><small>结构清晰，按需使用</small></span></div>
+      <section class="principle-strip" :aria-label="t.principlesLabel">
+        <div v-for="item in t.principles" :key="item.title"><DesignIcon :name="item.icon" :size="30" /><span><b>{{ item.title }}</b><small>{{ item.copy }}</small></span></div>
       </section>
 
       <section id="features" class="content-section feature-section">
-        <div class="section-heading"><p>WHAT YOU CAN READ</p><h2>从日常状态，到每一次训练。</h2><span>界面只展示真实获取到的字段；缺失数据会明确标记，不用虚构数值填满仪表盘。</span></div>
-        <div class="capability-grid"><article v-for="item in capabilities" :key="item.title" :class="`capability-card tone-${item.tone}`"><DesignIcon :name="item.icon" :size="62" /><span><b>{{ item.title }}</b><small>{{ item.copy }}</small></span><DesignIcon name="chevron-right" :size="19" /></article></div>
+        <div class="section-heading"><p>{{ t.features.overline }}</p><h2>{{ t.features.heading }}</h2><span>{{ t.features.lead }}</span></div>
+        <div class="capability-grid"><article v-for="item in t.features.items" :key="item.title" :class="`capability-card tone-${item.tone}`"><DesignIcon :name="item.icon" :size="62" /><span><b>{{ item.title }}</b><small>{{ item.copy }}</small></span><DesignIcon name="chevron-right" :size="19" /></article></div>
       </section>
 
       <section id="local" class="content-section connect-section">
-        <div class="connect-intro"><p>NOT ONLY A WINDOW</p><h2>不打开界面，也能用。</h2><span>桌面应用、命令行、MCP 和本机只读接口共用同一个核心，因此单位、时区、来源和缺失值的说法只有一种。缺的数据就是缺的——任何一个出口都不会用 0 填空。</span><div class="connect-art"><DesignIcon name="app-icon" :size="84" /><div class="mini-flow"><i></i><i></i><i></i></div><DesignIcon name="structured-data" :size="84" /></div></div>
-        <div class="auth-grid"><article v-for="outlet in localOutlets" :key="outlet.title"><div class="auth-title"><DesignIcon :name="outlet.icon" :size="46" /><span>{{ outlet.tag }}</span></div><h3>{{ outlet.title }}</h3><p>{{ outlet.copy }}</p><DesignIcon name="chevron-right" :size="19" /></article></div>
+        <div class="connect-intro"><p>{{ t.local.overline }}</p><h2>{{ t.local.heading }}</h2><span>{{ t.local.lead }}</span><div class="connect-art"><DesignIcon name="app-icon" :size="84" /><div class="mini-flow"><i></i><i></i><i></i></div><DesignIcon name="structured-data" :size="84" /></div></div>
+        <div class="auth-grid"><article v-for="outlet in t.local.items" :key="outlet.title"><div class="auth-title"><DesignIcon :name="outlet.icon" :size="46" /><span>{{ outlet.tag }}</span></div><h3>{{ outlet.title }}</h3><p>{{ outlet.copy }}</p><DesignIcon name="chevron-right" :size="19" /></article></div>
       </section>
 
       <section id="connect" class="content-section connect-section">
-        <div class="connect-intro"><p>THREE PATHS, ONE LOCAL VAULT</p><h2>选择适合你的连接方式。</h2><span>ZeppBridge 支持从简单的官方网页登录，到可审计的手动授权流程。连接状态和错误原因都会明确显示。</span><div class="connect-art"><DesignIcon name="zepp-cloud" :size="84" /><div class="mini-flow"><i></i><i></i><i></i></div><DesignIcon name="app-icon" :size="84" /></div></div>
-        <div class="auth-grid"><article v-for="method in authMethods" :key="method.title"><div class="auth-title"><DesignIcon :name="method.icon" :size="46" /><span>{{ method.tag }}</span></div><h3>{{ method.title }}</h3><p>{{ method.copy }}</p><DesignIcon name="chevron-right" :size="19" /></article></div>
+        <div class="connect-intro"><p>{{ t.connect.overline }}</p><h2>{{ t.connect.heading }}</h2><span>{{ t.connect.lead }}</span><div class="connect-art"><DesignIcon name="zepp-cloud" :size="84" /><div class="mini-flow"><i></i><i></i><i></i></div><DesignIcon name="app-icon" :size="84" /></div></div>
+        <div class="auth-grid"><article v-for="method in t.connect.items" :key="method.title"><div class="auth-title"><DesignIcon :name="method.icon" :size="46" /><span>{{ method.tag }}</span></div><h3>{{ method.title }}</h3><p>{{ method.copy }}</p><DesignIcon name="chevron-right" :size="19" /></article></div>
       </section>
 
       <section id="privacy" class="privacy-section">
-        <div class="privacy-copy"><p>PRIVACY BY ARCHITECTURE</p><h2>你的穿戴数据，不该成为别人的云资产。</h2><span>本地数据库、脱敏显示和来源隔离共同构成默认保护。需要 AI 时，由你主动选择导出的内容和去向。</span><div class="privacy-points"><span><DesignIcon name="database" :size="26" />本地 SQLite 存储</span><span><DesignIcon name="profile" :size="26" />账户标识默认脱敏</span><span><DesignIcon name="cloud-output" :size="26" />导出由用户主动触发</span></div></div>
-        <div class="privacy-vault"><DesignIcon name="private" :size="104" /><div><b>LOCAL VAULT</b><span>ZeppBridge 没有中转健康数据的后端服务。</span></div></div>
+        <div class="privacy-copy"><p>{{ t.privacy.overline }}</p><h2>{{ t.privacy.heading }}</h2><span>{{ t.privacy.lead }}</span><div class="privacy-points"><span v-for="point in t.privacy.points" :key="point.label"><DesignIcon :name="point.icon" :size="26" />{{ point.label }}</span></div></div>
+        <div class="privacy-vault"><DesignIcon name="private" :size="104" /><div><b>LOCAL VAULT</b><span>{{ t.privacy.vault }}</span></div></div>
       </section>
     </main>
 
-    <footer><a class="landing-brand" href="#top"><span><BrandMark :size="29" /></span><strong>ZeppBridge</strong></a><p>开源的 Amazfit 数据桥接工具 · Windows 和 Mac（Apple Silicon）</p><p class="footer-disclaimer">独立的非官方开源项目，与 Zepp Health、Huami、Amazfit 无隶属或背书关系。仅用于你本人有权访问的账号和数据。</p><div><a :href="githubUrl" target="_blank" rel="noopener">GitHub</a><a :href="releaseUrl" target="_blank" rel="noopener">下载</a></div></footer>
+    <footer><a class="landing-brand" href="#top"><span><BrandMark :size="29" /></span><strong>ZeppBridge</strong></a><p>{{ t.footer.tagline }}</p><p class="footer-disclaimer">{{ t.footer.disclaimer }}</p><div><a :href="githubUrl" target="_blank" rel="noopener">GitHub</a><a :href="releaseUrl" target="_blank" rel="noopener">{{ t.footer.download }}</a></div></footer>
   </div>
 </template>
 
@@ -136,7 +351,11 @@ const authMethods: Array<{ icon: DesignIconName; title: string; copy: string; ta
 .landing-nav nav { display: flex; gap: 30px; }
 .landing-nav nav a { color: #9ca892; font-size: 12px; text-decoration: none; }
 .landing-nav nav a:hover { color: #d6e99e; }
+.nav-actions { display: inline-flex; align-items: center; gap: 10px; }
+.lang-toggle { display: inline-flex; align-items: center; gap: 6px; padding: 7px 12px 7px 8px; border: 1px solid var(--site-line); border-radius: 11px; background: rgba(255,255,255,.02); color: #9ca892; font: inherit; font-size: 12px; font-weight: 700; cursor: pointer; }
+.lang-toggle:hover { color: #d6e99e; border-color: rgba(185,220,112,.5); }
 .nav-github { display: inline-flex; align-items: center; gap: 7px; padding: 7px 12px 7px 7px; border: 1px solid var(--site-line); border-radius: 11px; background: rgba(255,255,255,.02); color: #dce7cb; font-size: 12px; font-weight: 700; text-decoration: none; }
+.ui-language-notice { display: inline-flex; align-items: center; gap: 7px; margin: 16px 0 0; padding: 7px 12px 7px 9px; border: 1px solid rgba(211,231,171,.16); border-radius: 11px; color: #a9b79c; font-size: 11px; line-height: 1.5; }
 main, footer { position: relative; z-index: 1; }
 .hero-section { display: grid; grid-template-columns: minmax(0,.9fr) minmax(520px,1.1fr); align-items: center; gap: 42px; width: min(1240px, calc(100% - 48px)); min-height: 690px; margin: 0 auto; padding: 72px 0 82px; }
 .overline, .section-heading > p, .connect-intro > p, .privacy-copy > p { display: flex; align-items: center; gap: 8px; margin: 0 0 20px; color: #91b44e; font-family: var(--font-mono); font-size: 10px; font-weight: 700; letter-spacing: .17em; }
@@ -155,7 +374,7 @@ main, footer { position: relative; z-index: 1; }
 .alt-cta:hover { transform: translateY(-2px); border-color: rgba(185,220,112,.5); }
 .alt-cta { transition: transform .2s ease, border-color .2s ease; }
 .secondary-cta { gap: 8px; white-space: nowrap; padding: 12px 16px 12px 10px; border: 1px solid var(--site-line); border-radius: 14px; background: #151915; color: #dce6cd; font-size: 12px; font-weight: 700; }
-.primary-cta, .secondary-cta, .nav-github { transition: transform .2s ease, border-color .2s ease; }
+.primary-cta, .secondary-cta, .nav-github, .lang-toggle { transition: transform .2s ease, border-color .2s ease, color .2s ease; }
 .primary-cta:hover, .secondary-cta:hover, .nav-github:hover { transform: translateY(-2px); border-color: rgba(185,220,112,.5); }
 .trust-row { display: flex; gap: 20px; margin-top: 26px; color: #7e8a79; font-size: 10px; }
 .trust-row span { display: inline-flex; align-items: center; gap: 5px; }
@@ -200,6 +419,6 @@ main, footer { position: relative; z-index: 1; }
 .privacy-vault div { display: grid; gap: 6px; }.privacy-vault b { color: #b9d87a; font-family: var(--font-mono); font-size: 13px; letter-spacing: .12em; }.privacy-vault span { color: #7e8979; font-size: 11px; line-height: 1.6; }
 footer { display: flex; align-items: center; flex-wrap: wrap; gap: 18px; width: min(1240px, calc(100% - 48px)); min-height: 120px; margin: 0 auto; } footer p { margin-right: auto; color: #697365; font-size: 10px; } footer .footer-disclaimer { flex-basis: 100%; margin-right: 0; max-width: 62ch; line-height: 1.6; } footer > div { display: flex; gap: 20px; } footer > div a { color: #909b8c; font-size: 11px; text-decoration: none; }
 @media (max-width: 1080px) { .hero-section { grid-template-columns: 1fr; padding-top: 56px; } .hero-stage { min-height: 500px; } .capability-grid { grid-template-columns: repeat(2,1fr); } .connect-section { grid-template-columns: 1fr; } .privacy-section { grid-template-columns: 1fr; } }
-@media (max-width: 720px) { .landing-nav { width: min(100% - 28px,1240px); }.landing-nav nav { display: none; }.hero-section, .content-section, .principle-strip, footer { width: min(100% - 28px,1240px); }.hero-section { min-height: auto; padding: 48px 0 64px; }.hero-copy h1 { font-size: 44px; }.hero-actions { align-items: stretch; flex-direction: column; }.primary-cta { min-width: 0; }.trust-row { flex-wrap: wrap; }.hero-stage { min-height: auto; }.output-stack { grid-template-columns: 1fr 1fr; }.principle-strip { grid-template-columns: repeat(2,1fr); }.principle-strip > div:nth-child(2) { border-right: 0; }.principle-strip > div:nth-child(-n+2) { border-bottom: 1px solid var(--site-line); }.content-section { padding: 84px 0; }.capability-grid, .auth-grid { grid-template-columns: 1fr; }.capability-card { min-height: 210px; }.auth-grid article { min-height: 245px; }.privacy-section { padding: 80px 20px; }.privacy-vault { align-items: flex-start; flex-direction: column; }.privacy-vault > .design-icon { width: 78px !important; height: 78px !important; } footer { align-items: flex-start; flex-wrap: wrap; padding: 28px 0; } footer p { width: 100%; order: 3; } }
-@media (prefers-reduced-motion: reduce) { .landing-page { scroll-behavior: auto; } .primary-cta, .secondary-cta, .nav-github { transition: none; } }
+@media (max-width: 720px) { .landing-nav { width: min(100% - 28px,1240px); }.landing-nav nav { display: none; }.hero-section, .content-section, .principle-strip, footer { width: min(100% - 28px,1240px); }.hero-section { min-height: auto; padding: 48px 0 64px; }.hero-copy h1 { font-size: 44px; }.hero-actions { align-items: stretch; flex-direction: column; }.primary-cta { min-width: 0; }.ui-language-notice { align-items: flex-start; }.trust-row { flex-wrap: wrap; }.hero-stage { min-height: auto; }.output-stack { grid-template-columns: 1fr 1fr; }.principle-strip { grid-template-columns: repeat(2,1fr); }.principle-strip > div:nth-child(2) { border-right: 0; }.principle-strip > div:nth-child(-n+2) { border-bottom: 1px solid var(--site-line); }.content-section { padding: 84px 0; }.capability-grid, .auth-grid { grid-template-columns: 1fr; }.capability-card { min-height: 210px; }.auth-grid article { min-height: 245px; }.privacy-section { padding: 80px 20px; }.privacy-vault { align-items: flex-start; flex-direction: column; }.privacy-vault > .design-icon { width: 78px !important; height: 78px !important; } footer { align-items: flex-start; flex-wrap: wrap; padding: 28px 0; } footer p { width: 100%; order: 3; } }
+@media (prefers-reduced-motion: reduce) { .landing-page { scroll-behavior: auto; } .primary-cta, .secondary-cta, .nav-github, .lang-toggle { transition: none; } }
 </style>


### PR DESCRIPTION
把 `todo.md` 里**能一次做干净**的未完成项做掉。应用 i18n（第三点九节）没动，原因见末尾。

## 1. 落地页中英双语（§3.10 G1/G2/G3）

- `src/composables/useLandingLocale.ts`（新）：两份文案 + 一个开关。默认按 `navigator.language`，手动选择存 localStorage（和 `zeppbridge-ui-scale` 同一套做法）。**没有引 vue-i18n**——为一个 205 行的静态页装一套 i18n 运行时只会把首屏体积赔进去。
- `<html lang>` / `<title>` / `description` / `og:title` / `og:description` / `og:locale` 全部跟着切。
- 英文是**重写**不是翻译。中文那股「缺就是缺，不用 0 补」的语气直译会全废。
- 英文版下载按钮下面写明 `The app UI is currently Chinese only — English is in progress.` 落地页英文了、下载下来还是中文界面，等于把人骗进来。应用 i18n 做完再删这句。
- `LandingPage` 改 `defineAsyncComponent`（G2）。

**首屏体积（gzip，实测改动前后）**

| | 改前(main) | 改后 |
|---|---|---|
| initialJs | 75.6 kB | **73.0 kB** |
| initialCss | 6.8 kB | **4.0 kB** |

净降 5.4 kB。`bundle-budget.json` 的基线本来就是陈旧的（记的是 71.7 kB，而 main 实际 75.6 kB），顺手 `budget:update` 刷成真实值；上限由脚本按基线 ×1.15 重算。

**已在浏览器里验过**：中/英切换、刷新后保持、`?app-preview=1` 不渲染落地页（桌面端不受影响）。

## 2. fix: 「待归一化」漏算运动详情（§3.5 A5 的「未做」项）

用户库里 1,941 条一直不消化，原以为卡在后台重放。查下来：

1. **重放没卡**。`reprocess_raw_records_if_needed()` 由 `normalizer_revision` 把门，跑过一次盖上戳就永远返回 `None`——设计如此。
2. **是这个数自己算错了**。判定看的是「有没有一行在 `metric_samples`/`daily_metrics`/`sleep_sessions`/`workouts` 里引用它」，而 `workout_detail` 的产物落在 `workout_samples`/`route_points`/`workout_pauses`，**这三张表按 `workout_id` 关联，没有 `raw_record_id` 这一列**。于是每一条解析得好好的运动详情都被永久算成「待归一化」，重放多少次都降不下来，健康页还一直劝用户再重放。

按 `source_key` 把这三张表认回来。只改诊断查询，没碰派生逻辑，**不 bump `NORMALIZER_REVISION`**。

新增测试两头都钉：已产出样本的详情必须算 0，真的什么都没产出的报文必须仍然算 1。（退回旧查询跑过一次确认它会红。）

> ⚠️ 残值不会归零：空响应、以及那些明令只留 raw 不归一化的数据流（`Charge/insight_data`、`Charge/stress_data` 等）本来就永远产不出标准化记录。对它们建议「重放」仍然是误导——但那要改的是健康页给的**动作**，是产品决定，我没有自作主张。

## 3. fix: 型号指认后的重读被写入前的请求顶掉（§3.6 C4 遗留）

C4 那条「确认 `assignModel` 走的不是缓存」查明了：`load(false)` 的 `refresh=false` 只表示**不打 Zepp 云端**，`enrich_profiles_with_local_data()` 每次都跑，用户指认就是在那里从 SQLite 读的——**不是缓存问题**。

但顺着看出一个真的竞态：`load(false)` 会复用 `profileRequests` 里已经在飞的请求，或 `backgroundRefreshInFlight`。两者都可能是在 `setDeviceModelOverride` **之前**发出的 → 结果里没有刚保存的指认 → 用户看到的还是「提交完型号依然没改过来」（C4 的表象，只不过那次根因在后端）。

加 `reloadAfterLocalWrite()`：写完库直接问一次后端，绕开去重与后台刷新，并抢 `requestId` 让抢跑的后台刷新结果失效。

## 4. docs: 体重与血压改成明确不支持（§二 遗留清理）

原文还是「拿到经过审计的脱敏 fixture 就接」的证据门禁措辞，和 8-30「不做、不支持」的决定冲突。两种说法留在同一份文档里，下一个人会照旧版重启接入。顺带去掉指向 `todo.md 8.0` 的悬空引用。

## 门禁

`cargo fmt` / `clippy -D warnings` / `cargo test --workspace`（204，+1）/ `vue-tsc` / `vite build` / `vitest`(45) / `test:feedback`(7) / `version:check` / `docs:check` / `budget:check` — **全绿**。

## 没做的（说明原因）

- **§3.9 应用 i18n**：前端 78k 中文字符，`Settings.vue` 一个文件 19.5k，且 F1 的边界（导出 JSON 的说明字段翻不翻）是没定的产品决策。不是一个 PR 能干完的事，也不该塞进这个 PR。
- **Cloudflare Pages 部署 + D1 迁移**（B4-a / C5 / C6）：对外可见的发布动作，等你点头。
- 各条「待验收」：要真人在应用里点。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
