### PR TITLE
fix(landing): 下载页不再因为多了 Linux 包就整页退回 GitHub

### DIFF
--- a/src/lib/__tests__/releaseAssets.test.ts
+++ b/src/lib/__tests__/releaseAssets.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import { isUsableReleasePayload, REQUIRED_DOWNLOADS } from '../releaseAssets';
+
+const BASE = 'https://github.com/lingcang728/ZeppBridge/releases/download/v2.0.0';
+const trusted = (url: string) => url.startsWith('https://github.com/lingcang728/ZeppBridge/releases/download/');
+
+const asset = (name: string) => ({ url: `${BASE}/${name}` });
+
+const windowsAndMac = () => ({
+  windowsExe: asset('ZeppBridge_2.0.0_x64-setup.exe'),
+  windowsMsi: asset('ZeppBridge_2.0.0_x64_en-US.msi'),
+  macosDmg: asset('ZeppBridge_2.0.0_aarch64.dmg'),
+});
+
+const withLinux = () => ({
+  ...windowsAndMac(),
+  linuxDeb: asset('ZeppBridge_2.0.0_amd64.deb'),
+  linuxRpm: asset('ZeppBridge_2.0.0_x86_64.rpm'),
+  linuxAppImage: asset('ZeppBridge_2.0.0_x86_64.AppImage'),
+  linuxFlatpak: asset('ZeppBridge_2.0.0_x86_64.flatpak'),
+});
+
+describe('isUsableReleasePayload', () => {
+  it('accepts the three required installers on their own', () => {
+    expect(isUsableReleasePayload(windowsAndMac(), trusted)).toBe(true);
+  });
+
+  /*
+   * 这条是本文件存在的理由。
+   *
+   * 守卫原本写的是 `assets.length !== 3`。2.0.0 加了四个 Linux 包之后，这一句
+   * 把整个下载页打进 fallback——三个 CTA 全部退化成「打开 GitHub Release」，
+   * Windows 和 macOS 的直链一起没了。页面照样渲染，控制台照样干净。
+   */
+  it('does not break when the endpoint grows new optional assets', () => {
+    expect(isUsableReleasePayload(withLinux(), trusted)).toBe(true);
+
+    // 再多加一个以后才会有的平台，也不能把它打倒。
+    const future = { ...withLinux(), windowsArm64: asset('ZeppBridge_9.9.9_arm64-setup.exe') };
+    expect(isUsableReleasePayload(future, trusted)).toBe(true);
+  });
+
+  it.each(REQUIRED_DOWNLOADS)('fails closed when %s is missing', (key) => {
+    const downloads: Record<string, { url: string } | undefined> = withLinux();
+    delete downloads[key];
+    expect(isUsableReleasePayload(downloads, trusted)).toBe(false);
+  });
+
+  /* 安全边界：这些 URL 会被直接放进 href，一条也不能指向别的域名。 */
+  it('rejects an untrusted url anywhere, including in an optional asset', () => {
+    const tamperedRequired = { ...withLinux(), macosDmg: { url: 'https://evil.test/ZeppBridge.dmg' } };
+    expect(isUsableReleasePayload(tamperedRequired, trusted)).toBe(false);
+
+    const tamperedOptional = { ...withLinux(), linuxDeb: { url: 'https://evil.test/ZeppBridge.deb' } };
+    expect(isUsableReleasePayload(tamperedOptional, trusted)).toBe(false);
+  });
+
+  it('treats a missing or empty payload as unusable', () => {
+    expect(isUsableReleasePayload(null, trusted)).toBe(false);
+    expect(isUsableReleasePayload(undefined, trusted)).toBe(false);
+    expect(isUsableReleasePayload({}, trusted)).toBe(false);
+  });
+});

