### PR TITLE
ci: 让 Windows 打包重试，别再被一次下载失败作废

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,10 +153,34 @@ jobs:
 
       - name: Build and bundle (NSIS + MSI)
         # beforeBuildCommand (icons:generate + vite build) runs as part of this.
+        #
+        # 重试三次，因为 NSIS 打包这一步要现从 GitHub 下载 nsis-3.11.zip 和
+        # nsis_tauri_utils.dll。那两个下载是网络操作，会被对端重置——
+        # 见 run 33368661745：Rust 编译成功（6m22s，exe 已产出），随后倒在
+        #   `failed to bundle project: io: An existing connection was
+        #    forcibly closed by the remote host. (os error 10054)`
+        # 那不是代码问题，同一提交的 PR 跑是绿的。但它会让一次 23 分钟的
+        # 构建整个作废，还把 main 标红，看起来像是刚合进去的改动出了事。
+        #
+        # 重试很便宜：cargo 的 fingerprint 还在，第二次不会重新编译，
+        # 只重跑打包。真正的代码错误则三次都会失败，仍然照常报红。
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-        run: npm run tauri build
+        shell: pwsh
+        run: |
+          $attempts = 3
+          for ($i = 1; $i -le $attempts; $i++) {
+            Write-Host "== tauri build attempt $i/$attempts =="
+            npm run tauri build
+            if ($LASTEXITCODE -eq 0) { exit 0 }
+            if ($i -lt $attempts) {
+              Write-Host "attempt $i failed (exit $LASTEXITCODE); retrying in 20s"
+              Start-Sleep -Seconds 20
+            }
+          }
+          Write-Error "tauri build failed after $attempts attempts"
+          exit 1
 
       # latest.json 的 notes 就是应用内更新弹窗展示给用户的说明，硬编码会
       # 让每次发版都显示上一版的内容。发布 tag 时取该 tag 的注释首行。


### PR DESCRIPTION
## 你那个 PR 没有错

`main` 上 run [33368661745](https://github.com/lingcang728/ZeppBridge/actions/runs/33368661745) 的 **Package Windows installers** 红了，但**不是 #13 的问题**：

- Rust 编译**成功**：`Finished release profile in 6m 22s`，`zeppbridge.exe` 已产出。
- 同一提交的 PR 跑（[33367680864](https://github.com/lingcang728/ZeppBridge/actions/runs/33367680864)）**是绿的**。
- #13 只改了站点文件和 ci.yml 的两行。

真正倒下的地方在编译**之后**的打包步骤：

```
Info Verifying NSIS package
Downloading https://github.com/tauri-apps/binary-releases/releases/download/nsis-3.11/nsis-3.11.zip
Info validating hash
Info extracting NSIS
Downloading https://github.com/.../nsis_tauri_utils-v0.5.3/nsis_tauri_utils.dll
failed to bundle project: `io: An existing connection was forcibly closed by the remote host. (os error 10054)`
```

`os error 10054` = 对端把 TCP 连接重置了。Tauri 的 NSIS 打包器要在打包时现去 GitHub 下载 `nsis-3.11.zip` 和 `nsis_tauri_utils.dll`，这是纯网络操作，和仓库里的代码无关。

**为什么 PR 跑没暴露**：`Package Windows installers` 有 `if: github.event_name != 'pull_request'`，只在推 main 和打 tag 时跑。所以这类抖动只会在合并之后才现形——正好是最容易被误读成「刚合进去的改动出事了」的时刻。

## 改动

Windows 打包步骤改成最多三次尝试，失败间隔 20 秒。

重试很便宜：cargo 的 fingerprint 还在，第二次不会重新编译（省掉那 6 分多钟），只重跑打包。真正的代码错误三次都会失败，照常报红——这不是把失败藏起来，是不让网络抖动冒充失败。

只动 Windows：macOS 那条 `app,dmg` 路径不在打包时拉远程二进制，没有同一个暴露面。

## 已做的即时处理

我已经用 `gh run rerun --failed` 重跑了那次失败的作业，main 上的红叉应该已经自己好了。这个 PR 是让它不再复发。

🤖 Generated with [Claude Code](https://claude.com/claude-code)