### PR TITLE
fix(ci): make the Linux and Flatpak packaging jobs actually complete

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,41 @@ jobs:
           flatpak-builder --show-manifest \
             packaging/flatpak/com.zeppbridge.app.yml > /dev/null
 
+      # `appstreamcli validate` 只看那份 XML 自己合不合法。flatpak-builder
+      # 真正跑的是 `appstreamcli compose`，那一步还要去读 desktop 文件和图标，
+      # 而它是在整个 Rust 编译成功之后才跑的——一个读不了的图标会让十五分钟
+      # 的构建倒在最后一步，报一句既不提文件名也不提图标的
+      #   com.zeppbridge.app  E: file-read-error
+      #
+      # 这里用打包用的那几个文件搭一个最小的 /usr 树，把同一个 compose 提前
+      # 到秒级跑掉。（这条检查就是这么发现 icon-source.svg 不能当平台图标的：
+      # 它用 <symbol> + <use> 间接引用，compose 读不了。）
+      - name: Dry-run the AppStream compose the Flatpak build will do
+        run: |
+          set -euo pipefail
+          sudo apt-get install -y --no-install-recommends appstream-compose
+          root=$(mktemp -d)/files
+          mkdir -p "$root/usr/share/applications" "$root/usr/share/metainfo"
+          install -m644 packaging/flatpak/com.zeppbridge.app.desktop \
+            "$root/usr/share/applications/com.zeppbridge.app.desktop"
+          install -m644 packaging/flatpak/com.zeppbridge.app.metainfo.xml \
+            "$root/usr/share/metainfo/com.zeppbridge.app.metainfo.xml"
+
+          # 图标来源要和 manifest 里的 install 命令一致，否则这条检查会
+          # 检查一个和实际构建不同的东西。
+          for pair in 32x32:32x32 64x64:64x64 128x128:128x128 \
+                      128x128@2x:256x256 icon:512x512; do
+            src="${pair%%:*}"; dir="${pair##*:}"
+            mkdir -p "$root/usr/share/icons/hicolor/$dir/apps"
+            install -m644 "src-tauri/icons/$src.png" \
+              "$root/usr/share/icons/hicolor/$dir/apps/com.zeppbridge.app.png"
+          done
+
+          out=$(mktemp -d)
+          appstreamcli compose --origin=ci --prefix=/usr \
+            --result-root="$out" --data-dir="$out/data" --icons-dir="$out/icons" \
+            --components=com.zeppbridge.app "$root"
+
       # 钉住的 runtime 会在某一天停止维护，而那一天不会有任何东西提醒我们：
       # 构建照样绿，装出来的应用照样能跑，只是它内嵌的 WebView 不再收到
       # 安全更新了。这个项目上，WebView 是暴露面最大的那个组件。
@@ -436,21 +471,29 @@ jobs:
             libdbus-1-dev \
             libxdo-dev \
             patchelf \
-            rpm
+            rpm \
+            xdg-utils
 
       - name: Install frontend dependencies
         run: npm ci
 
       # deb/rpm/appimage 三样都出。三种发行版家族，不要求用户去转换包格式。
       #
-      # 刻意不签名、也不产出 updater 用的 .sig：latest.json 里没有 linux 的
-      # 条目，应用内更新在 Linux 上是关掉的（updates.rs 的
-      # self_update_supported）。这里的更新走包管理器。
+      # `--config src-tauri/tauri.linux.conf.json` 把 createUpdaterArtifacts
+      # 关掉。基础配置里它是 true（Windows 和 macOS 要用），而那个开关是全局
+      # 的：开着的时候 tauri 会去找签名私钥，找不到就直接失败——
+      #   `A public key has been found, but no private key.`
+      # 而 Linux 这边刻意不产出 updater 产物：latest.json 里没有 linux 条目，
+      # 应用内更新在 Linux 上是关掉的（updates.rs 的 self_update_supported），
+      # 签一份没人会去取的产物只是白签。这个作业因此也不需要拿到那个 secret。
       - name: Build and bundle (deb + rpm + appimage)
         # appimagetool 要用 FUSE 挂载自己，CI runner 上没有。
         env:
           APPIMAGE_EXTRACT_AND_RUN: 1
-        run: npm run tauri build -- --bundles deb,rpm,appimage
+        run: |
+          npm run tauri build -- \
+            --config src-tauri/tauri.linux.conf.json \
+            --bundles deb,rpm,appimage
 
       - name: Collect Linux artifacts
         shell: bash
