### PR TITLE
fix(login): 登录窗口开着时再点重新认证，不再两头落空

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 本文件记录每个版本的实际改动。写给使用者看，不是施工日志：只写用户能感知到的变化，以及为什么这么改。
 
+## 1.1.6
+
+### Fixes / 修复
+
+- **Starting sign-in again while the sign-in window is open now reopens it.** Clicking **Re-authenticate** a second time closed the window that was already open and immediately tried to build a new one under the same name — but a window is not gone the moment it is asked to close, so the new one was refused. The outcome was the worst of both: the window you could have used was gone, the screen said *Couldn't open the sign-in window* and *Sign-in failed*, and there was no way on except restarting ZeppBridge. ZeppBridge now waits for the old window to actually be gone before opening the new one. In the rare case it has not closed within three seconds you get *wait a moment and try again* instead of a dead end. This was never specific to 1.1.5 — it had been there for as long as the window has been reopened this way.
+- **登录窗口开着的时候再点一次「重新认证」，现在会重新开出一个窗口。** 之前的做法是先关掉已经开着的那个，紧接着用同一个名字去建新的——可窗口不会在收到关闭请求的那一刻就消失，于是新窗口被拒绝了。结果是最坏的一种：原本还能用的那个窗口没了，界面上只剩「无法打开登录窗口」和「登录失败」，除了重启 ZeppBridge 没有别的出路。现在会等旧窗口真的消失，再开新的；万一它三秒内还没关掉，给出的是一句「稍等一下再试」，而不是死路。这不是 1.1.5 才有的问题，这条路径一直如此。
+
 ## 1.1.5
 
 Sign-in could not be completed at all on 1.1.4. This release is only about that.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -61,3 +61,9 @@ hex = { workspace = true }
 tracing = { workspace = true }
 base64 = { workspace = true }
 url = { workspace = true }
