### PR TITLE
chore(release): 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 本文件记录每个版本的实际改动。写给使用者看，不是施工日志：只写用户能感知到的变化，以及为什么这么改。
 
+## 1.1.0
+
+The first build an English-speaking user can actually sit down and use. The desktop UI follows the system language (Chinese or English) and has a switch in Settings.
+
+这一版是第一次能给英文用户直接用的正式包。桌面界面跟随系统语言（中/英），设置页可以切换。
+
+### New / 新增
+
+- **English and Chinese UI.** Overview, workouts, sleep, devices, insights, weekly report, export, Hand to AI, settings, health check, backups and history backfill. Dates and numbers follow the interface language. Prompts handed to an AI are translated too — an English user should not get a Chinese prompt that makes the model answer in Chinese.
+- **桌面界面中英双语。** 概览、运动、睡眠、设备、洞察、周报、导出、交给 AI、设置、数据健康、快照和历史补拉。日期和数字跟着界面语言走。交给 AI 的提示词也翻译了——英文用户不该拿到一段中文提示词，然后看 AI 用中文回答。
+- **Public landing page is bilingual**, with a language toggle. 落地页同样中英双语，有语言开关。
+- CI now fails the build if someone hard-codes Chinese into a Vue file. A leftover Chinese string is exactly the kind of bug an English-speaking user cannot report.
+  CI 现在会拦住界面里的硬编码中文。漏翻一句，只有看不懂中文的用户会看到它——而他没法告诉你。
+
+### Fixes / 修复
+
+- **"Pending normalisation" counted already-parsed workout details.** A health-page counter that would never go down, and kept suggesting another replay. It now recognises workout-detail output sitting in the sample / route / pause tables.
+- **「待归一化」把已经解析好的运动详情也算进去了。** 这个数字永远降不下来，健康页还一直劝你再重放一次。现在会把落在逐点样本 / 轨迹 / 暂停表里的运动详情认回来。
+- **Re-identifying a device could show the old model after you had just assigned one.** A request that started before the write could land afterwards and overwrite the screen.
+- **刚指认完型号，界面可能又闪回旧的。** 写入前发出去的请求稍后回来，会把屏幕盖回旧数据。
+
+### Still in Chinese / 仍是中文
+
+- CLI and MCP output stays Chinese: the four exits (GUI / CLI / MCP / export) must give the same answer to the same question, so the backend sends codes and the GUI translates. CLI/MCP still print the original Chinese string.
+  CLI 和 MCP 的输出仍是中文：四个出口对同一个问题必须给同一份回答，所以后端发码、界面翻译；CLI/MCP 继续打印原来的中文。
+- A few failure-path messages from the backend (some errors, disk-estimate stop reasons, snapshot blockers) still arrive as Chinese. They are on exception paths.
+  少数异常路径上的后端文案（部分错误、磁盘估算的停止原因、快照拦截原因）仍是中文。
+
+### Upgrade / 升级说明
+
+- Overlay-install from 1.0.x. Local data, backups and settings are untouched. No schema change.
+- 从 1.0.x 覆盖安装即可。本地数据、备份和设置都不会动。数据库结构没有变化。
+
 ## 1.0.1
 
 修一个只在**从旧版本升级上来**时才会出现的问题。全新安装不受影响。

