### PR TITLE
fix(login): region probe no longer fooled by empty responses; an empty sync no longer stays silent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,24 @@
 
 本文件记录每个版本的实际改动。写给使用者看，不是施工日志：只写用户能感知到的变化，以及为什么这么改。
 
-## 1.1.6
+## 1.2.0
 
 ### Fixes / 修复
 
+- **Signing in no longer picks the wrong Zepp region and then shows an empty library.** Once your credentials were read, ZeppBridge asked around ten regional Zepp servers in parallel which one your account belongs to, and used whichever answered successfully first. The question it asked was "does this account have heart-rate samples in the last two hours" — and a server that has never heard of your account answers that with an empty result, exactly like the right server does when you simply were not wearing the watch. Worse, the wrong server answers *faster*, because it has nothing to look up. So the wrong region could win, get saved, and every sync after that went to a place your data is not: the screen said **Connected**, the sync said it succeeded, and nothing ever appeared. ZeppBridge now asks a question a stranger cannot answer — it looks up the devices bound to your account, by your account id — and prefers the server that actually returns your watch over one that merely replies. When no server can claim the account, the sign-in still completes, but the region is now marked as a guess instead of a fact.
+- **登录不再挑错 Zepp 区域，然后给你一个空库。** 读到凭据之后，ZeppBridge 会同时问十来个 Zepp 区域服务器「这个账号是不是你的」，谁先答应就用谁。可它问的问题是「这个账号最近两小时有没有心率数据」——一个从没听说过你的服务器，回答同样是「空」，跟正确的服务器在你没戴表时给的回答一模一样。更糟的是错的那个答得**更快**，因为它压根不用去查。于是错误区域可能赢下这场竞速、被保存下来，之后每一次同步都打向一个没有你数据的地方：界面写着**已连接**，同步说成功，而什么都没有出现。现在问的是一个陌生人答不上来的问题——按账号 ID 去取这个账号绑定的设备——并且优先采用真的交出了你那块表的服务器，而不是仅仅应了一声的。所有服务器都认领不了这个账号时，登录照常完成，但区域会被标成「猜的」，而不是当成事实。
+- **A sync that completes and brings back nothing now says so.** When the library was empty, every screen said *Nothing on this machine yet — sync once*, including right after a sync had just finished. That sentence asks you to redo the thing that just failed to help, and it never mentions the most likely reason. There is now a separate message for "the sync succeeded and returned nothing", and when the region was only a guess it says that first, with a way back to reconnecting.
+- **同步跑通却什么都没带回来，现在会说出来。** 库是空的时候，每一页显示的都是「本机还没有任何数据，先同步一次」——包括刚刚同步完的那一刻。这句话是在让你重做一件刚刚没起作用的事，而且完全不提最可能的原因。现在「同步成功但一条没有」有它自己的一句话；如果当时的区域只是猜出来的，会先说这件事，并给出重新连接的入口。
+- **A third-party sign-in that has stalled now tells you there is another way in.** Google passkeys frequently stop at *verifying it's you* inside an in-app window and never continue — that is a limitation of the embedded browser, not something ZeppBridge can drive through. Previously the only thing that ever happened was *Sign-in timed out*, fifteen minutes later. After two minutes stuck on a third-party account page with nothing read, ZeppBridge now says so and points at email + password, or entering an App Token by hand in Settings. Nothing is interrupted: the window stays open in case it does go through.
+- **第三方登录卡住时，现在会告诉你还有别的路。** Google 的通行密钥在应用内窗口里经常停在「正在验证是不是你本人」不再往下走——这是嵌入式浏览器的限制，不是 ZeppBridge 能推得动的。以前唯一会发生的事是十五分钟后的一句「登录超时」。现在停在第三方账号页两分钟、并且什么都没读到时，会直接说出来，并指向邮箱+密码，或者在设置里手动填写 App Token。不打断任何东西：窗口留着，万一它真的走通了呢。
 - **Starting sign-in again while the sign-in window is open now reopens it.** Clicking **Re-authenticate** a second time closed the window that was already open and immediately tried to build a new one under the same name — but a window is not gone the moment it is asked to close, so the new one was refused. The outcome was the worst of both: the window you could have used was gone, the screen said *Couldn't open the sign-in window* and *Sign-in failed*, and there was no way on except restarting ZeppBridge. ZeppBridge now waits for the old window to actually be gone before opening the new one. In the rare case it has not closed within three seconds you get *wait a moment and try again* instead of a dead end. This was never specific to 1.1.5 — it had been there for as long as the window has been reopened this way.
 - **登录窗口开着的时候再点一次「重新认证」，现在会重新开出一个窗口。** 之前的做法是先关掉已经开着的那个，紧接着用同一个名字去建新的——可窗口不会在收到关闭请求的那一刻就消失，于是新窗口被拒绝了。结果是最坏的一种：原本还能用的那个窗口没了，界面上只剩「无法打开登录窗口」和「登录失败」，除了重启 ZeppBridge 没有别的出路。现在会等旧窗口真的消失，再开新的；万一它三秒内还没关掉，给出的是一句「稍等一下再试」，而不是死路。这不是 1.1.5 才有的问题，这条路径一直如此。
+
+### Not verified on real accounts / 未在真实账号上验证
+
+Xiaomi-account sign-in, Google sign-in and Google passkeys could not be reproduced or re-tested here: the only account available for development is a mainland-China account, verified through email + password and the WeChat QR code. The region fix above is covered by tests that feed the selection synthetic answers, and the stalled-sign-in hint is a pure function with its own tests — but neither has been through a real Google or Xiaomi sign-in. If you reported one of these, a re-test on this build is what would close it.
+
+小米账号登录、Google 登录和 Google 通行密钥在这里无法复现，也无法复测：开发用的只有一个中国大陆账号，验证过的路径是邮箱+密码和微信扫码。上面的区域修复由喂给选择逻辑合成结果的测试覆盖，卡住提示是一个带测试的纯函数——但两者都没有走过真实的 Google 或小米登录。如果这几条是你报的，在这一版上复测一次才能真正闭环。
 
 ## 1.1.5
 