@@ -460,13 +503,35 @@ jobs:
           bundle=src-tauri/target/release/bundle
           mkdir -p release-linux
 
-          # tauri 给出的文件名在不同版本间变过（`_amd64` / `_x86_64`、
-          # 有无 `-1` 的 rpm release 号）。用通配拿到那一个文件，再自己
-          # 命名，发布产物的名字才不会随工具链漂移。
-          cp "$(ls "$bundle"/deb/*.deb)"           "release-linux/ZeppBridge_${version}_amd64.deb"
-          cp "$(ls "$bundle"/rpm/*.rpm)"           "release-linux/ZeppBridge_${version}_x86_64.rpm"
-          cp "$(ls "$bundle"/appimage/*.AppImage)" "release-linux/ZeppBridge_${version}_x86_64.AppImage"
-          ls -la release-linux
+          # tauri 给出的文件名在不同版本间变过（`_amd64` / `_x86_64`、rpm 那边
+          # 还带一个 release 号：ZeppBridge-1.1.5-1.x86_64.rpm）。用通配拿到
+          # 文件再自己命名，发布产物的名字才不会随工具链漂移。
+          #
+          # 恰好一个匹配才算数。零个意味着打包静默地没产出这一种格式；两个
+          # 意味着上一次构建的残留还在，而那时 cp 会随机挑一个——发布出去的
+          # 就可能是个旧版本的包，且没有任何迹象。
+          # nullglob 是必须的：默认情况下不匹配的通配会原样留下，于是
+          # `matches` 里是那一段字面的模式字符串，计数报「1 个」。真正拦住它
+          # 的是下面的 -f 检查，但报错会指着一个看起来存在的文件名，读的人
+          # 得先怀疑自己。
+          shopt -s nullglob
+
+          take_one() {
+            local pattern="$1" dest="$2"
+            local matches=()
+            # shellcheck disable=SC2206
+            matches=($pattern)
+            if [[ ${#matches[@]} -ne 1 || ! -f "${matches[0]}" ]]; then
+              echo "::error::期望 $pattern 恰好匹配一个文件，实际 ${#matches[@]} 个：${matches[*]-}"
+              exit 1
+            fi
+            cp "${matches[0]}" "$dest"
+            echo "  ${matches[0]}  ->  $dest"
+          }
+
+          take_one "$bundle/deb/*.deb"           "release-linux/ZeppBridge_${version}_amd64.deb"
+          take_one "$bundle/rpm/*.rpm"           "release-linux/ZeppBridge_${version}_x86_64.rpm"
+          take_one "$bundle/appimage/*.AppImage" "release-linux/ZeppBridge_${version}_x86_64.AppImage"
 
       - name: Package CLI and MCP tools
         shell: bash
@@ -496,9 +561,15 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install flatpak-builder
+        # elfutils 提供 eu-strip。flatpak-builder 默认会把调试信息从二进制里
+        # 剥出来单独放，那一步就是调 eu-strip；缺了它，整个构建会在**编译全部
+        # 成功之后**才失败：
+        #   Failed to execute child process "eu-strip" (No such file or directory)
+        # ubuntu-latest 上没有预装它。
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends flatpak flatpak-builder
+          sudo apt-get install -y --no-install-recommends \
+            flatpak flatpak-builder elfutils
 
       - name: Build and export the bundle
         # --bundle 会写 release/ZeppBridge_<version>_x86_64.flatpak；

--- a/docs/guides/docker.md
+++ b/docs/guides/docker.md
@@ -215,7 +215,8 @@ structural rather than a promise.
 ```bash
 docker build -f packaging/docker/Dockerfile.build -t zeppbridge-build:local .
 docker run --rm -v "$PWD:/src" -w /src zeppbridge-build:local \
-  bash -c 'npm ci && npm run tauri build -- --bundles deb,rpm,appimage'
+  bash -c 'npm ci && npm run tauri build -- \
+    --config src-tauri/tauri.linux.conf.json --bundles deb,rpm,appimage'
 ```
 
 Debian bookworm on purpose, not a rolling base: the glibc a binary links against

--- a/docs/guides/docker.zh-CN.md
+++ b/docs/guides/docker.zh-CN.md
@@ -171,7 +171,8 @@ docker compose -f packaging/docker/docker-compose.yml run --rm sync
 ```bash
 docker build -f packaging/docker/Dockerfile.build -t zeppbridge-build:local .
 docker run --rm -v "$PWD:/src" -w /src zeppbridge-build:local \
-  bash -c 'npm ci && npm run tauri build -- --bundles deb,rpm,appimage'
+  bash -c 'npm ci && npm run tauri build -- \
+    --config src-tauri/tauri.linux.conf.json --bundles deb,rpm,appimage'
 ```
 
 刻意用 Debian bookworm 而不是滚动版本：二进制链接的 glibc 就是它能运行的最低 glibc，在最新的发行版上构建，产出的包会在人们实际在用的 LTS 上拒绝启动。Node 和 Rust 的版本作为构建参数钉死——要升就明确地升。

--- a/docs/guides/linux.md
+++ b/docs/guides/linux.md
@@ -39,7 +39,8 @@ cd ZeppBridge
 flatpak run com.zeppbridge.app
 ```
 
-The script needs `flatpak` and `flatpak-builder` on the host and nothing else —
+The script needs `flatpak`, `flatpak-builder` and `elfutils` on the host and
+nothing else —
 Rust and Node come from Flatpak SDK extensions, so no toolchain is installed
 system-wide. Everything is `--user`; it never asks for root.
 
@@ -147,14 +148,28 @@ whole bus would be a hole in the sandbox).
 
 ```bash
 sudo apt install libwebkit2gtk-4.1-dev libgtk-3-dev \
-  libayatana-appindicator3-dev librsvg2-dev libdbus-1-dev libxdo-dev patchelf
+  libayatana-appindicator3-dev librsvg2-dev libdbus-1-dev libxdo-dev patchelf \
+  rpm xdg-utils
 npm ci
-npm run tauri build -- --bundles deb,rpm,appimage
+npm run tauri build -- \
+  --config src-tauri/tauri.linux.conf.json \
+  --bundles deb,rpm,appimage
 ```
 
-`libdbus-1-dev` is the one that is easy to miss: it is not on Tauri's own
-prerequisites list. It is there because the Secret Service credential backend
-links libdbus. Runtime needs `libdbus-1-3`, which the deb and rpm both declare.
+`--config src-tauri/tauri.linux.conf.json` turns off updater artifacts. The base
+config enables them for Windows and macOS, and that switch is global — with it
+on, the bundler looks for the release signing key and stops with *"A public key
+has been found, but no private key"*. Linux builds deliberately produce no
+updater artifacts, since in-app updating is off there.
+
+Three of those are easy to miss, and none is on Tauri's own prerequisites list:
+
+- `libdbus-1-dev` — the Secret Service credential backend links libdbus. At
+  runtime this is `libdbus-1-3`, which the deb and rpm both declare.
+- `rpm` — the rpm bundler shells out to `rpmbuild`.
+- `xdg-utils` — the AppImage bundler copies `/usr/bin/xdg-open` into the image.
+  Missing it fails *after* the deb and rpm have already been written, which
+  makes it look like an AppImage-specific bug rather than a missing package.
 
 To avoid installing any of that, use the pinned toolchain container instead —
 same compiler, same webkit, same glibc as CI:
@@ -162,7 +177,8 @@ same compiler, same webkit, same glibc as CI:
 ```bash
 docker build -f packaging/docker/Dockerfile.build -t zeppbridge-build .
 docker run --rm -v "$PWD:/src" -w /src zeppbridge-build \
-  bash -c 'npm ci && npm run tauri build -- --bundles deb,rpm,appimage'
+  bash -c 'npm ci && npm run tauri build -- \
+    --config src-tauri/tauri.linux.conf.json --bundles deb,rpm,appimage'
 ```
 
 ## Flathub

--- a/docs/guides/linux.zh-CN.md
+++ b/docs/guides/linux.zh-CN.md
@@ -32,7 +32,7 @@ cd ZeppBridge
 flatpak run com.zeppbridge.app
 ```
 
-脚本只要求宿主机上有 `flatpak` 和 `flatpak-builder`，别的都不需要——Rust 和 Node 来自 Flatpak 的 SDK 扩展，不会往系统里装任何工具链。全程 `--user`，不需要 root。
+脚本只要求宿主机上有 `flatpak`、`flatpak-builder` 和 `elfutils`（提供 `eu-strip`，flatpak-builder 剥调试信息时要用），别的都不需要——Rust 和 Node 来自 Flatpak 的 SDK 扩展，不会往系统里装任何工具链。全程 `--user`，不需要 root。
 
 加 `--bundle` 还会额外产出一个可直接安装的单文件：`release/ZeppBridge_<版本>_x86_64.flatpak`。
 
@@ -108,19 +108,32 @@ AppImage 用户手动换文件。为什么没有自更新：更新清单里没�
 
 ```bash
 sudo apt install libwebkit2gtk-4.1-dev libgtk-3-dev \
-  libayatana-appindicator3-dev librsvg2-dev libdbus-1-dev libxdo-dev patchelf
+  libayatana-appindicator3-dev librsvg2-dev libdbus-1-dev libxdo-dev patchelf \
+  rpm xdg-utils
 npm ci
-npm run tauri build -- --bundles deb,rpm,appimage
+npm run tauri build -- \
+  --config src-tauri/tauri.linux.conf.json \
+  --bundles deb,rpm,appimage
 ```
 
-`libdbus-1-dev` 是容易漏的那一个：它不在 Tauri 自己的前置依赖清单里。它在这里是因为 Secret Service 凭据后端链接 libdbus。运行时要 `libdbus-1-3`，deb 和 rpm 都已经声明了它。
+`--config src-tauri/tauri.linux.conf.json` 的作用是关掉 updater 产物。基础配置里
+它是开着的（Windows 和 macOS 要用），而那个开关是全局的：开着的时候打包会去找
+发布签名私钥，找不到就停在「A public key has been found, but no private key」。
+Linux 这边刻意不产出 updater 产物——应用内更新在 Linux 上本来就是关的。
+
+其中三个容易漏，而且都不在 Tauri 自己的前置依赖清单里：
+
+- `libdbus-1-dev` —— Secret Service 凭据后端链接 libdbus。运行时对应 `libdbus-1-3`，deb 和 rpm 都已经声明了它。
+- `rpm` —— rpm 打包那一步要调 `rpmbuild`。
+- `xdg-utils` —— AppImage 打包会把 `/usr/bin/xdg-open` 复制进镜像。缺了它，失败发生在 deb 和 rpm 都已经写出来**之后**，看起来像是 AppImage 自己的 bug，而不是少装了一个包。
 
 不想往系统里装这些的话，用那个版本钉死的工具链容器——编译器、webkit、glibc 都和 CI 一致：
 
 ```bash
 docker build -f packaging/docker/Dockerfile.build -t zeppbridge-build .
 docker run --rm -v "$PWD:/src" -w /src zeppbridge-build \
-  bash -c 'npm ci && npm run tauri build -- --bundles deb,rpm,appimage'
+  bash -c 'npm ci && npm run tauri build -- \
+    --config src-tauri/tauri.linux.conf.json --bundles deb,rpm,appimage'
 ```
 
 ## Flathub

--- a/packaging/docker/Dockerfile.build
+++ b/packaging/docker/Dockerfile.build
@@ -7,7 +7,8 @@
 #
 #   docker build -f packaging/docker/Dockerfile.build -t zeppbridge-build:local .
 #   docker run --rm -v "$PWD:/src" -w /src zeppbridge-build:local \
-#       npm ci && npm run tauri build -- --bundles deb,rpm,appimage
+#       npm ci && npm run tauri build -- \
+#         --config src-tauri/tauri.linux.conf.json --bundles deb,rpm,appimage
 #
 # Bookworm on purpose, not trixie or a rolling base: the glibc a Tauri binary
 # is linked against is the oldest glibc it will run on. Building on the newest
@@ -21,6 +22,10 @@ ENV DEBIAN_FRONTEND=noninteractive
 #   libdbus-1-dev — the Secret Service credential backend (see
 #                   src-tauri/crates/core/Cargo.toml)
 #   rpm           — the rpm bundler shells out to rpmbuild
+#   xdg-utils     — the AppImage bundler copies /usr/bin/xdg-open into the
+#                   image so "open this link" works on the host. Missing it
+#                   fails *after* deb and rpm have already been produced:
+#                   `failed to bundle project: xdg-open binary not found`
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         build-essential \
@@ -38,6 +43,7 @@ RUN apt-get update \
         patchelf \
         pkg-config \
         rpm \
+        xdg-utils \
         xz-utils \
     && rm -rf /var/lib/apt/lists/*
 

--- a/packaging/flatpak/build-flatpak.sh
+++ b/packaging/flatpak/build-flatpak.sh
@@ -29,14 +29,20 @@ for arg in "$@"; do
   esac
 done
 
-for tool in flatpak flatpak-builder; do
+# eu-strip is in the list because flatpak-builder does not check for it up
+# front: it strips debug info as a post-processing step, so a missing eu-strip
+# fails the build *after* the whole Rust release compile has succeeded. Ten
+# minutes in, with an error that names a binary nobody has heard of.
+for tool in flatpak flatpak-builder eu-strip; do
   if ! command -v "$tool" >/dev/null 2>&1; then
     cat >&2 <<MSG
-$tool is not installed.
+$tool is not installed. All three are needed:
 
-  Debian/Ubuntu: sudo apt install flatpak flatpak-builder
-  Fedora:        sudo dnf install flatpak flatpak-builder
-  Arch:          sudo pacman -S flatpak flatpak-builder
+  Debian/Ubuntu: sudo apt install flatpak flatpak-builder elfutils
+  Fedora:        sudo dnf install flatpak flatpak-builder elfutils
+  Arch:          sudo pacman -S flatpak flatpak-builder elfutils
+
+(eu-strip comes from the elfutils package.)
 MSG
     exit 1
   fi

--- a/packaging/flatpak/com.zeppbridge.app.yml
+++ b/packaging/flatpak/com.zeppbridge.app.yml
@@ -95,18 +95,33 @@ modules:
         /app/share/icons/hicolor/256x256/apps/com.zeppbridge.app.png
       - install -Dm644 src-tauri/icons/icon.png
         /app/share/icons/hicolor/512x512/apps/com.zeppbridge.app.png
-      - install -Dm644 src-tauri/icons/icon-source.svg
-        /app/share/icons/hicolor/scalable/apps/com.zeppbridge.app.svg
+      # 刻意不装 icons/icon-source.svg 作为 scalable 图标，两个理由：
+      #
+      # 1. 它不是平台图标。scripts/icon/generate-icons.mjs 说得很清楚：平台
+      #    图标以 icon-master.png 为源，icon-source.svg 是留给应用内
+      #    BrandMark 用的。它的描边是 currentColor，靠 CSS 给颜色——脱离
+      #    界面单独渲染时颜色是没有定义的。
+      # 2. 装了它，构建会在编译全部成功之后倒在 appstreamcli compose 上：
+      #    `com.zeppbridge.app  E: file-read-error`。那个 SVG 用 <symbol> +
+      #    <use href="#..."> 的间接引用，compose 读不了它。而这个报错既不
+      #    提文件名也不提 SVG，从它推回到「那一行 install」要花很久。
+      #
+      # 上面五个 PNG（32/64/128/256/512）覆盖了所有实际用到的尺寸。
     sources:
       - type: dir
         path: ../..
         # 构建产物和依赖目录不进构建沙箱：node_modules 可能是给另一个平台
         # 装的，target/ 里那几个 G 只会让复制变慢。
+        #
+        # `.git` 刻意**不**在这份名单里，尽管它是 31 MB。vite.config.ts 用
+        # `git rev-parse --short HEAD` 生成构建标记，那一行显示在设置页上，
+        # 是「同一个版本号构建了很多次，你手上是哪一个」的唯一答案。跳过
+        # .git 时它会安静地回落成 unknown——而 Flatpak 恰好是这三个渠道里
+        # 最没被验证过的那个，正是最需要收到可定位的问题报告的地方。
         skip:
           - node_modules
           - dist
           - src-tauri/target
           - target
-          - .git
           - release
           - data

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -52,20 +52,10 @@
     },
     "linux": {
       "deb": {
-        "depends": [
-          "libwebkit2gtk-4.1-0",
-          "libgtk-3-0",
-          "libayatana-appindicator3-1",
-          "libdbus-1-3"
-        ]
+        "depends": ["libdbus-1-3"]
       },
       "rpm": {
-        "depends": [
-          "webkit2gtk4.1",
-          "gtk3",
-          "libayatana-appindicator-gtk3",
-          "dbus-libs"
-        ]
+        "depends": ["dbus-libs"]
       }
     },
     "windows": {

--- a/src-tauri/tauri.linux.conf.json
+++ b/src-tauri/tauri.linux.conf.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "bundle": {
+    "createUpdaterArtifacts": false
+  }
+}


### PR DESCRIPTION
Fixes the two jobs from #26 that failed on `main`. They don't run on pull requests, which is why the failure only appeared after merge — this PR also closes that blind spot.

修复 #26 合入后在 `main` 上失败的两个作业。它们在 PR 上不跑，所以合并前没人看得见——这个 PR 也把这个盲区补上。

Failing run: https://github.com/lingcang728/ZeppBridge/actions/runs/33497297548

## Four failures, nested

Each one only becomes visible after the previous is fixed, which is why the run showed two and there were actually four.

**1. `Package Linux bundles` — `A public key has been found, but no private key.`**

`createUpdaterArtifacts` is `true` in the base config for Windows and macOS, and it's a **global** switch: with it on, bundling looks for the release signing key. The Linux job deliberately isn't given that secret, because Linux produces no updater artifacts on purpose — `latest.json` has no Linux entry and in-app updating is off there.

Fix: a new `src-tauri/tauri.linux.conf.json` that turns it off, layered on with `--config`. Windows and macOS are untouched.

**2. `Package Flatpak bundle` — `Failed to execute child process "eu-strip"`**

flatpak-builder splits debug info out as a post-processing step, which shells out to `eu-strip` from `elfutils`. Not preinstalled on `ubuntu-latest`. This fails **after** the entire Rust release build has succeeded — 15 minutes in, naming a binary most people have never heard of. Added to CI and to `build-flatpak.sh`'s prerequisite check.

**3. AppImage — `xdg-open binary not found`**

Only found by running the whole pipeline locally; CI hadn't reached it. The AppImage bundler copies `/usr/bin/xdg-open` into the image. Missing `xdg-utils` fails *after* the deb and rpm are already written, so it reads like an AppImage bug rather than a missing package.

**4. Revealed by fixing #2 — `appstreamcli compose failed` / `E: file-read-error`**

This one is mine from #26: I installed `icons/icon-source.svg` as the scalable platform icon. That was wrong on its own terms — `scripts/icon/generate-icons.mjs` already says platform icons come from `icon-master.png` and `icon-source.svg` is kept for the in-app `BrandMark`. It strokes with `currentColor` and uses `<symbol>` + `<use href="#...">`, which `appstreamcli compose` can't read. Removed; the five PNGs (32/64/128/256/512) cover every size actually used.

## A seconds-long guard for that last class

`appstreamcli validate` only checks the XML in isolation. What flatpak-builder actually runs is `appstreamcli compose`, which also reads the desktop file and the icons — and it runs *after* the full compile. So an unreadable icon costs a 15-minute build and reports an error naming neither a file nor an icon.

`verify-linux` now assembles a minimal `/usr` tree from the packaging files and runs that same compose in seconds, on every PR. That guard is how I found the SVG problem, and I verified it goes red on the bad SVG and green on the current icon set.

## Three things picked up along the way

- **`Collect Linux artifacts` no longer uses `$(ls ...)`.** It now globs into an array and requires exactly one match. Zero means a format silently didn't build; two means leftovers from a previous build are still around, and `cp` would pick one arbitrarily — publishing a stale package with nothing to show it. `nullglob` is set, otherwise a non-match reports "1 match" and points at a literal glob pattern.
- **deb/rpm `depends` reduced to what Tauri doesn't already add** (`libdbus-1-3` / `dbus-libs`). The previous list duplicated Tauri's defaults; `dpkg-deb -f` showed three repeated entries.
- **The Flatpak source no longer skips `.git`.** `vite.config.ts` derives the build stamp from `git rev-parse`, and skipping `.git` made it silently fall back to `unknown`. That stamp is the only answer to "which of the many builds of this version do you have", and Flatpak is the least-verified channel — the one where locatable bug reports matter most. Costs copying 31 MB.

## Verified locally this time, not on CI

Given #26 was merged on the strength of jobs that don't run on PRs, I ran the real thing:

| | Result |
|---|---|
| deb + rpm + AppImage in the pinned toolchain container, **with no signing key in the environment** | All three produced |
| `Collect Linux artifacts`, exactly as CI runs it | All three renamed correctly; zero-match and two-match both rejected with accurate counts |
| Flatpak, end to end | flatpak-builder reaches `Success!`, eu-strip completes, `flatpak build-bundle` writes a 30 MB `.flatpak` |
| Keeping `.git` | `not a git repository` no longer appears during the build (it did before) |
| Tools archive via pwsh on Linux | Correct name and contents, no `.exe` suffix |
| AppStream compose guard | Green on current icons, red on the SVG |

Docs updated too: the build commands in both Linux guides, both Docker guides and `Dockerfile.build` all carried the command that hits failure #1, and the from-source apt list was missing `rpm` and `xdg-utils`.

No CHANGELOG entry — none of this changes anything a user can perceive; the Linux packages never shipped, since the release job never got its artifacts.

没有加 CHANGELOG：这些都不是用户能感知到的变化，而且 Linux 的包本来就没发出去过——release 作业根本没拿到产物。
