### PR TITLE
Hotfix 1.1.1: Zepp OAuth and English sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 本文件记录每个版本的实际改动。写给使用者看，不是施工日志：只写用户能感知到的变化，以及为什么这么改。
 
+## 1.1.1
+
+Two urgent fixes for the Zepp account sign-in and the English desktop layout.
+
+两个紧急修复：Zepp 账号登录与英文桌面布局。
+
+### Fixes / 修复
+
+- **Xiaomi, WeChat, Google and Facebook sign-in buttons work inside the Zepp login window.** The previous navigation policy allowed only Zepp/Huami domains, so the official page's OAuth form submissions were silently blocked. The login window now allows only the exact provider hosts used by that page, keeps popup-style OAuth in the same cookie session, and still rejects unrelated destinations.
+- **小米、微信、Google、Facebook 登录按钮现在可在 Zepp 登录窗口内使用。** 旧版导航策略只允许 Zepp/Huami 域名，官方页面提交到第三方 OAuth 时会被静默拦截。新版只精确放行该页面实际使用的认证主机；即使认证改成弹窗，也会留在同一 Cookie 会话，陌生地址仍会被拒绝。
+- **English text in the lower-left cloud and version area no longer runs outside the sidebar.** Long status, account and version text now shrinks and ellipsizes within the available width, including enlarged UI scale.
+- **英文界面左下角不再出格。** 云端状态、账号和版本文字会在侧栏可用宽度内收缩并显示省略号，放大界面时也不会撑破容器。
+
+### Upgrade / 升级说明
+
+- Overlay-install from 1.1.0. Local data, backups and settings are untouched. No schema change.
+- 从 1.1.0 覆盖安装即可。本地数据、备份和设置都不会动。数据库结构没有变化。
+
 ## 1.1.0
 
 The first build an English-speaking user can actually sit down and use. The desktop UI follows the system language (Chinese or English) and has a switch in Settings.

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -1,6 +1,6 @@
 # ZeppBridge 架构摘要
 