--- a/src-tauri/src/app_state.rs
+++ b/src-tauri/src/app_state.rs
@@ -47,6 +47,13 @@ pub struct AppState {
     /// `startup_warning` so a successful sync can clear the transient auth
     /// warning without erasing one-time startup notices.
     pub(crate) auth_warning: Arc<RwLock<Option<String>>>,
+    /// 上一次登录时，凭什么认定当前 `region_host` 属于这个账号。
+    ///
+    /// `identified` / `hinted` / `unconfirmed`，外加进程重启后无从得知的
+    /// `unknown`。留着它是因为「区域猜错了」和「这个账号这段时间确实没数据」
+    /// 在界面上长得一模一样——两者都是同步跑通、一条记录没有。见
+    /// `commands::login::RegionWinner`。
+    pub(crate) region_confidence: Arc<RwLock<String>>,
 }
 
 impl AppState {
@@ -97,6 +104,8 @@ impl AppState {
             auth_state: Arc::new(RwLock::new(auth_state)),
             startup_warning: Arc::new(RwLock::new(startup_warning)),
             auth_warning: Arc::new(RwLock::new(None)),
+            // 保存的凭据不记录当初是怎么认定区域的，重启后只能说不知道。
+            region_confidence: Arc::new(RwLock::new("unknown".to_string())),
         })
     }
 

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -160,6 +160,10 @@ pub async fn clear_auth(
         let mut warning = state.startup_warning.write().await;
         *warning = None;
     }
+    {
+        let mut region = state.region_confidence.write().await;
+        *region = "unknown".to_string();
+    }
 
     build_app_status(&state).await
 }
@@ -211,6 +215,52 @@ pub(crate) fn validate_verify_payload(value: &Value) -> std::result::Result<(), 
         Err(ZeppBridgeError::ParseError(
             "认证验证返回了失败的响应代码".to_string(),
         ))
+    }
+}
+
+/// 登录时的区域判定证据强度。
+///
+/// 「这份凭据还有效吗」和「这个 host 是不是本账号的区域」是两个问题，之前由
+/// 同一个判据回答。`validate_verify_payload` 回答的是前者，那里「空」是合法
+/// 的——用户可能这两小时没戴表。可后者不行：一个根本不认识这个账号的区域
+/// 同样返回结构化空响应，而且因为它压根不去查数据，往往还答得更快。于是在
+/// 十来个候选区域的并发竞速里，最先返回的常常是错的那个，被存成
+/// `region_host`；之后每一次同步都打向那里，界面显示「已连接」，库里一条
+/// 记录也没有。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum RegionEvidence {
+    /// 请求成功了，但没有任何内容能证明这个 host 认识本账号。
+    Empty,
+    /// 这个 host 按 `user_id` 返回了该账号绑定的设备——它认识这个人。
+    Identified,
+}
+
+/// 判断某个区域 host 是不是本账号的区域。
+///
+/// 用 `/users/{user_id}/devices`：路径里带着 `user_id`，所以「区域对但这两
+/// 小时没数据」和「这个区域不认识这个用户」不再返回同一个东西。会用
+/// ZeppBridge 的人必然绑过一块表，因此拿到设备就是强证据。
+///
+/// 设备端点因为非鉴权原因失败时，退回到与 `verify_auth` 相同的心率检查，把
+/// 结果记成弱证据——宁可退回改动前的判据，也不要让一条从来没出过问题的
+/// 登录路径因为换了端点而失败。
+pub(crate) async fn probe_region_evidence(
+    auth: &AuthInfo,
+) -> std::result::Result<RegionEvidence, ZeppBridgeError> {
+    let connector = ZeppConnector::new(auth.clone())?;
+    match connector.fetch_devices().await {
+        Ok(payload) => {
+            if super::data::parse_device_profiles(&payload).is_empty() {
+                Ok(RegionEvidence::Empty)
+            } else {
+                Ok(RegionEvidence::Identified)
+            }
+        }
+        // 凭据被明确拒绝是结论，不必再问第二个端点。
+        Err(error @ ZeppBridgeError::NeedsReauth(_)) => Err(error),
+        Err(_) => verify_recent_heart_rate(auth)
+            .await
+            .map(|()| RegionEvidence::Empty),
     }
 }
 

--- a/src-tauri/src/commands/login.rs
+++ b/src-tauri/src/commands/login.rs
@@ -1,4 +1,4 @@
-use super::auth::verify_recent_heart_rate;
+use super::auth::{probe_region_evidence, RegionEvidence};
 use crate::app_state::AppState;
 use crate::connectors::zepp::validate_region_host;
 use crate::ipc_error::AppError;
@@ -25,6 +25,14 @@ const POLL_INTERVAL: Duration = Duration::from_millis(750);
 /// 还要确认这一页确实没人碰过，见 `fallback_is_due` 与 `login_page_is_idle`。
 const FALLBACK_AFTER: Duration = Duration::from_secs(90);
 const SESSION_TIMEOUT: Duration = Duration::from_secs(15 * 60);
+/// 停在第三方授权页多久之后，主动说一句「这条路可能走不通」。
+///
+/// 这不是超时，也不会打断任何东西——登录本来就慢，输密码、等邮箱里的验证码、
+/// 扫码都要时间。它针对的是另一件事：Google 的 passkey 在嵌入式 WebView 里
+/// 常常停在 "verifying it's you" 不动，而这一点我们改不了。与其让人对着一个
+/// 不会有结果的页面等满十五分钟才看到一句「登录超时」，不如现在就告诉他还有
+/// 邮箱+密码，以及设置页里手动填 App Token 这两条路。
+const THIRD_PARTY_STALL_AFTER: Duration = Duration::from_secs(120);
 const COOKIE_EVAL_TIMEOUT: Duration = Duration::from_secs(2);
 /// 关掉上一个登录窗口后，最多等多久让它把 `zepp-login` 这个标签交还。
 ///