--- a/src/lib/releaseAssets.ts
+++ b/src/lib/releaseAssets.ts
@@ -1,0 +1,40 @@
+/**
+ * 下载页对 `/api/release` 的校验。
+ *
+ * 抽成纯函数是因为它坏过一次，而且坏得很安静：2.0.0 给 `/api/release` 加了
+ * 四个可选的 Linux 包，而这里原本写的是 `assets.length !== 3`——一次纯粹的
+ * 新增，把整个下载页打进了 fallback，Windows 和 macOS 的直链跟着一起没了。
+ * 页面照样渲染、控制台照样干净，只是每个按钮都变成了「打开 GitHub」。
+ *
+ * 写在 `.vue` 里的时候没有任何东西能测它。放这里就能。
+ */
+
+/** 缺了任何一个就整页退回 GitHub Release 页面。 */
+export const REQUIRED_DOWNLOADS = ['windowsExe', 'windowsMsi', 'macosDmg'] as const;
+
+export interface ReleaseAssetLike {
+  url: string;
+}
+
+/**
+ * 这份 payload 能不能拿来做直链下载。
+ *
+ * 两条判据，都不看资产**个数**：
+ *   1. 三个必需安装包都在（按名字查，不按个数）；
+ *   2. 每一条 URL 都指向本仓库的 Release 下载路径。
+ *
+ * 第 2 条是安全边界：下载页会把这些 URL 直接放进 `href`，一个被改过的
+ * 响应不该能把访客送到别的域名去。它对**所有**资产生效，包括以后新增的。
+ */
+export const isUsableReleasePayload = (
+  downloads: Record<string, ReleaseAssetLike | undefined> | null | undefined,
+  isTrustedAssetUrl: (url: string) => boolean,
+): boolean => {
+  if (!downloads) return false;
+  for (const key of REQUIRED_DOWNLOADS) {
+    if (!downloads[key]?.url) return false;
+  }
+  return Object.values(downloads).every(
+    (asset) => typeof asset?.url === 'string' && isTrustedAssetUrl(asset.url),
+  );
+};

--- a/src/views/LandingPage.vue
+++ b/src/views/LandingPage.vue
@@ -4,6 +4,7 @@ import BrandMark from '../components/BrandMark.vue';
 import DesignIcon, { type DesignIconName } from '../components/DesignIcon.vue';
 import DeviceMarquee from '../components/DeviceMarquee.vue';
 import { useLandingLocale } from '../composables/useLandingLocale';
+import { isUsableReleasePayload } from '../lib/releaseAssets';
 
 const githubUrl = 'https://github.com/lingcang728/ZeppBridge';
 const releaseUrl = `${githubUrl}/releases/latest`;
@@ -348,8 +349,15 @@ const loadLatestRelease = async () => {
     const response = await fetch(releaseEndpoint, { headers: { Accept: 'application/json' } });
     if (!response.ok) throw new Error(`release endpoint returned ${response.status}`);
     const payload = await response.json() as LatestRelease;
-    const assets = Object.values(payload.downloads ?? {});
-    if (assets.length !== 3 || assets.some((asset) => !isTrustedAssetUrl(asset.url))) {
+    /*
+     * 判据在 lib/releaseAssets.ts，那里能测。
+     *
+     * 这里原来写的是 `assets.length !== 3`：2.0.0 给 /api/release 加了四个
+     * 可选的 Linux 包之后，这一句立刻把整个下载页打进 fallback——三个 CTA
+     * 全部退化成「打开 GitHub Release 页面」，Windows 和 macOS 的直链也跟着
+     * 一起没了。页面照样渲染，控制台照样干净。
+     */
+    if (!isUsableReleasePayload(payload.downloads, isTrustedAssetUrl)) {
       throw new Error('release endpoint returned an invalid asset set');
     }
     latestRelease.value = payload;


### PR DESCRIPTION
2.0.0 发布当天在真机上看下载页时发现的：**三个 CTA 全部退化成「打开 GitHub Release 页面」**，Windows 和 macOS 的直链也一起没了。

## 原因

`/api/release` 这一版新增了四个**可选**的 Linux 包，而 `LandingPage.vue` 的守卫写的是：

```js
if (assets.length !== 3 || assets.some((asset) => !isTrustedAssetUrl(asset.url))) {
  throw new Error('release endpoint returned an invalid asset set');
}
```

一个只认死个数的守卫，被一次纯粹的新增打倒了。而且它坏得很安静——页面照样渲染，控制台照样干净，只有状态那行字从「点击直接下载，无需打开 GitHub」变成了「暂时没读取到直链」。`npm test` / `vue-tsc` / `test:functions` 一个都没红。

## 改法

判据改成**按名字**查必需的三个（`windowsExe` / `windowsMsi` / `macosDmg`），个数不再参与判断。

安全性质一个没丢：
- 每一条 URL 仍然必须指向 `https://github.com/lingcang728/ZeppBridge/releases/download/`，**包括以后新增的可选资产**；
- 缺任何一个必需安装包，仍然整页 fail closed 回 GitHub。

顺带把判据从 `.vue` 搬进 `src/lib/releaseAssets.ts`：写在 SFC 里的时候没有任何东西能测它，而这正是它坏掉的原因。

## 测试

新增 7 个（`src/lib/__tests__/releaseAssets.test.ts`），其中这一条专门钉住本次回归：

```
✓ does not break when the endpoint grows new optional assets
```

它同时验了「再多加一个以后才会有的平台也不能把它打倒」。另有一条验证被篡改的 URL 出现在**可选**资产里时也要拒绝。

`npm test` 93 passed（原 86）。

## 部署

合并后需要手动跑一次 `deploy-cloudflare-pages`（那个 workflow 是 `workflow_dispatch`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