-本文描述 v1.1.0 的产品边界与当前实现。使用入口见项目 [README](../../README.md)，工程门禁见 [开发文档](../development/development.md)。
+本文描述 v1.1.1 的产品边界与当前实现。使用入口见项目 [README](../../README.md)，工程门禁见 [开发文档](../development/development.md)。
 
 ## 产品边界
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zeppbridge",
-  "version": "0.11.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zeppbridge",
-      "version": "0.11.0",
+      "version": "1.1.1",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zeppbridge",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5897,7 +5897,7 @@ dependencies = [
 
 [[package]]
 name = "zeppbridge"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5925,7 +5925,7 @@ dependencies = [
 
 [[package]]
 name = "zeppbridge-cli"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "chrono",
  "serde",
@@ -5936,7 +5936,7 @@ dependencies = [
 
 [[package]]
 name = "zeppbridge-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5961,7 +5961,7 @@ dependencies = [
 
 [[package]]
 name = "zeppbridge-mcp"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "chrono",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,7 +25,7 @@ zeppbridge-core = { path = "crates/core" }
 
 [package]
 name = "zeppbridge"
-version = "1.1.0"
+version = "1.1.1"
 description = "本地优先的 Zepp 健康数据桥"
 authors = ["ZeppBridge"]
 edition = "2021"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,8 +1,8 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "Capability for the main and Zepp login windows",
-  "windows": ["main", "zepp-login"],
+  "description": "Capability for the main application window",
+  "windows": ["main"],
   "permissions": [
     "core:default",
     "dialog:allow-save",

--- a/src-tauri/capabilities/zepp-login.json
+++ b/src-tauri/capabilities/zepp-login.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "zepp-login",
+  "description": "Minimal capability for the external Zepp account login window",
+  "windows": ["zepp-login"],
+  "permissions": ["core:default"]
+}

--- a/src-tauri/crates/cli/Cargo.toml
+++ b/src-tauri/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeppbridge-cli"
-version = "1.1.0"
+version = "1.1.1"
 description = "ZeppBridge 命令行：给 Task Scheduler / cron / agent 用的无交互入口"
 edition = "2021"
 

--- a/src-tauri/crates/core/Cargo.toml
+++ b/src-tauri/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeppbridge-core"
-version = "1.1.0"
+version = "1.1.1"
 description = "ZeppBridge 的共享数据核心：模型、存储、迁移、归一化、查询、导出与写入协调"
 edition = "2021"
 

--- a/src-tauri/crates/mcp/Cargo.toml
+++ b/src-tauri/crates/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeppbridge-mcp"
-version = "1.1.0"
+version = "1.1.1"
 description = "ZeppBridge MCP 服务：只读、stdio、不监听任何端口"
 edition = "2021"
 

--- a/src-tauri/src/commands/login.rs
+++ b/src-tauri/src/commands/login.rs
@@ -6,7 +6,10 @@ use crate::models::AuthInfo;
 use serde_json::Value;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
-use tauri::{AppHandle, Emitter, Manager, WebviewUrl, WebviewWindow, WebviewWindowBuilder};
+use tauri::{
+    webview::NewWindowResponse, AppHandle, Emitter, Manager, WebviewUrl, WebviewWindow,
+    WebviewWindowBuilder,
+};
 
 const LOGIN_WINDOW_LABEL: &str = "zepp-login";
 const LOGIN_EVENT: &str = "login://status";
@@ -84,12 +87,34 @@ fn build_login_window(
     page_url: &str,
 ) -> std::result::Result<WebviewWindow, String> {
     let url = page_url.parse().map_err(|_| "登录地址无效".to_string())?;
+    let app_for_new_window = app.clone();
     WebviewWindowBuilder::new(app, LOGIN_WINDOW_LABEL, WebviewUrl::External(url))
         .title("登录 Zepp")
         .inner_size(920.0, 760.0)
         .min_inner_size(420.0, 520.0)
         .resizable(true)
-        .on_navigation(|url| is_allowed_login_url(url.as_str()))
+        .on_navigation(|url| {
+            let allowed = is_allowed_login_url(url.as_str());
+            if !allowed {
+                log_blocked_login_url("navigation", url);
+            }
+            allowed
+        })
+        // Keep OAuth in this login webview.  A provider that switches to
+        // `target=_blank` must not escape to the system browser because the
+        // resulting Zepp cookies would live in a different browser profile.
+        .on_new_window(move |url, _features| {
+            if !is_allowed_login_url(url.as_str()) {
+                log_blocked_login_url("new-window", &url);
+                return NewWindowResponse::Deny;
+            }
+            if let Some(window) = app_for_new_window.get_webview_window(LOGIN_WINDOW_LABEL) {
+                if let Err(error) = window.navigate(url) {
+                    eprintln!("Zepp login OAuth navigation failed: {error}");
+                }
+            }
+            NewWindowResponse::Deny
+        })
         .build()
         .map_err(|error| format!("无法打开登录窗口：{error}"))
 }
@@ -524,7 +549,8 @@ fn is_allowed_login_url(url: &str) -> bool {
     let Ok(parsed) = reqwest::Url::parse(url) else {
         return false;
     };
-    // Only HTTPS navigation to the known Zepp/Huami login domains is allowed.
+    // Only HTTPS navigation to the Zepp/Huami account domains and the exact
+    // OAuth hosts used by the official universal-login page is allowed.
     // `data:`, `blob:` and `about:` URLs are deliberately rejected: page
     // scripts must never be able to steer the credential-collecting webview
     // onto attacker-controlled inline content.
@@ -537,7 +563,25 @@ fn is_allowed_login_url(url: &str) -> bool {
             || host.ends_with(".zepp.com")
             || host == "huami.com"
             || host.ends_with(".huami.com")
+            || matches!(
+                host.as_str(),
+                "account.xiaomi.com"
+                    | "open.weixin.qq.com"
+                    | "accounts.google.com"
+                    | "www.facebook.com"
+                    | "account-us.amazfit.com"
+            )
     })
+}
+
+fn login_url_log_fields(url: &reqwest::Url) -> String {
+    let host = url.host_str().unwrap_or("<none>");
+    format!("host={host} path={}", url.path())
+}
+
+fn log_blocked_login_url(kind: &str, url: &reqwest::Url) {
+    // Query and fragment can contain OAuth state/code values.  Never log them.
+    eprintln!("blocked Zepp login {kind}: {}", login_url_log_fields(url));
 }
 
 fn should_use_fallback(elapsed: Duration, fallback_used: bool, page_url: &str) -> bool {
@@ -684,11 +728,60 @@ mod tests {
         assert!(is_allowed_login_url(
             "https://user.huami.com/privacy2/index.html"
         ));
+        assert!(is_allowed_login_url(
+            "https://account.xiaomi.com/oauth2/authorize"
+        ));
+        assert!(is_allowed_login_url(
+            "https://open.weixin.qq.com/connect/qrconnect"
+        ));
+        assert!(is_allowed_login_url(
+            "https://accounts.google.com/o/oauth2/auth"
+        ));
+        assert!(is_allowed_login_url(
+            "https://www.facebook.com/dialog/oauth"
+        ));
+        assert!(is_allowed_login_url(
+            "https://account-us.amazfit.com/v1/accounts/connect/facebook/callback"
+        ));
         assert!(!is_allowed_login_url("about:blank"));
         assert!(!is_allowed_login_url(
             "data:text/html,<script>alert(1)</script>"
         ));
         assert!(!is_allowed_login_url("https://example.com/"));
         assert!(!is_allowed_login_url("http://watchface.zepp.com/"));
+        assert!(!is_allowed_login_url(
+            "https://evil.xiaomi.com/oauth2/authorize"
+        ));
+        assert!(!is_allowed_login_url("https://facebook.com/dialog/oauth"));
+    }
+
+    #[test]
+    fn blocked_login_log_omits_query_and_fragment() {
+        let url = reqwest::Url::parse(
+            "https://example.com/oauth/callback?code=secret&state=private#access_token",
+        )
+        .unwrap();
+        let fields = login_url_log_fields(&url);
+        assert_eq!(fields, "host=example.com path=/oauth/callback");
+        assert!(!fields.contains("secret"));
+        assert!(!fields.contains("private"));
+        assert!(!fields.contains("access_token"));
+    }
+
+    #[test]
+    fn login_window_has_no_opener_permission() {
+        let main: serde_json::Value =
+            serde_json::from_str(include_str!("../../capabilities/default.json")).unwrap();
+        assert_eq!(main["windows"], serde_json::json!(["main"]));
+
+        let login: serde_json::Value =
+            serde_json::from_str(include_str!("../../capabilities/zepp-login.json")).unwrap();
+        assert_eq!(login["windows"], serde_json::json!(["zepp-login"]));
+        assert!(login["permissions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|permission| permission.as_str() != Some("opener:default")
+                && permission["identifier"] != "opener:allow-open-url"));
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -63,7 +63,14 @@ pub fn run() {
         .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
             show_main_window(app);
         }))
-        .plugin(tauri_plugin_opener::init())
+        // Main-window AI handoff links call the opener API explicitly.  Do
+        // not inject its `_blank` click interceptor into the Zepp login
+        // webview: OAuth must stay inside the cookie-polling login session.
+        .plugin(
+            tauri_plugin_opener::Builder::new()
+                .open_js_links_on_click(false)
+                .build(),
+        )
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_updater::Builder::new().build())

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ZeppBridge",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "identifier": "com.zeppbridge.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/App.vue
+++ b/src/App.vue
@@ -83,7 +83,7 @@ const t = useMessages(messages);
 
 // 桌面端从 Tauri 运行时读取版本（与 tauri.conf.json 单一来源），
 // 浏览器预览环境回退到下面的常量（与 package.json 保持同步）。