--- a/README.en.md
+++ b/README.en.md
@@ -66,13 +66,13 @@ Get the latest build from [Releases](https://github.com/lingcang728/ZeppBridge/r
 
 ## First connection
 
-1. Open ZeppBridge and go to **设置** (Settings) in the sidebar.
+1. Open ZeppBridge and go to **Settings** in the sidebar.
 2. Click connect. The **official Zepp login page** opens in its own window; sign in with your usual credentials.
 3. Once it says connected, the window closes and the app runs its first sync. Give it about 40 seconds.
 
 Both mainland-China and international accounts work; the app detects which regional server you belong to.
 
-The first sync fetches 30 days. For older history, use **长期归档与完整历史** (Long-term archive and full history) in settings: choose 1/2/3 years or a custom start, and it fetches month by month. You can stop at any point and continue later. Before starting, it estimates disk usage from the actual rate your own data accumulates — not from a hard-coded constant.
+The first sync fetches 30 days. For older history, use **Long-term archive and full history** in Settings: choose 1/2/3 years or a custom start, and it fetches month by month. You can stop at any point and continue later. Before starting, it estimates disk usage from the actual rate your own data accumulates — not from a hard-coded constant.
 
 If the range exceeds your local retention window, the app requires you to enable long-term archiving first; otherwise the history you just fetched would be cleaned up after the next successful sync.
 

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -1,6 +1,6 @@
 # ZeppBridge 架构摘要
 
-本文描述 v1.0.1 的产品边界与当前实现。使用入口见项目 [README](../../README.md)，工程门禁见 [开发文档](../development/development.md)。
+本文描述 v1.1.0 的产品边界与当前实现。使用入口见项目 [README](../../README.md)，工程门禁见 [开发文档](../development/development.md)。
 
 ## 产品边界
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zeppbridge",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5897,7 +5897,7 @@ dependencies = [
 
 [[package]]
 name = "zeppbridge"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5925,7 +5925,7 @@ dependencies = [
 
 [[package]]
 name = "zeppbridge-cli"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "chrono",
  "serde",
@@ -5936,7 +5936,7 @@ dependencies = [
 
 [[package]]
 name = "zeppbridge-core"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5961,7 +5961,7 @@ dependencies = [
 
 [[package]]
 name = "zeppbridge-mcp"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "chrono",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,7 +25,7 @@ zeppbridge-core = { path = "crates/core" }
 
 [package]
 name = "zeppbridge"
-version = "1.0.1"
+version = "1.1.0"
 description = "本地优先的 Zepp 健康数据桥"
 authors = ["ZeppBridge"]
 edition = "2021"

--- a/src-tauri/crates/cli/Cargo.toml
+++ b/src-tauri/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeppbridge-cli"
-version = "1.0.1"
+version = "1.1.0"
 description = "ZeppBridge 命令行：给 Task Scheduler / cron / agent 用的无交互入口"
 edition = "2021"
 

--- a/src-tauri/crates/core/Cargo.toml
+++ b/src-tauri/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeppbridge-core"
-version = "1.0.1"
+version = "1.1.0"
 description = "ZeppBridge 的共享数据核心：模型、存储、迁移、归一化、查询、导出与写入协调"
 edition = "2021"
 

--- a/src-tauri/crates/mcp/Cargo.toml
+++ b/src-tauri/crates/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeppbridge-mcp"
-version = "1.0.1"
+version = "1.1.0"
 description = "ZeppBridge MCP 服务：只读、stdio、不监听任何端口"
 edition = "2021"
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ZeppBridge",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "identifier": "com.zeppbridge.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/App.vue
+++ b/src/App.vue
@@ -83,7 +83,7 @@ const t = useMessages(messages);
 
 // 桌面端从 Tauri 运行时读取版本（与 tauri.conf.json 单一来源），
 // 浏览器预览环境回退到下面的常量（与 package.json 保持同步）。
-const FALLBACK_APP_VERSION = '1.0.1';
+const FALLBACK_APP_VERSION = '1.1.0';
 const APP_VERSION = ref(FALLBACK_APP_VERSION);
 const desktopRuntime = isDesktop();
 // 落地页只在非桌面环境渲染（Cloudflare Pages 部署的就是这个分支），


### PR DESCRIPTION
Bump to 1.1.0 so the i18n merge actually ships as a GitHub Release.

`v1.1.0` annotated tag is already on `a1bd14e` and CI is packaging from it. This PR is only to get `main` past branch protection (direct push was rejected: 2 required status checks).

Includes:
- Version bump at all eight sites + Cargo.lock
- Bilingual CHANGELOG / GitHub Release notes
- README.en first-connection labels now match the English UI