@@ -222,6 +230,11 @@ fn spawn_login_poll(app: AppHandle, epoch: u64, window: WebviewWindow) {
         // 凭据已经读到了，卡住的是后面的区域确认。这和「压根没登录」「登录了
         // 但读不到凭据」都不一样，超时那一刻得说对是哪一种。
         let mut credentials_extracted = false;
+        // 当前停在哪一页、从什么时候开始停的。第三方授权页的停滞提示按这个计时，
+        // 而不是按整场登录——不然在授权页之间正常来回跳也会被算成卡住。
+        let mut current_page = String::new();
+        let mut page_since = std::time::Instant::now();
+        let mut third_party_hinted = false;
 
         loop {
             if !epoch_active(&app, epoch) {
@@ -251,6 +264,28 @@ fn spawn_login_poll(app: AppHandle, epoch: u64, window: WebviewWindow) {
             }
 
             let page_url = current_page_url(&window);
+            if page_url != current_page {
+                current_page = page_url.clone();
+                page_since = std::time::Instant::now();
+                third_party_hinted = false;
+            }
+            if third_party_stall_is_due(
+                &page_url,
+                page_since.elapsed(),
+                credentials_extracted,
+                third_party_hinted,
+            ) {
+                third_party_hinted = true;
+                emit_progress(
+                    &app,
+                    epoch,
+                    "waiting",
+                    "err.login.third_party_stalled",
+                    "第三方登录好像卡住了。可以关掉这个窗口，改用邮箱+密码登录；也可以在设置里手动填写 App Token。",
+                    &page_url,
+                )
+                .await;
+            }
             // 只有在还可能跳转时才去问页面；问出「有人在用」就永久作罢。
             let mut page_is_idle = false;
             if !user_active {
@@ -406,13 +441,14 @@ async fn persist_extracted_login(
     };
     let (preferred, authoritative_count) =
         preferred_region_hosts(&state, &extracted.user_id, extracted.region_hint.as_deref()).await;
-    let auth = probe_region_hosts(
+    let winner = probe_region_hosts(
         &extracted.user_id,
         &extracted.app_token,
         &preferred,
         authoritative_count,
     )
     .await?;
+    let RegionWinner { auth, confidence } = winner;
     if !epoch_active(app, epoch) {
         return Err(LoginFailure::fatal(AppError::new(
             "err.login.cancelled",
@@ -465,6 +501,10 @@ async fn persist_extracted_login(
     {
         let mut warning = state.auth_warning.write().await;
         *warning = None;
+    }
+    {
+        let mut region = state.region_confidence.write().await;
+        *region = confidence.to_string();
     }
     super::data::refresh_device_profile(&state).await;
     Ok(())
@@ -526,12 +566,82 @@ fn classify_region_probe_error(error: &ZeppBridgeError) -> RegionProbeFailure {
     }
 }
 
+/// 最终选中的区域 host，以及选中它的理由有多硬。
+///
+/// `confidence` 是给界面的稳定码，不是文案：
+/// * `identified` —— 这个 host 按 `user_id` 交出了该账号绑定的设备；
+/// * `hinted` —— Zepp 在这次登录响应里就指名了这个 host，请求也通了，只是这个
+///   账号没有设备可拿；
+/// * `unconfirmed` —— 从兜底列表里猜出来的，没有任何东西证明它属于这个账号。
+struct RegionWinner {
+    auth: AuthInfo,
+    confidence: &'static str,
+}
+
+/// 一批 host 探完之后剩下什么。
+#[derive(Default)]
+struct RegionBatchOutcome {
+    /// 认领了这个账号的 host。有它就不必再看别的。
+    identified: Option<AuthInfo>,
+    /// 请求通了但拿不出设备的 host 里，偏好顺序最靠前的那个。
+    fallback: Option<(usize, AuthInfo)>,
+}
+
+impl RegionBatchOutcome {
+    /// 收下一个探测结果。返回 `true` 表示已经拿到最硬的证据，不必再等别人。
+    ///
+    /// 结果按完成先后到达，而选谁要按偏好顺序，所以弱证据之间比的是 `rank`
+    /// 而不是先来后到。这正是原来那个 bug 的所在：谁先答应就用谁，而一个不
+    /// 认识这个用户的区域根本不去查数据，往往答得最快。
+    fn record(&mut self, rank: usize, auth: AuthInfo, evidence: RegionEvidence) -> bool {
+        match evidence {
+            RegionEvidence::Identified => {
+                self.identified = Some(auth);
+                true
+            }
+            RegionEvidence::Empty => {
+                let better = match self.fallback.as_ref() {
+                    Some((current, _)) => rank < *current,
+                    None => true,
+                };
+                if better {
+                    self.fallback = Some((rank, auth));
+                }
+                false
+            }
+        }
+    }
+
+    /// 折算成最终结论。
+    ///
+    /// `authoritative` 指这批 host 是不是 Zepp 在这次登录响应里自己指出来的。
+    /// 是的话，即便它交不出设备（这个账号可能一块表都没绑），也仍然有 Zepp 的
+    /// 背书；不是的话，就只是从兜底列表里猜中的一个，必须标出来。
+    fn into_winner(self, authoritative: bool) -> Option<RegionWinner> {
+        if let Some(auth) = self.identified {
+            return Some(RegionWinner {
+                auth,
+                confidence: "identified",
+            });
+        }
+        let (_, auth) = self.fallback?;
+        Some(RegionWinner {
+            auth,
+            confidence: if authoritative {
+                "hinted"
+            } else {
+                "unconfirmed"
+            },
+        })
+    }
+}
+
 async fn probe_region_hosts(
     user_id: &str,
     app_token: &str,
     hosts: &[String],
     authoritative_count: usize,
-) -> std::result::Result<AuthInfo, LoginFailure> {
+) -> std::result::Result<RegionWinner, LoginFailure> {
     let deadline = tokio::time::Instant::now() + Duration::from_secs(45);
     let mut failures = RegionProbeFailures::default();
     let authoritative_count = authoritative_count.min(hosts.len());
@@ -540,79 +650,95 @@ async fn probe_region_hosts(
     // the same already-saved user), so verify it before sending the token to
     // any fallback region. A short stage timeout leaves enough of the global
     // budget for recovery when Zepp returned a stale host.
+    //
+    // 这一阶段的 host 是 Zepp 自己在这次登录响应里指出来的，它本身就是身份
+    // 证据。所以请求一通就采用，哪怕这个账号一块表都没绑——再去盲扫兜底列表
+    // 只会让最常见的那条路白等几十秒。
     if authoritative_count > 0 {
         let stage_deadline = std::cmp::min(
             deadline,
             tokio::time::Instant::now() + Duration::from_secs(15),
         );
-        if let Some(auth) = probe_region_batch(
+        let outcome = probe_region_batch(
             user_id,
             app_token,
             &hosts[..authoritative_count],
+            0,
             stage_deadline,
             &mut failures,
         )
-        .await
-        {
-            return Ok(auth);
+        .await;
+        if let Some(winner) = outcome.into_winner(true) {
+            return Ok(winner);
         }
     }
 
-    if let Some(auth) = probe_region_batch(
+    // 兜底阶段是在**猜**：这些 host 没有任何证据说它属于这个账号。所以这里不能
+    // 「谁先答应就用谁」——一个不认识这个用户的区域根本不会去查数据，它返回的
+    // 结构化空响应往往比正确区域返回真实数据还快。只有交出了设备的那个才算数；
+    // 全都交不出时才退而用偏好顺序最靠前的一个，并把这件事标成 unconfirmed。
+    let outcome = probe_region_batch(
         user_id,
         app_token,
         &hosts[authoritative_count..],
+        authoritative_count,
         deadline,
         &mut failures,
     )
-    .await
-    {
-        return Ok(auth);
+    .await;
+    if let Some(winner) = outcome.into_winner(false) {
+        return Ok(winner);
     }
     Err(failures.into_login_failure())
 }
 
+/// 并发探测一批 host。
+///
+/// `rank_offset` 是这批 host 在整个偏好列表里的起始位置：结果按完成先后到达，
+/// 而选谁要按偏好顺序，所以每个结果都得带着自己的名次回来。
 async fn probe_region_batch(
     user_id: &str,
     app_token: &str,
     hosts: &[String],
+    rank_offset: usize,
     deadline: tokio::time::Instant,
     failures: &mut RegionProbeFailures,
-) -> Option<AuthInfo> {
+) -> RegionBatchOutcome {
+    let mut outcome = RegionBatchOutcome::default();
     if hosts.is_empty() {
-        return None;
+        return outcome;
     }
-    let (tx, mut rx) = tokio::sync::mpsc::channel::<
-        std::result::Result<AuthInfo, RegionProbeFailure>,
-    >(hosts.len().max(1));
+    type ProbeResult = std::result::Result<(usize, AuthInfo, RegionEvidence), RegionProbeFailure>;
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<ProbeResult>(hosts.len().max(1));
     let mut handles = Vec::new();
-    for host in hosts {
+    for (index, host) in hosts.iter().enumerate() {
         let auth = AuthInfo {
             app_token: app_token.to_string(),
             user_id: user_id.to_string(),
             region_host: host.clone(),
         };
+        let rank = rank_offset + index;
         let tx = tx.clone();
         handles.push(tokio::spawn(async move {
-            let result = verify_recent_heart_rate(&auth)
+            let result = probe_region_evidence(&auth)
                 .await
-                .map(|_| auth)
+                .map(|evidence| (rank, auth, evidence))
                 .map_err(|error| classify_region_probe_error(&error));
             let _ = tx.send(result).await;
         }));
     }
     drop(tx);
 
-    let mut winner = None;
     for _ in 0..hosts.len() {
         let Some(remaining) = deadline.checked_duration_since(tokio::time::Instant::now()) else {
             failures.transient += 1;
             break;
         };
         match tokio::time::timeout(remaining, rx.recv()).await {
-            Ok(Some(Ok(auth))) => {
-                winner = Some(auth);
-                break;
+            Ok(Some(Ok((rank, auth, evidence)))) => {
+                if outcome.record(rank, auth, evidence) {
+                    break;
+                }
             }
             Ok(Some(Err(failure))) => failures.record(failure),
             Ok(None) => break,
@@ -625,7 +751,7 @@ async fn probe_region_batch(
     for handle in handles {
         handle.abort();
     }
-    winner
+    outcome
 }
 
 async fn preferred_region_hosts(
@@ -1045,15 +1171,45 @@ fn is_allowed_login_url(url: &str) -> bool {
             || host.ends_with(".zepp.com")
             || host == "huami.com"
             || host.ends_with(".huami.com")
-            || matches!(
-                host.as_str(),
-                "account.xiaomi.com"
-                    | "open.weixin.qq.com"
-                    | "accounts.google.com"
-                    | "www.facebook.com"
-                    | "account-us.amazfit.com"
-            )
+            || THIRD_PARTY_AUTH_HOSTS.contains(&host.as_str())
     })
+}
+
+/// 官方通用登录页会跳过去的第三方账号域名。
+///
+/// 放行导航和判断「是不是卡在第三方授权页」用的是同一份表：多一处手写的名单，
+/// 就多一个哪天加了新登录方式却漏改的地方。
+const THIRD_PARTY_AUTH_HOSTS: &[&str] = &[
+    "account.xiaomi.com",
+    "open.weixin.qq.com",
+    "accounts.google.com",
+    "www.facebook.com",
+    "account-us.amazfit.com",
+];
+
+/// 这个地址是不是第三方账号的授权页（而不是我们自己打开的 Zepp 登录页）。
+fn is_third_party_auth_page(url: &str) -> bool {
+    reqwest::Url::parse(url)
+        .ok()
+        .and_then(|parsed| parsed.host_str().map(str::to_ascii_lowercase))
+        .is_some_and(|host| THIRD_PARTY_AUTH_HOSTS.contains(&host.as_str()))
+}
+
+/// 该不该现在就把兜底路径摆出来。
+///
+/// 四个条件缺一不可：停在第三方授权页、在这一页上已经待够久、还没读到凭据、
+/// 这一轮没说过。「在这一页上」是关键——计时要跟着地址走，用户在几个授权页之间
+/// 来回跳的时候，每一页都重新计时，不会因为整场登录拖得久就误报。
+fn third_party_stall_is_due(
+    page_url: &str,
+    elapsed_on_page: Duration,
+    credentials_extracted: bool,
+    already_hinted: bool,
+) -> bool {
+    !already_hinted
+        && !credentials_extracted
+        && elapsed_on_page >= THIRD_PARTY_STALL_AFTER
+        && is_third_party_auth_page(page_url)
 }
 
 fn login_url_log_fields(url: &reqwest::Url) -> String {
@@ -1317,6 +1473,140 @@ async fn finish_idle_if_active(app: &AppHandle, epoch: u64) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn probe_auth(host: &str) -> AuthInfo {
+        AuthInfo {
+            app_token: "token".to_string(),
+            user_id: "user".to_string(),
+            region_host: host.to_string(),
+        }
+    }
+
+    /// 这是那个 bug 本身：错误区域先答应，正确区域后答应。
+    ///
+    /// 一个不认识这个用户的区域根本不去查数据，所以它的空响应往往比正确区域
+    /// 返回真实设备还快。旧代码「谁先答应就用谁」，于是把错的那个存了下来，
+    /// 之后每次同步都打向那里——界面显示已连接，库里一条记录也没有。
+    #[test]
+    fn a_fast_empty_region_does_not_beat_a_slower_one_that_knows_the_account() {
+        let mut outcome = RegionBatchOutcome::default();
+
+        assert!(!outcome.record(
+            0,
+            probe_auth("https://wrong.example"),
+            RegionEvidence::Empty
+        ));
+        assert!(outcome.record(
+            5,
+            probe_auth("https://right.example"),
+            RegionEvidence::Identified
+        ));
+
+        let winner = outcome.into_winner(false).expect("a winner");
+        assert_eq!(winner.auth.region_host, "https://right.example");
+        assert_eq!(winner.confidence, "identified");
+    }
+
+    /// 全都交不出设备时，按偏好顺序挑，而不是按谁先回来。
+    #[test]
+    fn only_empty_answers_fall_back_to_the_most_preferred_host() {
+        let mut outcome = RegionBatchOutcome::default();
+
+        outcome.record(
+            3,
+            probe_auth("https://third.example"),
+            RegionEvidence::Empty,
+        );
+        outcome.record(
+            1,
+            probe_auth("https://first.example"),
+            RegionEvidence::Empty,
+        );
+        outcome.record(
+            2,
+            probe_auth("https://second.example"),
+            RegionEvidence::Empty,
+        );
+
+        let winner = outcome.into_winner(false).expect("a winner");
+        assert_eq!(winner.auth.region_host, "https://first.example");
+        // 猜出来的就得说是猜的：同步之后一条记录都没有时，这是唯一的线索。
+        assert_eq!(winner.confidence, "unconfirmed");
+    }
+
+    /// Zepp 自己指名的 host 交不出设备，不等于它错了——这个账号可能一块表都没绑。
+    /// 它仍然算数，只是标成 `hinted` 而不是 `identified`。
+    #[test]
+    fn an_authoritative_host_still_counts_when_the_account_has_no_devices() {
+        let mut outcome = RegionBatchOutcome::default();
+        outcome.record(
+            0,
+            probe_auth("https://hinted.example"),
+            RegionEvidence::Empty,
+        );
+
+        let winner = outcome.into_winner(true).expect("a winner");
+        assert_eq!(winner.auth.region_host, "https://hinted.example");
+        assert_eq!(winner.confidence, "hinted");
+    }
+
+    /// 一个都没答应就是没有结论，不能随便挑一个凑数。
+    #[test]
+    fn no_answer_produces_no_winner() {
+        assert!(RegionBatchOutcome::default().into_winner(true).is_none());
+        assert!(RegionBatchOutcome::default().into_winner(false).is_none());
+    }
+
+    /// 凭据被明确拒绝，仍然是终局失败——不会被别处的空响应盖过去。
+    #[test]
+    fn an_explicit_rejection_stays_fatal() {
+        let mut failures = RegionProbeFailures::default();
+        failures.record(RegionProbeFailure::Transient);
+        failures.record(RegionProbeFailure::Rejected);
+        failures.record(RegionProbeFailure::Other);
+
+        let failure = failures.into_login_failure();
+        assert!(!failure.retryable);
+        assert_eq!(failure.error.code, "err.login.credentials_rejected");
+    }
+
+    /// 停在第三方授权页太久，才提示；其余情况一律不出声。
+    #[test]
+    fn the_third_party_hint_fires_only_while_stuck_on_a_third_party_page() {
+        let long = THIRD_PARTY_STALL_AFTER;
+        let short = Duration::from_secs(5);
+        let google = "https://accounts.google.com/o/oauth2/auth";
+
+        assert!(third_party_stall_is_due(google, long, false, false));
+        // 还没等够。登录本来就慢，输密码等验证码都要时间。
+        assert!(!third_party_stall_is_due(google, short, false, false));
+        // 这一页上已经说过一次了。
+        assert!(!third_party_stall_is_due(google, long, false, true));
+        // 凭据已经读到，卡住的是后面的区域确认，不该建议换登录方式。
+        assert!(!third_party_stall_is_due(google, long, true, false));
+        // 停在我们自己打开的那一页——那是另一条兜底路径（备用登录页）管的事。
+        assert!(!third_party_stall_is_due(
+            PRIMARY_LOGIN_URL,
+            long,
+            false,
+            false
+        ));
+    }
+
+    /// 放行导航和「是不是第三方授权页」读的是同一份 host 表。
+    #[test]
+    fn third_party_hosts_are_shared_with_the_navigation_allowlist() {
+        for host in THIRD_PARTY_AUTH_HOSTS {
+            let url = format!("https://{host}/oauth");
+            assert!(is_allowed_login_url(&url), "{url} should be allowed");
+            assert!(
+                is_third_party_auth_page(&url),
+                "{url} should be third-party"
+            );
+        }
+        assert!(!is_third_party_auth_page("https://watchface.zepp.com/"));
+        assert!(!is_third_party_auth_page("not a url"));
+    }
 
     /// 旧窗口还占着标签时，绝不能去建新窗口。
     ///

--- a/src-tauri/src/commands/status.rs
+++ b/src-tauri/src/commands/status.rs
@@ -39,6 +39,7 @@ pub(crate) async fn build_app_status(state: &AppState) -> std::result::Result<Ap
     let auth_state = state.auth_state.read().await.clone();
     let startup_warning = state.startup_warning.read().await.clone();
     let auth_warning = state.auth_warning.read().await.clone();
+    let region_confidence = state.region_confidence.read().await.clone();
 
     let connection_state = if !auth_status.configured {
         "unconfigured"
@@ -99,6 +100,7 @@ pub(crate) async fn build_app_status(state: &AppState) -> std::result::Result<Ap
         history_sync_days: prefs.history_sync_days,
         storage: Some(storage),
         coverage,
+        region_confidence,
         compacting: zeppbridge_core::storage::compaction_in_progress(),
     })
 }

--- a/src-tauri/src/ipc_types.rs
+++ b/src-tauri/src/ipc_types.rs
@@ -47,6 +47,14 @@ pub struct AppStatus {
     /// 本机实际有数据的那段日子。界面上每一个「最近 N 天」选择器读的都是本机
     /// 库，所以每一个都需要知道这个，才不会把「库里没有」画成「那几个月你没动」。
     pub coverage: crate::storage::LocalCoverage,
+    /// 凭什么认定当前 `region_host` 属于这个账号：`identified` / `hinted` /
+    /// `unconfirmed` / `unknown`。界面按这个码自己写句子——后端不按 locale 出
+    /// 文案，四个出口才会说同一件事。
+    ///
+    /// `unconfirmed` 是唯一需要提醒用户的一档：区域是从兜底列表里猜的，没有
+    /// 任何东西证明它属于这个账号。同步之后一条记录都没有时，这是用户唯一
+    /// 能看到的线索。
+    pub region_confidence: String,
     /// 后台是否正在压缩历史报文。
     ///
     /// 只发一个 `compaction://started` 事件是不够的：它在 Rust 的 setup() 里

--- a/src/components/CoverageNotice.vue
+++ b/src/components/CoverageNotice.vue
@@ -9,22 +9,38 @@
  *
  * 说法要诚实：空白的意思是**本机没有**，不是「那几个月你没动」。这两句话对
  * 一个看着自己训练曲线的人来说，是完全相反的两件事。
+ *
+ * 同一个理由带出第二种情况：**已经同步过了，库还是空的**。这时候再说一句
+ * 「先同步一次」是在让人重做刚做过的事。真正的原因通常是登录时没能确认账号
+ * 所在的 Zepp 区域——区域猜错了，同步会一路跑通、一条记录不带回来，界面上和
+ * 「这段时间你确实没数据」长得一模一样。所以这里要把两者分开说。
  */
 import { computed } from 'vue';
 import Icon from './Icon.vue';
 import { useSyncController } from '../composables/useSyncController';
+import { emptyLibraryNotice } from '../lib/emptyLibraryNotice';
 import { defineMessages, intlLocale, useMessages } from '../i18n';
 
-const props = defineProps<{
-  /** 用户当前选的范围（天）。 */
-  requestedDays: number;
-}>();
+const props = withDefaults(defineProps<{
+  /**
+   * 用户当前选的范围（天）。
+   *
+   * 省略（或 0）表示调用方没在挑范围，只想知道库是不是空的——概览页就是这样。
+   * 这种时候「你选的比本机有的多」无从谈起，那条提示不出。
+   */
+  requestedDays?: number;
+}>(), { requestedDays: 0 });
 
 const { appStatus, isSyncing, runSync } = useSyncController();
 
 const messages = defineMessages(
   {
     empty: '本机还没有任何数据。先同步一次，图表才有东西可画。',
+    emptyAfterSync:
+      '同步跑通了，但一条记录也没取到。可能是这个账号在 Zepp 里本来就没有这段时间的数据，也可能是手表还没把数据上传到 Zepp App。先在手机上打开 Zepp 确认那边有数据，再回来同步一次。',
+    emptyUnconfirmedRegion:
+      '同步跑通了，但一条记录也没取到。登录时没能确认你的账号属于哪个 Zepp 区域，现在用的是猜出来的那个——打向错误区域的同步就是这样：一路成功，什么都没有。请重新连接账号试试。',
+    reconnect: '去重新连接',
     short: (covered: number, earliest: string) =>
       `本机只有 ${covered} 天的数据（最早 ${earliest}）。更早的部分是空白，因为还没从云端取回来——不是那段时间你没有记录。`,
     backfill: '补拉更多历史',
@@ -33,6 +49,11 @@ const messages = defineMessages(
   },
   {
     empty: 'Nothing on this machine yet. Sync once and the charts will have something to draw.',
+    emptyAfterSync:
+      'The sync completed but brought nothing back. Either this account has no data for this period in Zepp, or the watch has not uploaded to the Zepp app yet. Check the Zepp app on your phone first, then sync again here.',
+    emptyUnconfirmedRegion:
+      'The sync completed but brought nothing back. Signing in could not confirm which Zepp region your account belongs to, so ZeppBridge is using its best guess — and a sync aimed at the wrong region behaves exactly like this: it succeeds and returns nothing. Try connecting your account again.',
+    reconnect: 'Reconnect account',
     short: (covered: number, earliest: string) =>
       `This machine holds ${covered} days (earliest ${earliest}). Everything before that is blank because it has not been fetched from the cloud yet — not because you recorded nothing then.`,
     backfill: 'Backfill more history',
@@ -44,8 +65,22 @@ const t = useMessages(messages);
 
 const coverage = computed(() => appStatus.value?.coverage ?? null);
 
-/** 库是空的：这时候该说的是「去同步」，不是「你选多了」。 */
-const isEmpty = computed(() => !coverage.value?.earliest_day);
+/** 库是空的时候该说哪一句。判断在 `emptyLibraryNotice` 里，那里有测试。 */
+const notice = computed(() => emptyLibraryNotice(appStatus.value));
+
+/** 还没同步过：这时候该说的是「去同步」，不是「你选多了」。 */
+const isEmpty = computed(() => notice.value === 'never_synced');
+
+/** 同步跑通了，库还是空的。「先同步一次」这句话在这里是错的。 */
+const isEmptyAfterSync = computed(
+  () => notice.value === 'synced_empty'
+    || notice.value === 'synced_empty_unconfirmed_region',
+);
+
+/** 区域是猜出来的——它是「同步成功却什么都没有」最可能的原因。 */
+const regionUnconfirmed = computed(
+  () => notice.value === 'synced_empty_unconfirmed_region',
+);
 
 /**
  * 差一天不值得打断人。只有当选的范围明显超出本机覆盖时才出声——
@@ -54,6 +89,7 @@ const isEmpty = computed(() => !coverage.value?.earliest_day);
 const isShort = computed(() => {
   const value = coverage.value;
   if (!value?.earliest_day) return false;
+  if (props.requestedDays <= 0) return false;
   return props.requestedDays - value.covered_days > 7;
 });
 
@@ -71,7 +107,17 @@ const syncNow = () => { void runSync('incremental'); };
 </script>
 
 <template>
-  <p v-if="isEmpty" class="coverage-notice" role="status">
+  <p v-if="isEmptyAfterSync" class="coverage-notice" role="status">
+    <Icon name="warning" :size="14" />
+    <span>{{ regionUnconfirmed ? t.emptyUnconfirmedRegion : t.emptyAfterSync }}</span>
+    <RouterLink v-if="regionUnconfirmed" class="button button-secondary" to="/settings">
+      {{ t.reconnect }}
+    </RouterLink>
+    <button v-else class="button button-secondary" type="button" :disabled="isSyncing" @click="syncNow">
+      {{ isSyncing ? t.backfilling : t.syncNow }}
+    </button>
+  </p>
+  <p v-else-if="isEmpty" class="coverage-notice" role="status">
     <Icon name="clock" :size="14" />
     <span>{{ t.empty }}</span>
     <button class="button button-secondary" type="button" :disabled="isSyncing" @click="syncNow">

--- a/src/i18n/errors.ts
+++ b/src/i18n/errors.ts
@@ -52,6 +52,8 @@ const messages = defineMessages(
     'err.login.credentials_rejected': 'Zepp 拒绝了这次登录凭据，请退出登录窗口后重新登录',
     'err.login.region_unreachable': '暂时无法连接 Zepp 区域服务，请检查网络后重试',
     'err.login.region_retrying': '暂时连不上 Zepp 区域服务，正在重试；登录窗口先留着，不用重新登录',
+    'err.login.third_party_stalled':
+      '第三方登录好像卡住了。Google 的通行密钥在应用内窗口里经常停在验证那一步走不下去。可以关掉登录窗口改用邮箱+密码，或者在设置里手动填写 App Token。',
     'err.login.bad_url': '登录地址无效',
     'err.login.window_failed': '无法打开登录窗口',
     'err.login.window_busy': '上一个登录窗口还没有关完，请稍等一下再试',
@@ -167,6 +169,8 @@ const messages = defineMessages(
       "Couldn't reach the Zepp region service. Check your network and try again",
     'err.login.region_retrying':
       "Can't reach the Zepp region service right now — retrying. The sign-in window stays open, so there is no need to sign in again",
+    'err.login.third_party_stalled':
+      'This third-party sign-in looks stuck. Google passkeys often stall at the verification step inside an in-app window. Close the sign-in window and use email + password instead, or enter an App Token manually in Settings.',
     'err.login.bad_url': 'Invalid sign-in address',
     'err.login.window_failed': "Couldn't open the sign-in window",
     'err.login.window_busy':

--- a/src/lib/__tests__/emptyLibraryNotice.test.ts
+++ b/src/lib/__tests__/emptyLibraryNotice.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { emptyLibraryNotice } from '../emptyLibraryNotice';
+import type { AppStatus } from '../../types';
+
+const status = (patch: Partial<AppStatus>): AppStatus => ({
+  configured: true,
+  auth_state: 'verified',
+  connection_state: 'connected',
+  streams: [],
+  capabilities: [],
+  retention_days: 0,
+  ...patch,
+} as AppStatus);
+
+describe('库是空的时候该说哪一句', () => {
+  it('库里有数据就什么都不说', () => {
+    expect(emptyLibraryNotice(status({
+      coverage: { earliest_day: '2026-01-01', latest_day: '2026-08-01', covered_days: 200 },
+    }))).toBe('none');
+  });
+
+  it('状态还没读回来时不猜——空状态不等于空库', () => {
+    expect(emptyLibraryNotice(null)).toBe('none');
+    expect(emptyLibraryNotice(undefined)).toBe('none');
+  });
+
+  it('还没同步过，「先同步一次」是对的', () => {
+    expect(emptyLibraryNotice(status({}))).toBe('never_synced');
+  });
+
+  it('同步失败过不算跑通——那有它自己的报错，不该在这里再解释一遍', () => {
+    expect(emptyLibraryNotice(status({
+      last_cloud_sync_at: '2026-09-01T00:00:00Z',
+      last_cloud_sync_outcome: 'failed',
+    }))).toBe('never_synced');
+  });
+
+  it('同步跑通了库还是空的，就不能再让人「先同步一次」', () => {
+    for (const outcome of ['updated', 'no_new_data'] as const) {
+      expect(emptyLibraryNotice(status({
+        last_cloud_sync_at: '2026-09-01T00:00:00Z',
+        last_cloud_sync_outcome: outcome,
+      }))).toBe('synced_empty');
+    }
+  });
+
+  it('区域是猜出来的，就先说区域——它是「同步成功却什么都没有」最可能的原因', () => {
+    expect(emptyLibraryNotice(status({
+      last_cloud_sync_at: '2026-09-01T00:00:00Z',
+      last_cloud_sync_outcome: 'no_new_data',
+      region_confidence: 'unconfirmed',
+    }))).toBe('synced_empty_unconfirmed_region');
+  });
+
+  it('区域有据可依时不拿区域说事', () => {
+    for (const confidence of ['identified', 'hinted', 'unknown'] as const) {
+      expect(emptyLibraryNotice(status({
+        last_cloud_sync_at: '2026-09-01T00:00:00Z',
+        last_cloud_sync_outcome: 'updated',
+        region_confidence: confidence,
+      }))).toBe('synced_empty');
+    }
+  });
+});

--- a/src/lib/emptyLibraryNotice.ts
+++ b/src/lib/emptyLibraryNotice.ts
@@ -1,0 +1,56 @@
+/**
+ * 库是空的，该说哪一句。
+ *
+ * 「本机还没有数据」这一句在同步之前是对的，同步之后就不对了——它让人去做刚
+ * 做过的事。而同步跑通了却一条记录都没带回来，最常见的原因是登录时没能确认
+ * 账号所在的 Zepp 区域：打向错误区域的请求一路成功、返回空，界面上和「这段
+ * 时间你确实没数据」长得一模一样。这个函数把这几种情况分开。
+ *
+ * 判断和文案分开：这里只出码，句子由组件按当前语言写。
+ */
+/**
+ * 只声明这个判断真正读的那几个字段，而不是整个 AppStatus。
+ *
+ * 组件拿到的状态是 `DeepReadonly` 的，写死成 AppStatus 只会在调用点上逼出一个
+ * 类型断言——那正是以后悄悄放错东西进来的地方。
+ */
+export interface EmptyLibraryInput {
+  readonly coverage?: { readonly earliest_day: string | null } | null;
+  readonly last_cloud_sync_at?: string;
+  readonly last_cloud_sync_outcome?: string;
+  readonly region_confidence?: string;
+}
+
+export type EmptyLibraryNotice =
+  /** 库里有数据，什么都不用说。 */
+  | 'none'
+  /** 还没跟云端同步过。「先同步一次」是对的。 */
+  | 'never_synced'
+  /** 同步跑通了，库还是空的，原因未知。 */
+  | 'synced_empty'
+  /** 同步跑通了，库还是空的，而且当前区域是猜出来的——最可能就是猜错了。 */
+  | 'synced_empty_unconfirmed_region';
+
+/**
+ * 一次云端同步算不算「跑通了」。
+ *
+ * 只看有没有时间戳不够：失败的同步同样会留下时间戳，而「失败了所以是空的」
+ * 本来就有它自己的报错，不该在这里再解释一遍。
+ */
+const cloudSyncSucceeded = (status: EmptyLibraryInput): boolean => {
+  if (!status.last_cloud_sync_at) return false;
+  return status.last_cloud_sync_outcome === 'updated'
+    || status.last_cloud_sync_outcome === 'no_new_data';
+};
+
+export const emptyLibraryNotice = (
+  status: EmptyLibraryInput | null | undefined,
+): EmptyLibraryNotice => {
+  // 状态还没读回来时不猜。空状态和空库不是一回事。
+  if (!status) return 'none';
+  if (status.coverage?.earliest_day) return 'none';
+  if (!cloudSyncSucceeded(status)) return 'never_synced';
+  return status.region_confidence === 'unconfirmed'
+    ? 'synced_empty_unconfirmed_region'
+    : 'synced_empty';
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -42,6 +42,14 @@ export interface AppStatus {
   storage?: StorageEstimate;
   /** 本机实际有数据的那段日子。界面上每个「最近 N 天」读的都是本机库。 */
   coverage?: LocalCoverage;
+  /**
+    * 凭什么认定当前 `region_host` 属于这个账号。
+    *
+    * `identified` 拿到了这个账号绑定的设备；`hinted` 是 Zepp 在登录响应里指名
+    * 的；`unconfirmed` 是从兜底列表里猜的——同步之后一条记录都没有时，这一档
+    * 是用户唯一能看到的线索。进程重启后无从得知，为 `unknown`。
+    */
+  region_confidence?: 'identified' | 'hinted' | 'unconfirmed' | 'unknown' | string;
   /** 后台是否正在压缩历史报文。事件可能在前端监听之前就发出去了，所以状态里也要有。 */
   compacting?: boolean;
 }

--- a/src/views/Overview.vue
+++ b/src/views/Overview.vue
@@ -5,6 +5,7 @@ import { RouterLink } from 'vue-router';
 import { graphic } from 'echarts/core';
 import { VChart } from '../lib/echartsSetup';
 import CircularProgress from '../components/CircularProgress.vue';
+import CoverageNotice from '../components/CoverageNotice.vue';
 import DesignIcon, { type DesignIconName } from '../components/DesignIcon.vue';
 import DeviceVisual from '../components/DeviceVisual.vue';
 import Icon from '../components/Icon.vue';
@@ -553,6 +554,12 @@ watch(dataRevision, () => { void loadOverview(); void loadDevices(); });
     </RouterLink>
 
     <WeeklyReportCard />
+
+    <!--
+      同步跑通却一条记录都没有，最先看到的是这一页。上面每个面板各自说一句
+      「暂无数据」，谁也不解释为什么——而原因往往是登录时没确认对区域。
+    -->
+    <CoverageNotice />
 
     <div v-if="partialWarning" class="inline-alert warning" role="status"><Icon name="info" :size="15" />{{ partialWarning }}</div>
     <div v-if="deviceError" class="inline-alert warning" role="status"><Icon name="info" :size="15" />{{ t.deviceErrorPrefix }}{{ deviceError }}</div>


### PR DESCRIPTION
第一批：登录批（计划里的 A + B + C）。

## A. 区域探测不再被空响应骗到

**根因（TODO 里只写了怀疑，这次确认了）**：`probe_region_batch` 把 apptoken 并发发给约 10 个候选区域 host，**第一个「成功」的直接 win 并 break**。而「成功」的判据是 `verify_recent_heart_rate` → `validate_verify_payload`，后者显式接受空结果（`Value::Array(_) => Ok(())`，无 `code` 字段的对象也 `Ok(())`）。

一个不认识这个账号的区域，返回的正是结构化空响应——和正确区域在「用户这两小时没戴表」时给的回答完全一样，而且因为它不用查数据，往往答得更快。于是错误区域赢下竞速、被存成 `region_host`，之后每次同步都打向那里：界面「已连接」、同步「成功」、库里一条没有。这就是 Reddit p748eb0。

**改动**：
- 新增 `probe_region_evidence`（`auth.rs`）：用 `/users/{user_id}/devices` —— 路径里带 `user_id`，陌生区域答不上来。设备端点因**非鉴权**原因失败时退回原来的心率判据（弱证据），不让一条从没出过问题的登录路径因为换端点而失败。
- `validate_verify_payload` 的原语义**不动**：`verify_auth` 复验已保存凭据时，「空 = 有效」是对的，用户可能真的没戴表。两个问题拆成两个函数。
- 证据分三档，写进 `AppStatus.region_confidence`：
  - `identified` — 交出了这个账号绑定的设备
  - `hinted` — Zepp 在登录响应里指名的 host，请求通了但账号没绑设备
  - `unconfirmed` — 从兜底列表里猜中的
- 兜底阶段不再 first-wins：弱证据之间按**偏好顺序**比，不按谁先回来。
- 常见路径的耗时没变：authoritative 阶段请求一通就返回，`Identified` 立即短路。

## B. 同步跑通却什么都没有，不再静默

库空时每一页都说「本机还没有任何数据，先同步一次」——包括刚同步完的那一刻，等于让人重做刚做过的事。现在 `emptyLibraryNotice()`（`src/lib/`，带 7 条测试）把三种情况分开：还没同步过 / 同步成功但空 / 同步成功但空且区域是猜的。最后一种先说区域，并给出重新连接的入口。`CoverageNotice` 也挂到了概览页——同步完什么都没有的人，第一眼看到的就是那一页。

## C. 第三方登录卡住时给出出路

停在第三方授权页（Google / 小米 / 微信 / Facebook / Amazfit）满 2 分钟且仍未读到凭据时，提前提示改用邮箱+密码或在设置里手动填 App Token，而不是让人等满 15 分钟只等到「登录超时」。计时跟着**地址**走，在授权页之间正常来回跳不会误报。判定是纯函数，有测试。放行导航和这个判定现在共用同一份第三方 host 表。

Google passkey 在嵌入式 WebView2 里停在 "verifying it's you" 是浏览器的限制，代码改不了——能做的只是别让人干等。

**计划里对 C 的一个假设是错的，这里更正**：`import_from_har` / `manual_auth` 的前端入口**已经存在**（`Settings.vue:469` / `:492`，UI 在 `:1009-1023`），不需要新加。

## 未在真实账号上验证

开发账号只有一个中国大陆账号，验证过的路径是**邮箱+密码**和**微信扫码**。小米账号 OAuth 和 Google 登录 / passkey 无法在本机复现或复测。区域修复由喂给选择逻辑合成结果的单测覆盖，停滞提示是纯函数单测——但都没走过真实的 Google 或小米登录。CHANGELOG 里有一节如实写明了这一点，回写 Issue 时也应保持 needs verification。

## 验证

```
cargo fmt --check          OK
cargo clippy -D warnings   OK
cargo test --workspace     55 + 6 + 168 + 4 passed
npm test                   86 passed（新增 7 条）
npm run i18n:check         88 个后端错误码中英齐全
npm run build              OK
version / docs / budget / test:functions   OK
```

新增的 Rust 用例直接钉住这个 bug：`a_fast_empty_region_does_not_beat_a_slower_one_that_knows_the_account`（错误区域先答应、正确区域后答应，必须选后者）、`only_empty_answers_fall_back_to_the_most_preferred_host`、`an_authoritative_host_still_counts_when_the_account_has_no_devices`、`an_explicit_rejection_stays_fatal`。

版本号仍是 1.1.5：按计划，版本号 / tag / Release 统一放在最后的发布批。

## 后续批次

2. 目录批：运动码 211 = 公路骑行、code 7 越野跑取证、设备 deviceSource 数字编号映射 + 反馈库 triage
3. 界面批：500 条上限分页、显式 Logout、英文界面中文残留实机扫查
4. 心率批：日最高心率 raw max 对照
5. 发布批：1.2.0 版本号 + tag + Release + Cloudflare Pages 重新部署

🤖 Generated with [Claude Code](https://claude.com/claude-code)
