### PR TITLE
ci: artifact actions 升到当前大版本（upload v7 / download v8）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,7 +369,10 @@ jobs:
         run: ./scripts/release/package-tools.ps1
 
       - name: Upload installers
-        uses: actions/upload-artifact@v4
+        # v4 跑在已经废弃的 Node 20 上。upload 与 download 的大版本号从 v5
+        # 起就不再同步（download 多走了一版路径修复），所以这里是 v7 / v8，
+        # 不是同一个数字写错了。
+        uses: actions/upload-artifact@v7
         with:
           name: zeppbridge-installers
           path: |
@@ -443,7 +446,7 @@ jobs:
           mv release/zeppbridge-tools-*.zip release-macos/
 
       - name: Upload macOS bundle
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: zeppbridge-macos
           path: release-macos/*
@@ -555,7 +558,7 @@ jobs:
           mv release/zeppbridge-tools-*.zip release-linux/
 
       - name: Upload Linux bundles
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: zeppbridge-linux
           path: release-linux/*
@@ -590,7 +593,7 @@ jobs:
         run: ./packaging/flatpak/build-flatpak.sh --bundle --no-install
 
       - name: Upload Flatpak bundle
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: zeppbridge-flatpak
           path: release/ZeppBridge_*.flatpak
@@ -662,25 +665,27 @@ jobs:
           fetch-depth: 0
 
       - name: Download Windows installers
-        uses: actions/download-artifact@v4
+        # download v8 起，摘要对不上默认是**报错**而不是警告（`digest-mismatch`）。
+        # 这条路径上宁可发布失败，也不该把一个下载途中损坏的安装包发出去。
+        uses: actions/download-artifact@v8
         with:
           name: zeppbridge-installers
           path: release
 
       - name: Download macOS bundle
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: zeppbridge-macos
           path: release-macos
 
       - name: Download Linux bundles
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: zeppbridge-linux
           path: release-linux
 
       - name: Download Flatpak bundle
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: zeppbridge-flatpak
           path: release-linux


### PR DESCRIPTION
TODO 里的 C3。刚发完 2.1.0，距离下次发布最远，正是在 main 上验证发布路径改动的窗口。

## 为什么不是 v5

TODO 写的是「升到 v5」，那是按当时的信息记的。现在 `upload-artifact` 最新大版本是 **v7**、`download-artifact` 是 **v8**；而且只升到 v5 也达不到目的——`upload-artifact` 要到 **v6** 才把 Node 24 变成默认运行时，v5 仍然默认跑 Node 20。

两个 action 的大版本号从 v5 起就不同步（download 多走了一版路径修复），所以 v7 / v8 不是写错了。已在 workflow 里就地注明，免得下一个人来对齐。

## 逐版核对过的 changelog

| 版本 | 变化 | 对我们的影响 |
|---|---|---|
| upload v5 | Node 24 预备支持 | 无 |
| upload v6 | Node 24 成为默认，要求 runner ≥ 2.327.1 | 无，全部用 GitHub 托管 runner |
| upload v7 | ESM 化；新增可选 `archive: false` | 无，不传就是原来的打包上传 |
| download v5 | **破坏性**：按 **id** 下载单个产物时的落盘路径修正 | 无，四处全部按 `name` 下载 |
| download v6 / v7 | Node 24 | 无 |
| download v8 | ESM 化；跳过非 zip 内容；**`digest-mismatch` 默认从警告改为报错** | 保持默认 |

最后一条是唯一真正的行为变化：发布路径上宁可整条 job 失败，也不该把一个下载途中损坏的安装包发出去。

## 验证

改的四个上传步骤和四个下载步骤都只在 push main / tag 时跑，PR 上是跳过的——这正是 TODO 里「刻意留着」的原因。合进 main 后那一轮 CI 会真正跑到 `package` / `package-macos` / `package-linux` / `package-flatpak` 四个上传步骤；四个下载步骤只有 tag 那一轮才跑，届时留意 `Publish GitHub Release` job。

本地只做了 YAML 解析校验和 changelog 核对，没有别的可跑的。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