-const FALLBACK_APP_VERSION = '1.1.0';
+const FALLBACK_APP_VERSION = '1.1.1';
 const APP_VERSION = ref(FALLBACK_APP_VERSION);
 const desktopRuntime = isDesktop();
 // 落地页只在非桌面环境渲染（Cloudflare Pages 部署的就是这个分支），
@@ -651,6 +651,8 @@ a { color: inherit; }
 
 .sidebar-footer { margin-top: auto; padding-top: 16px; min-width: 0; display: grid; gap: 12px; }
 .cloud-card {
+  min-width: 0;
+  overflow: hidden;
   border: 1px solid var(--line);
   border-radius: var(--radius-md);
   background: var(--surface);
@@ -658,7 +660,7 @@ a { color: inherit; }
   display: grid;
   gap: 8px;
 }
-.cloud-row { display: flex; align-items: center; gap: 8px; font-size: 12px; color: var(--ink); }
+.cloud-row { display: flex; align-items: center; gap: 8px; min-width: 0; font-size: 12px; color: var(--ink); }
 .cloud-row svg:first-child { color: var(--muted); }
 .cloud-row span { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .cloud-check { color: var(--faint); }
@@ -668,12 +670,13 @@ a { color: inherit; }
   align-items: center;
   justify-content: space-between;
   gap: 8px;
+  min-width: 0;
   padding-top: 8px;
   border-top: 1px solid var(--line);
   color: var(--subtle);
   font-size: 11px;
 }
-.cloud-account span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.cloud-account span { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .manage-btn {
   flex: 0 0 auto;
   padding: 2px 10px;
@@ -688,11 +691,12 @@ a { color: inherit; }
   display: flex;
   align-items: center;
   gap: 8px;
+  min-width: 0;
   padding: 0 6px;
   color: var(--subtle);
   font-size: 11px;
 }
-.version-row span:nth-child(2) { flex: 1; }
+.version-row span:nth-child(2) { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .version-brand { display: grid; place-items: center; width: 18px; height: 18px; opacity: .8; }
 .version-brand svg { width: 18px; height: 18px; }
 .shield-link {


### PR DESCRIPTION
## What changed
- allow the exact Xiaomi, WeChat, Google, Facebook, and Zepp callback hosts used by the official Zepp login page
- keep OAuth popup navigation inside the login WebView cookie session and isolate opener permissions from that window
- constrain long English cloud/account/version text to the sidebar width
- bump the desktop, CLI, MCP, docs, and updater metadata to 1.1.1

## Verification
- Rust workspace tests: 205 passed, 1 ignored
- targeted login tests: 10 passed
- frontend tests: 48 passed
- feedback tests: 7 passed
- cargo clippy --workspace --all-targets --locked -- -D warnings
- frontend production build, i18n, docs links, version consistency, and bundle budgets
- signed Windows NSIS/MSI package generation and updater metadata
- 1280x800 English sidebar visual check

Manual provider sign-in remains for account-holder verification; no Computer Use automation was used.