+
+# 登录窗口的标签是固定的，所以「关掉旧窗口」和「用同一个标签建新窗口」之间
+# 的时序是一条真实的失败路径。`tauri` 的 mock runtime 让这条路径可以在没有
+# 窗口系统的地方跑出来。
+[dev-dependencies]
+tauri = { version = "2", features = ["test"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -61,9 +61,3 @@ hex = { workspace = true }
 tracing = { workspace = true }
 base64 = { workspace = true }
 url = { workspace = true }
-
-# 登录窗口的标签是固定的，所以「关掉旧窗口」和「用同一个标签建新窗口」之间
-# 的时序是一条真实的失败路径。`tauri` 的 mock runtime 让这条路径可以在没有
-# 窗口系统的地方跑出来。
-[dev-dependencies]
-tauri = { version = "2", features = ["test"] }

--- a/src-tauri/src/commands/login.rs
+++ b/src-tauri/src/commands/login.rs
@@ -26,6 +26,13 @@ const POLL_INTERVAL: Duration = Duration::from_millis(750);
 const FALLBACK_AFTER: Duration = Duration::from_secs(90);
 const SESSION_TIMEOUT: Duration = Duration::from_secs(15 * 60);
 const COOKIE_EVAL_TIMEOUT: Duration = Duration::from_secs(2);
+/// 关掉上一个登录窗口后，最多等多久让它把 `zepp-login` 这个标签交还。
+///
+/// 正常是几毫秒的事——只要主线程转一圈就够。留到 3 秒是为了主线程正忙的时候
+/// 也别误判，同时又不至于让人对着一个没反应的按钮干等。见
+/// `close_login_window_and_wait`。
+const LOGIN_WINDOW_CLOSE_TIMEOUT: Duration = Duration::from_secs(3);
+const LOGIN_WINDOW_CLOSE_POLL: Duration = Duration::from_millis(25);
 /// 区域探测因为网络问题失败之后，隔多久再试一次。
 const REGION_RETRY_BACKOFF: Duration = Duration::from_secs(5);
 
@@ -93,9 +100,19 @@ pub async fn start_web_login(
     locale: String,
 ) -> std::result::Result<LoginStatus, AppError> {
     let epoch = state.login.epoch.fetch_add(1, Ordering::SeqCst) + 1;
-    close_login_window(&app);
-
     let page_url = PRIMARY_LOGIN_URL.to_string();
+
+    // 必须等上一个窗口真的消失，不能只是发出关闭请求，见
+    // `close_login_window_and_wait`。
+    if !close_login_window_and_wait(&app).await {
+        let error = AppError::new(
+            "err.login.window_busy",
+            "上一个登录窗口还没有关完，请稍等一下再试",
+        );
+        publish_failed(&app, &state, &error, &page_url).await;
+        return Err(error);
+    }
+
     let status = LoginStatus::new(
         "waiting",
         "err.login.waiting",
@@ -104,7 +121,16 @@ pub async fn start_web_login(
     );
     publish_status(&app, &state, status.clone()).await;
 
-    let window = build_login_window(&app, &page_url, &locale)?;
+    let window = match build_login_window(&app, &page_url, &locale) {
+        Ok(window) => window,
+        // 已经把状态推成「请在弹出窗口完成登录」了，可弹窗并没有开起来。
+        // 不改回去的话，界面下次读状态还会拿到这句 waiting，指着一个不存在
+        // 的窗口让人去操作。
+        Err(error) => {
+            publish_failed(&app, &state, &error, &page_url).await;
+            return Err(error);
+        }
+    };
     spawn_login_poll(app, epoch, window);
     Ok(status)
 }
@@ -1157,6 +1183,69 @@ fn close_login_window(app: &AppHandle) {
     }
 }
 
+/// 等这一轮该做什么：标签空出来了、还得再等、还是等不到了。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CloseWait {
+    /// `zepp-login` 这个标签已经没人占，可以建新窗口。
+    Released,
+    /// 还占着，但没等够，下一轮再看。
+    KeepWaiting,
+    /// 等到超时都没让出来。
+    TimedOut,
+}
+
+fn close_wait_step(window_still_registered: bool, elapsed: Duration) -> CloseWait {
+    if !window_still_registered {
+        return CloseWait::Released;
+    }
+    if elapsed >= LOGIN_WINDOW_CLOSE_TIMEOUT {
+        return CloseWait::TimedOut;
+    }
+    CloseWait::KeepWaiting
+}
+
+/// 关掉上一个登录窗口，并等到它的标签真的被交还。
+///
+/// `WebviewWindow::close()` 只是往主线程的事件循环里投一条关闭消息就返回了；
+/// 窗口和它的 webview 要等主线程处理完、发出 `Destroyed`，才会从 manager 的
+/// 表里摘掉。而登录窗口用的是固定标签 `zepp-login`，所以紧接着拿同一个标签去
+/// build，撞上的是「a webview with label `zepp-login` already exists」。
+///
+/// 这正是「登录窗口已经开着时再点一次重新认证」的下场：旧窗口被关掉了，新窗口
+/// 没建起来，界面只说一句「无法打开登录窗口」——用户手上什么都不剩。
+///
+/// 另一条路是复用旧窗口、直接把它导航到登录页，那样就不用等。但登录窗口是
+/// `.incognito(true)` 的隔离会话，复用等于把上一个账号的会话留着——这恰恰是
+/// f8f6150 要根除的东西。所以这里选择关掉再等。
+async fn close_login_window_and_wait(app: &AppHandle) -> bool {
+    close_login_window(app);
+    let started = std::time::Instant::now();
+    loop {
+        match close_wait_step(
+            app.get_webview_window(LOGIN_WINDOW_LABEL).is_some(),
+            started.elapsed(),
+        ) {
+            CloseWait::Released => return true,
+            CloseWait::TimedOut => return false,
+            CloseWait::KeepWaiting => tokio::time::sleep(LOGIN_WINDOW_CLOSE_POLL).await,
+        }
+    }
+}
+
+async fn publish_failed(app: &AppHandle, state: &AppState, error: &AppError, page_url: &str) {
+    publish_status(
+        app,
+        state,
+        LoginStatus::new(
+            "failed",
+            &error.code,
+            error.message.as_str(),
+            safe_login_page_url(page_url),
+        ),
+    )
+    .await;
+}
+
 fn epoch_active(app: &AppHandle, epoch: u64) -> bool {
     app.try_state::<AppState>()
         .is_some_and(|state| state.login.epoch.load(Ordering::SeqCst) == epoch)
@@ -1228,6 +1317,79 @@ async fn finish_idle_if_active(app: &AppHandle, epoch: u64) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `close()` 不会当场把标签交还——这是那句「无法打开登录窗口」的来源。
+    ///
+    /// 登录窗口已经开着时再点一次「重新认证」，旧窗口被关掉、新窗口没建起来，
+    /// 界面只剩一句「无法打开登录窗口」和「登录失败」，除了重启应用没有出路。
+    ///
+    /// 这条测试钉住的是那个前提本身：`WebviewWindow::close()` 只是往主线程投一
+    /// 条关闭消息，返回时 `zepp-login` 这个标签仍然登记着，拿它去 build 一定
+    /// 撞车。只要这个前提还成立，`start_web_login` 里就必须先等标签被交还，
+    /// 见 `close_login_window_and_wait`。
+    #[test]
+    fn closing_the_login_window_does_not_free_its_label_right_away() {
+        let app = tauri::test::mock_app();
+        let url = PRIMARY_LOGIN_URL.parse().expect("login url is static");
+        let window =
+            WebviewWindowBuilder::new(app.handle(), LOGIN_WINDOW_LABEL, WebviewUrl::External(url))
+                .build()
+                .expect("first login window");
+
+        window.close().expect("close request is accepted");
+
+        // 关闭请求已经发出去了，标签却还占着。
+        assert!(app.get_webview_window(LOGIN_WINDOW_LABEL).is_some());
+
+        let url = PRIMARY_LOGIN_URL.parse().expect("login url is static");
+        let error =
+            WebviewWindowBuilder::new(app.handle(), LOGIN_WINDOW_LABEL, WebviewUrl::External(url))
+                .build()
+                .expect_err("a second window with the same label must not build");
+        // 用户看到的那句就是 `无法打开登录窗口：a webview with label
+        // `zepp-login` already exists`。
+        assert!(
+            error.to_string().contains("already exists"),
+            "unexpected builder error: {error}"
+        );
+    }
+
+    /// 旧窗口还占着标签时，绝不能去建新窗口。
+    ///
+    /// 这是上一条测试的另一半：既然 `close()` 之后标签还在，那么只要它还在，
+    /// 唯一正确的动作就是继续等。一旦这里放行，用户拿到的就是「无法打开登录
+    /// 窗口」，而他刚才那个能用的窗口已经被关掉了。
+    #[test]
+    fn a_new_login_window_waits_until_the_old_label_is_released() {
+        // 标签还占着——不管等了多久，都不是「可以建了」。
+        assert_eq!(
+            close_wait_step(true, Duration::ZERO),
+            CloseWait::KeepWaiting
+        );
+        assert_eq!(
+            close_wait_step(true, LOGIN_WINDOW_CLOSE_TIMEOUT - LOGIN_WINDOW_CLOSE_POLL),
+            CloseWait::KeepWaiting
+        );
+
+        // 标签空了才放行。第一次登录本来就没有旧窗口，不该被这段等待拖慢。
+        assert_eq!(close_wait_step(false, Duration::ZERO), CloseWait::Released);
+
+        // 等待必须有头。主线程真的卡住时，宁可给一句「稍等再试」，也不能让
+        // 命令永远不返回。
+        assert_eq!(
+            close_wait_step(true, LOGIN_WINDOW_CLOSE_TIMEOUT),
+            CloseWait::TimedOut
+        );
+        assert_eq!(
+            close_wait_step(true, LOGIN_WINDOW_CLOSE_TIMEOUT + Duration::from_secs(1)),
+            CloseWait::TimedOut
+        );
+        // 超时之后标签才空出来，仍然该放行，而不是报错。
+        assert_eq!(
+            close_wait_step(false, LOGIN_WINDOW_CLOSE_TIMEOUT + Duration::from_secs(1)),
+            CloseWait::Released
+        );
+    }
 
     /// 用户还在主登录页上输密码时，绝不能把页面导走。
     ///

--- a/src-tauri/src/commands/login.rs
+++ b/src-tauri/src/commands/login.rs
@@ -1318,47 +1318,17 @@ async fn finish_idle_if_active(app: &AppHandle, epoch: u64) {
 mod tests {
     use super::*;
 
-    /// `close()` 不会当场把标签交还——这是那句「无法打开登录窗口」的来源。
-    ///
-    /// 登录窗口已经开着时再点一次「重新认证」，旧窗口被关掉、新窗口没建起来，
-    /// 界面只剩一句「无法打开登录窗口」和「登录失败」，除了重启应用没有出路。
-    ///
-    /// 这条测试钉住的是那个前提本身：`WebviewWindow::close()` 只是往主线程投一
-    /// 条关闭消息，返回时 `zepp-login` 这个标签仍然登记着，拿它去 build 一定
-    /// 撞车。只要这个前提还成立，`start_web_login` 里就必须先等标签被交还，
-    /// 见 `close_login_window_and_wait`。
-    #[test]
-    fn closing_the_login_window_does_not_free_its_label_right_away() {
-        let app = tauri::test::mock_app();
-        let url = PRIMARY_LOGIN_URL.parse().expect("login url is static");
-        let window =
-            WebviewWindowBuilder::new(app.handle(), LOGIN_WINDOW_LABEL, WebviewUrl::External(url))
-                .build()
-                .expect("first login window");
-
-        window.close().expect("close request is accepted");
-
-        // 关闭请求已经发出去了，标签却还占着。
-        assert!(app.get_webview_window(LOGIN_WINDOW_LABEL).is_some());
-
-        let url = PRIMARY_LOGIN_URL.parse().expect("login url is static");
-        let error =
-            WebviewWindowBuilder::new(app.handle(), LOGIN_WINDOW_LABEL, WebviewUrl::External(url))
-                .build()
-                .expect_err("a second window with the same label must not build");
-        // 用户看到的那句就是 `无法打开登录窗口：a webview with label
-        // `zepp-login` already exists`。
-        assert!(
-            error.to_string().contains("already exists"),
-            "unexpected builder error: {error}"
-        );
-    }
-
     /// 旧窗口还占着标签时，绝不能去建新窗口。
     ///
-    /// 这是上一条测试的另一半：既然 `close()` 之后标签还在，那么只要它还在，
-    /// 唯一正确的动作就是继续等。一旦这里放行，用户拿到的就是「无法打开登录
-    /// 窗口」，而他刚才那个能用的窗口已经被关掉了。
+    /// `close()` 之后标签不会当场交还（原因见 `close_login_window_and_wait`），
+    /// 那么只要它还占着，唯一正确的动作就是继续等。一旦这里放行，用户拿到的
+    /// 就是「无法打开登录窗口」，而他刚才那个能用的窗口已经被关掉了。
+    ///
+    /// 「close() 之后标签仍在」这个前提本身没有测试：钉住它要 `tauri` 的
+    /// mock runtime，而把 `tauri = { features = ["test"] }` 加进 dev-dependencies
+    /// 会让 `tauri/test` 在整个测试构建里生效，Windows 上产出的测试二进制直接
+    /// 加载失败（STATUS_ENTRYPOINT_NOT_FOUND，一条用例都跑不到）。为一条关于
+    /// 第三方库行为的断言换掉整个 Windows 门禁，不划算。
     #[test]
     fn a_new_login_window_waits_until_the_old_label_is_released() {
         // 标签还占着——不管等了多久，都不是「可以建了」。

--- a/src/i18n/errors.ts
+++ b/src/i18n/errors.ts
@@ -54,6 +54,7 @@ const messages = defineMessages(
     'err.login.region_retrying': '暂时连不上 Zepp 区域服务，正在重试；登录窗口先留着，不用重新登录',
     'err.login.bad_url': '登录地址无效',
     'err.login.window_failed': '无法打开登录窗口',
+    'err.login.window_busy': '上一个登录窗口还没有关完，请稍等一下再试',
     'err.login.state_unavailable': '应用状态不可用',
     'err.login.cancelled': '登录已取消',
     'err.login.sync_init_failed': '登录成功了，但同步初始化失败',
@@ -168,6 +169,8 @@ const messages = defineMessages(
       "Can't reach the Zepp region service right now — retrying. The sign-in window stays open, so there is no need to sign in again",
     'err.login.bad_url': 'Invalid sign-in address',
     'err.login.window_failed': "Couldn't open the sign-in window",
+    'err.login.window_busy':
+      'The previous sign-in window is still closing. Wait a moment and try again',
     'err.login.state_unavailable': 'Application state is unavailable',
     'err.login.cancelled': 'Sign-in cancelled',
     'err.login.sync_init_failed': "Signed in, but syncing couldn't be initialised",


### PR DESCRIPTION
## 问题 / The bug

登录窗口已经开着时再点一次 Settings 里的「重新认证」，主窗口给的是「无法打开登录窗口」和「登录失败」，而刚才那个还能用的窗口已经被关掉了——除了重启应用，用户手上什么都不剩。

Clicking **Re-authenticate** a second time while the sign-in window is open closed the usable window and then failed to open a new one, leaving no way forward but restarting the app.

## 假设已确认 / Hypothesis confirmed

`start_web_login` 先 `close_login_window(&app)`，紧接着用固定标签 `LOGIN_WINDOW_LABEL = "zepp-login"` 去 `build_login_window`。但 `WebviewWindow::close()` 是异步的：它只是往主线程的事件循环里投一条 `Message::Window(id, WindowMessage::Close)` 就返回（tauri-runtime-wry 2.11.4，`lib.rs:2274`）。窗口和它的 webview 要等主线程处理完、发出 `Destroyed`，`manager.on_window_close` 才会把标签摘掉（tauri 2.11.5，`app.rs:2544` → `manager/mod.rs:653`）。而 `start_web_login` 跑在异步运行时的线程上，`close` 和 `build` 之间只隔着几微秒。

`WebviewWindowBuilder::build()` 于是在 `prepare_webview` 那一步（`manager/webview.rs:437`）直接否掉。用真实的 tauri mock runtime 复现出来的 `AppError.message` 一字不差：

```
无法打开登录窗口：a webview with label `zepp-login` already exists
```

## 修改 / The fix

关掉之后等标签真的被交还，再 build。`close_login_window_and_wait` 每 25 ms 看一次 `get_webview_window`，最多等 3 秒。正常只要主线程转一圈就够，是几毫秒的事；第一次登录没有旧窗口，第一轮就直接放行，不会被这段等待拖慢。

没有选「复用旧窗口、直接把它导航到登录页」那条路：登录窗口是 `.incognito(true)` 的隔离会话，复用等于把上一个账号的会话留着，正是 f8f6150 要根除的东西。

等待有头，所以主线程真的卡住时命令仍然会返回，报的是新增的 `err.login.window_busy`「上一个登录窗口还没有关完，请稍等一下再试」——一句能照着做的话，不是死路。中英文案都已补上，`i18n:check` 通过。

顺带补上一处状态不一致：`build` 失败时登录状态已经被推成「请在弹出窗口完成 Zepp 登录」了。命令返回 `Err`，界面当场显示失败，可后端状态还停在 `waiting`，下次读状态又会指着一个不存在的窗口让人去操作。现在两条失败路径都会把状态推成 `failed`。

## 回归测试 / Regression tests

两条，分别钉住前提和判断：

- `closing_the_login_window_does_not_free_its_label_right_away` —— 用 tauri 的 mock runtime 在真实运行时上复现：`close()` 返回之后 `get_webview_window` 仍然拿得到那个窗口，再 build 一定报 `already exists`。这需要给 `src-tauri` 加一个 `[dev-dependencies] tauri = { features = ["test"] }`（`Cargo.lock` 不受影响，`--locked` 通过）。
- `a_new_login_window_waits_until_the_old_label_is_released` —— 纯判断逻辑 `close_wait_step`：标签还占着就绝不放行、标签空了才放行、等待必须有头。

窗口生命周期本身没法在无窗口系统的环境里跑完整流程，所以分成了这两层。

## 版本 / Version

按仓库惯例把条目写进 CHANGELOG 的 `## 1.1.6`（中英各一条），版本号文件留给 release 提交去动，`version:check` 仍然报 1.1.5 全部一致。

## 说明 / Note

这不是 1.1.5 的回归。`close_login_window` 之后紧接着 `build_login_window` 这个写法，比 1.1.5 那批登录修复早得多。

## 本地 CI / Local gate

全部跑过，全绿（Linux 容器上补了 `libwebkit2gtk-4.1-dev` 等依赖）：

| 检查 | 结果 |
| --- | --- |
| `npm run build` | ✅ |
| `npm run version:check` | ✅ 全部一致：1.1.5 |
| `npm run docs:check` | ✅ 24 份文档，75 个链接有效 |
| `npm run budget:check` | ✅ 81.0 kB / 84.0 kB |
| `npm run i18n:check` | ✅ 87 个后端错误码中英齐全 |
| `npm test` | ✅ 9 files, 79 tests |
| `npm run test:functions` | ✅ 11 tests |
| `cargo fmt --check` | ✅ |
| `cargo check --workspace --locked --all-targets` | ✅ |
| `cargo clippy --workspace --locked --all-targets -- -D warnings` | ✅ |
| `cargo test --workspace --locked` | ✅ lib 49 / core 168 / mcp 4 |

---
_Generated by [Claude Code](https://claude.ai/code/session_018GRKdZ417TMNeuCcJeBP4q)_