### PR TITLE
fix(cli): status 的纯文本输出补上「本机覆盖」那一行

### DIFF
--- a/src-tauri/crates/cli/src/main.rs
+++ b/src-tauri/crates/cli/src/main.rs
@@ -364,10 +364,16 @@ fn cmd_status(args: &[String]) -> u8 {
     });
 
     let human = format!(
-        "ZeppBridge {VERSION}\n账号：{}\n数据库：{} 字节，schema v{}\n上次云端同步：{}\n历史账本：{}",
+        "ZeppBridge {VERSION}\n账号：{}\n数据库：{} 字节，schema v{}\n本机覆盖：{}\n上次云端同步：{}\n历史账本：{}",
         if connected { "已连接" } else { "未连接" },
         database_bytes,
         health.database.schema_version,
+        // JSON 里早就有这三个字段，纯文本却漏了一行——同一个命令的两种
+        // 输出对「本机有多少历史」给出不同的答案，是这个项目最不该出现的事。
+        match coverage.earliest_day.as_deref() {
+            Some(day) => format!("{} 天，最早 {}", coverage.covered_days, day),
+            None => "本机还没有任何数据".to_string(),
+        },
         health
             .timings
             .last_cloud_sync_at


### PR DESCRIPTION
## 问题

`zeppbridge status` 的两种输出对同一个问题给出不同答案：

```
$ zeppbridge-cli status --json
{ "coverageDays": 368, "coverageEarliestDay": "2025-08-29", ... }   ← 有

$ zeppbridge-cli status
ZeppBridge 1.1.3
账号：已连接
数据库：551022592 字节，schema v16
上次云端同步：...                                                    ← 没有
历史账本：...
```

这是我在 #14 里的疏漏，**已经随 1.1.3 发出去了**。JSON 是机器契约、没受影响，但纯文本少一行。

## 漏掉的原因

这个仓库的 Rust 源文件是 **CRLF 行尾**。当初改这个文件用的是跨行字符串替换、按 LF 匹配，于是那一处**静默地什么都没做**——同一个脚本里的单行替换全部成功，所以没暴露。

这次改成按行操作（`split("\r\n")`），并且**验证的是实际输出而不是「编译通过」**。

## 验证

在真实的 551 MB 库上跑过：

```
ZeppBridge 1.1.3
账号：已连接
数据库：551022592 字节，schema v16
本机覆盖：368 天，最早 2025-08-29     ← 新增
上次云端同步：2026-08-31T09:00:01.992343400+00:00
历史账本：还有 117 个月份块没有结论
```

`cargo fmt --check` / `clippy -D warnings` 通过。

不急着发版：1.1.3 的 JSON 契约是完整的，这一行等下次发版带上即可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)