### PR TITLE
Fix: app can open with no visible window, and re-syncs on every launch

### DIFF
--- a/src-tauri/crates/core/src/paths.rs
+++ b/src-tauri/crates/core/src/paths.rs
@@ -183,6 +183,35 @@ pub fn webview_user_data_dir(data_dir: &Path) -> PathBuf {
     data_dir.join("webview")
 }
 
+/// 除了这次用的目录之外，本机还有哪些地方躺着一个 `zepp.db`。
+///
+/// 为什么需要它：`resolve_data_dir()` 的落点会随安装方式变。NSIS 装到
+/// `%LOCALAPPDATA%`（可写，用 `{exe_dir}/data`），MSI 装到 `Program Files`
+/// （不可写，退到 `%APPDATA%`）。同一个人先后装过两种包、或者提权跑过一次，
+/// 两边就各留一个库——而应用只会用其中一个，另一边的数据看起来「消失了」。
+///
+/// 这里**只读、不搬、不删**：`fall_back_to_user_data_dir` 已经立下了
+/// 「不自作主张换目录」的规矩，这里沿用，只把事实报出来，由人来决定。
+/// 返回空表示没有第二份，也就是绝大多数人的情况。
+pub fn other_libraries_on_this_machine(data_dir: &Path) -> Vec<PathBuf> {
+    let mut found = Vec::new();
+    let mut candidates = legacy_source_dirs();
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(parent) = exe.parent() {
+            candidates.push(parent.join("data"));
+        }
+    }
+    for candidate in candidates {
+        if candidate == data_dir || !candidate.join(SQLITE_GROUP[0]).is_file() {
+            continue;
+        }
+        if !found.contains(&candidate) {
+            found.push(candidate);
+        }
+    }
+    found
+}
+
 /// Copy-or-move leftover AppData libraries into the install-local folder.
 /// Existing destination files are never overwritten.
 pub fn relocate_legacy_data(data_dir: &Path) -> Option<String> {

--- a/src-tauri/src/diagnostics.rs
+++ b/src-tauri/src/diagnostics.rs
@@ -20,6 +20,7 @@ use std::fmt::Display;
 use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Mutex, OnceLock};
 
 /// 单个日志文件的上限。够装几十次启动的记录，又不至于让用户在发文件时犯难。
@@ -28,6 +29,8 @@ const MAX_LOG_BYTES: u64 = 2 * 1024 * 1024;
 const KEPT_LOGS: usize = 3;
 
 static LOG_FILE: OnceLock<Option<PathBuf>> = OnceLock::new();
+/// 启动横幅写过没有。见 [`init`]。
+static BANNER_WRITTEN: AtomicBool = AtomicBool::new(false);
 /// 写日志是跨线程的（启动线程、后台重放线程、命令线程都会写），而轮转要在
 /// 「判断大小」和「改名」之间保持原子。一把进程内的锁就够——跨进程的那把在
 /// `storage::write_lock`，日志不需要那么强。
@@ -66,6 +69,12 @@ pub fn init(data_dir: Option<&Path>) {
         rotate_if_needed(&path);
         Some(path)
     });
+    // Windows 上现在有两处调用 `init`：`run()` 开头（为了让 WebView2 目录那几条
+    // 日志有地方落）和 `setup()` 里。横幅只写一次，否则同一次启动会出现两条
+    // 「启动 ZeppBridge」，看日志的人会以为程序重启过。
+    if BANNER_WRITTEN.swap(true, Ordering::Relaxed) {
+        return;
+    }
     log(&format!(
         "启动 ZeppBridge {} / {} / exe={} / data_dir={}",
         env!("CARGO_PKG_VERSION"),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -74,6 +74,45 @@ fn show_main_window(app: &AppHandle) {
     let _ = window.set_always_on_top(false);
 }
 
+/// `tauri.conf.json` 里 `minWidth` / `minHeight` 的那两个数。
+///
+/// 算出来的初始尺寸不能低于它们：低于了窗口会小到点不着，而 Tauri 只在用户
+/// 拖动时才强制最小尺寸，`set_size` 传什么就是什么。
+const MIN_WINDOW_WIDTH: f64 = 520.0;
+const MIN_WINDOW_HEIGHT: f64 = 560.0;
+
+/// 主窗口的初始尺寸，按显示器工作区算。
+///
+/// 这段以前是内联在 `setup()` 里的三行算术，**没有任何下限**：
+///
+/// ```text
+/// let work_w = (work.size.width as f64 / scale) - 24.0;
+/// let width  = (work_w * 0.88).max(1280.0_f64.min(work_w));
+/// ```
+///
+/// `current_monitor()` 返回 `0x0` 的工作区不是假想的状态——远程桌面会话、
+/// 显示器热插拔、以及窗口比显示器先就绪的那一瞬都会给出它。那时
+/// `work_w = -24.0`，宽度算成 `-21.1`，`set_size` 收到一个负数。用户看到的
+/// 正是「托盘图标活着、进程活着、点 Open ZeppBridge 一点反应都没有」——
+/// 窗口在，只是没有可见像素，而重装当然也修不好。
+/// 见 2026-09-04 Reddit u/poseidon1111。
+///
+/// 返回 `None` 表示这台显示器的信息不可信，那就一个字都别改，让
+/// `tauri.conf.json` 里的 1280x800 原样生效。
+fn main_window_size(work_width: u32, work_height: u32, scale: f64) -> Option<(f64, f64)> {
+    if work_width == 0 || work_height == 0 || !scale.is_finite() || scale <= 0.0 {
+        return None;
+    }
+    let work_w = (f64::from(work_width) / scale) - 24.0;
+    let work_h = (f64::from(work_height) / scale) - 32.0;
+    if !work_w.is_finite() || !work_h.is_finite() || work_w <= 0.0 || work_h <= 0.0 {
+        return None;
+    }
+    let width = (work_w * 0.88).max(1280.0_f64.min(work_w));
+    let height = (work_h * 0.88).max(800.0_f64.min(work_h));
+    Some((width.max(MIN_WINDOW_WIDTH), height.max(MIN_WINDOW_HEIGHT)))
+}
+
 /// 托盘菜单的三条文案。原生菜单没法走前端的 i18n，只能在这里备一份。
 struct TrayLabels {
     show: &'static str,
@@ -205,11 +244,36 @@ pub fn run() {
         std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
     }
 
+    // WebView2 的用户数据目录必须在 `Builder` 之前定下来：环境变量是
+    // WebView2 初始化时读的，`setup()` 里再设已经晚了。
+    //
+    // 只有目录**真的建出来了**才设这个变量。以前这里是
+    // `let _ = std::fs::create_dir_all(...)` 之后无条件 `set_var`：受控文件夹
+    // 访问、杀软的目录保护、OneDrive 占用都会让创建失败，而变量照设不误，
+    // 于是 WebView2 拿到一个用不了的路径、初始化失败——窗口和托盘都在，
+    // 里面一片空白。指向坏路径比不指向差：不设的话 WebView2 走系统默认目录，
+    // 至少还能开。
     #[cfg(target_os = "windows")]
-    if let Ok(data_dir) = paths::resolve_data_dir() {
-        let webview_dir = paths::webview_user_data_dir(&data_dir);
-        let _ = std::fs::create_dir_all(&webview_dir);
-        std::env::set_var("WEBVIEW2_USER_DATA_FOLDER", &webview_dir);
+    {
+        let resolved = paths::resolve_data_dir();
+        // 日志要先装起来，否则下面这几条 `log` 全部落空——而它们正是
+        // 「窗口一片空白」这一类问题唯一能拿到的证据。`init` 是幂等的。
+        diagnostics::init(resolved.as_deref().ok());
+        match resolved {
+            Ok(data_dir) => {
+                let webview_dir = paths::webview_user_data_dir(&data_dir);
+                match std::fs::create_dir_all(&webview_dir) {
+                    Ok(()) => std::env::set_var("WEBVIEW2_USER_DATA_FOLDER", &webview_dir),
+                    Err(error) => diagnostics::log(&format!(
+                        "WebView2 数据目录 {} 建不出来（{error}），改用系统默认目录",
+                        webview_dir.display()
+                    )),
+                }
+            }
+            Err(error) => {
+                diagnostics::log(&format!("数据目录解析失败（{error}），稍后由启动流程报错"));
+            }
+        }
     }
     tauri::Builder::default()
         // Single-instance must be registered first so a second launch never
@@ -243,6 +307,18 @@ pub fn run() {
                     return Err(diagnostics::fatal_startup("无法使用数据文件夹", error).into());
                 }
             };
+            // 本机还有没有第二个库。有的话，用户看到的会是「我的数据不见了」，
+            // 而真相是这次解析到了另一个目录（NSIS 装在 %LOCALAPPDATA%、MSI 装在
+            // Program Files，两者的落点不同）。只记录，不搬动——见
+            // `paths::other_libraries_on_this_machine` 的注释。
+            for other in paths::other_libraries_on_this_machine(&data_dir) {
+                diagnostics::log(&format!(
+                    "注意：{} 里也有一个 zepp.db，本次用的是 {}。要固定用哪一个，请设 {}",
+                    other.display(),
+                    data_dir.display(),
+                    paths::DATA_DIR_ENV
+                ));
+            }
             let webview_dir = paths::webview_user_data_dir(&data_dir);
             if let Err(error) = std::fs::create_dir_all(&webview_dir) {
                 return Err(diagnostics::fatal_startup(
@@ -365,11 +441,20 @@ pub fn run() {
                 if let Ok(Some(monitor)) = window.current_monitor() {
                     let work = monitor.work_area();
                     let scale = monitor.scale_factor();
-                    let work_w = (work.size.width as f64 / scale) - 24.0;
-                    let work_h = (work.size.height as f64 / scale) - 32.0;
-                    let width = (work_w * 0.88).max(1280.0_f64.min(work_w));
-                    let height = (work_h * 0.88).max(800.0_f64.min(work_h));
-                    let _ = window.set_size(tauri::LogicalSize::new(width, height));
+                    match main_window_size(work.size.width, work.size.height, scale) {
+                        Some((width, height)) => {
+                            diagnostics::log(&format!(
+                                "窗口尺寸：工作区 {}x{} @{scale} → {width:.0}x{height:.0}",
+                                work.size.width, work.size.height
+                            ));
+                            let _ = window.set_size(tauri::LogicalSize::new(width, height));
+                        }
+                        // 下一个报「打不开」的人，日志里会有这一行。
+                        None => diagnostics::log(&format!(
+                            "工作区信息不可用（{}x{} @{scale}），沿用配置里的默认尺寸",
+                            work.size.width, work.size.height
+                        )),
+                    }
                 }
                 let hidden = window.clone();
                 let tray_alive = tray_present.clone();
@@ -559,5 +644,53 @@ mod locale_tests {
             "取回来的不像一个语言标记：{name:?}"
         );
         assert!(!name.contains('\0'), "结尾的 NUL 没有去掉：{name:?}");
+    }
+}
+
+#[cfg(test)]
+mod window_size_tests {
+    use super::{main_window_size, MIN_WINDOW_HEIGHT, MIN_WINDOW_WIDTH};
+
+    /// 一台正常的 1080p 显示器，尺寸落在工作区里面。
+    #[test]
+    fn a_normal_monitor_gets_a_window_that_fits_inside_it() {
+        let (width, height) = main_window_size(1920, 1040, 1.0).expect("正常显示器要给出尺寸");
+        assert!(width <= 1920.0 - 24.0, "宽度不能超出工作区：{width}");
+        assert!(height <= 1040.0 - 32.0, "高度不能超出工作区：{height}");
+        assert!(width >= MIN_WINDOW_WIDTH && height >= MIN_WINDOW_HEIGHT);
+    }
+
+    /// 这条是这次修复的全部理由。
+    ///
+    /// `current_monitor()` 给出 `0x0` 时，旧代码算出的宽度是 -21.1，
+    /// `set_size` 收下一个负数——窗口在、托盘在、点开没有任何反应。
+    #[test]
+    fn a_zero_sized_work_area_falls_back_to_the_configured_size() {
+        assert_eq!(main_window_size(0, 0, 1.0), None);
+        assert_eq!(main_window_size(1920, 0, 1.0), None);
+        assert_eq!(main_window_size(0, 1040, 1.0), None);
+    }
+
+    /// 坏掉的缩放系数同样不能变成一个负数或 NaN。
+    #[test]
+    fn a_broken_scale_factor_falls_back_to_the_configured_size() {
+        assert_eq!(main_window_size(1920, 1040, 0.0), None);
+        assert_eq!(main_window_size(1920, 1040, -1.0), None);
+        assert_eq!(main_window_size(1920, 1040, f64::NAN), None);
+    }
+
+    /// 工作区小到比边距还窄时也不许出负数。
+    #[test]
+    fn a_work_area_smaller_than_the_margins_falls_back() {
+        assert_eq!(main_window_size(20, 20, 1.0), None);
+    }
+
+    /// 小屏 / 高 DPI：算出来的值再小也不能低于 `tauri.conf.json` 的最小尺寸，
+    /// 否则窗口小到点不着，和「打不开」没有区别。
+    #[test]
+    fn a_tiny_work_area_never_goes_below_the_configured_minimum() {
+        let (width, height) = main_window_size(800, 600, 2.0).expect("这仍然是一台可用的显示器");
+        assert!(width >= MIN_WINDOW_WIDTH, "宽度低于最小值：{width}");
+        assert!(height >= MIN_WINDOW_HEIGHT, "高度低于最小值：{height}");
     }
 }

--- a/src/composables/useSyncController.ts
+++ b/src/composables/useSyncController.ts
@@ -1,6 +1,6 @@
 import { computed, readonly, ref } from 'vue';
 import { backend, isDesktop, toUserMessage } from '../lib/bridge';
-import { readAutoSyncSettings, writeAutoSyncSettings } from '../lib/autoSync';
+import { launchSyncIsDue, readAutoSyncSettings, writeAutoSyncSettings } from '../lib/autoSync';
 import type { AppStatus, LoginStatus, SyncOutcome, SyncProgress, SyncReport } from '../types';
 import { syncStreamLabel } from '../lib/syncStreams';
 import { defineMessages, intlLocale, messagesOf } from '../i18n';
@@ -496,7 +496,10 @@ const initialize = async () => {
       await refreshStatus();
     }
   }
-  if (autoSyncEnabled.value && status?.connection_state === 'connected') void runSync('incremental', undefined, { silent: true });
+  if (autoSyncEnabled.value && status?.connection_state === 'connected'
+    && launchSyncIsDue(status?.last_cloud_sync_at, autoSyncInterval.value)) {
+    void runSync('incremental', undefined, { silent: true });
+  }
 };
 
 const markDataChanged = () => {

--- a/src/lib/__tests__/autoSync.test.ts
+++ b/src/lib/__tests__/autoSync.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { launchSyncIsDue } from '../autoSync';
+
+/*
+ * 「每次打开 ZeppBridge 都在重新同步账号。」（2026-09-04 的用户反馈）
+ *
+ * 那句话描述的不是错觉：`initialize()` 的最后一行以前无条件跑一次增量同步，
+ * 而传给它的 `silent: true` 只管「已经在同步了」那一个分支，进度条和
+ * 「正在同步最近 N 天」照样铺满界面。最小化到托盘再打开没事，因为那条路
+ * 不重跑 `initialize()`——这正是它难以在本机复现的原因。
+ *
+ * 下面这组用例钉住的是新规则本身：**看的是离上次成功同步过去了多久，
+ * 不是这次是不是启动**。关掉五分钟再打开不该同步；隔了一天再打开该同步。
+ */
+describe('launchSyncIsDue', () => {
+  const now = new Date('2026-09-04T12:00:00Z').getTime();
+  const minutesAgo = (minutes: number) =>
+    new Date(now - minutes * 60_000).toISOString();
+
+  it('从没同步过时必须同步——那是首次连接后的第一趟', () => {
+    expect(launchSyncIsDue(null, 15, now)).toBe(true);
+    expect(launchSyncIsDue(undefined, 15, now)).toBe(true);
+    expect(launchSyncIsDue('', 15, now)).toBe(true);
+  });
+
+  it('刚同步完就重开，不再跑第二趟', () => {
+    expect(launchSyncIsDue(minutesAgo(0), 15, now)).toBe(false);
+    expect(launchSyncIsDue(minutesAgo(5), 15, now)).toBe(false);
+    expect(launchSyncIsDue(minutesAgo(14.9), 15, now)).toBe(false);
+  });
+
+  it('过了一个自动同步间隔就该同步了', () => {
+    expect(launchSyncIsDue(minutesAgo(15), 15, now)).toBe(true);
+    expect(launchSyncIsDue(minutesAgo(60), 15, now)).toBe(true);
+    // 隔了一天再打开——这一趟是有用的，显示出来也是对的。
+    expect(launchSyncIsDue(minutesAgo(60 * 24), 15, now)).toBe(true);
+  });
+
+  it('门槛跟着用户设的间隔走', () => {
+    // 同一个 30 分钟，在 15 分钟间隔下该同步，在 60 分钟间隔下不该。
+    expect(launchSyncIsDue(minutesAgo(30), 15, now)).toBe(true);
+    expect(launchSyncIsDue(minutesAgo(30), 60, now)).toBe(false);
+  });
+
+  it('间隔是个不认识的值时按默认的 15 分钟算，而不是永不同步', () => {
+    expect(launchSyncIsDue(minutesAgo(20), Number.NaN, now)).toBe(true);
+    expect(launchSyncIsDue(minutesAgo(20), 99999, now)).toBe(true);
+    expect(launchSyncIsDue(minutesAgo(5), 99999, now)).toBe(false);
+  });
+
+  /*
+   * 坏时间戳和时钟回跳都按「该同步」处理。宁可多跑一趟，也不要因为一个解析
+   * 不出来的值或者一次 NTP 校时，把同步永久卡在「不用跑」上——那种坏法用户
+   * 是看不见的，只会发现数据停在某一天。
+   */
+  it('坏时间戳与时钟回跳不会把同步永久卡住', () => {
+    expect(launchSyncIsDue('not a timestamp', 15, now)).toBe(true);
+    const future = new Date(now + 60 * 60_000).toISOString();
+    expect(launchSyncIsDue(future, 15, now)).toBe(true);
+  });
+});

--- a/src/lib/autoSync.ts
+++ b/src/lib/autoSync.ts
@@ -40,3 +40,39 @@ export const writeAutoSyncSettings = (settings: AutoSyncSettings): AutoSyncSetti
   }
   return normalized;
 };
+
+/**
+ * 启动时该不该立刻同步一次。
+ *
+ * `useSyncController.initialize()` 的最后一行以前是无条件的：只要自动同步开着、
+ * 账号连着，**每一次进程启动**都会跑一次增量同步，界面上跟着出现「正在同步最近
+ * 数据」和进度条。传给它的 `silent: true` 帮不上忙——那个开关只管「已经在同步了」
+ * 一个分支，`notice` 和 `sync://progress` 照写不误。
+ *
+ * 用户看到的就成了「每次打开 ZeppBridge 都在重新同步账号」，而最小化到托盘再
+ * 打开却一切正常——后者不重跑 `initialize()`。见 2026-09-04 的反馈。
+ *
+ * 判断依据是「离上次成功同步过去了多久」，不是「这次是不是启动」：关掉五分钟再
+ * 打开，云端不会有新东西，那一趟纯是噪音；隔了一天再打开就该同步，那时它有用，
+ * 显示出来也是对的。用自动同步的间隔当门槛，因为那本来就是用户对「多久算新」的
+ * 表态。
+ *
+ * @param lastCloudSyncAt 上次成功同步的时刻（RFC3339）。空表示从没同步过。
+ * @param intervalMinutes 自动同步间隔，分钟。
+ * @param now 现在（毫秒），便于测试。
+ */
+export const launchSyncIsDue = (
+  lastCloudSyncAt: string | null | undefined,
+  intervalMinutes: number,
+  now: number = Date.now(),
+): boolean => {
+  // 从没同步过：这是首次连接后的第一趟，必须跑。
+  if (!lastCloudSyncAt) return true;
+  const at = new Date(lastCloudSyncAt).getTime();
+  // 时间戳解析不出来时按「该同步」处理：宁可多跑一趟，也不要因为一个坏值把
+  // 同步永久卡死。下面时钟回跳（负数）同理。
+  if (Number.isNaN(at)) return true;
+  const elapsedMinutes = (now - at) / 60_000;
+  if (elapsedMinutes < 0) return true;
+  return elapsedMinutes >= normalizeInterval(intervalMinutes);
+};


### PR DESCRIPTION
Four independent startup issues, all reported from the field.

## 1. The window could be sized out of existence

`setup()` derived the initial window size from `current_monitor()`'s work area with no bounds check:

```rust
let work_w = (work.size.width as f64 / scale) - 24.0;
let width  = (work_w * 0.88).max(1280.0_f64.min(work_w));
```

A `0x0` work area is not hypothetical — remote desktop sessions, monitor hot-plug, and the moment before a display is ready all report it. `work_w` becomes `-24.0`, the width comes out at `-21.1`, and `set_size` accepts the negative number.

What the user sees is exactly the report we got: **the tray icon is there, the process is running, and clicking "Open ZeppBridge" does nothing.** The window exists; it just has no visible pixels. Reinstalling cannot fix it.

Extracted into `main_window_size()` with 5 unit tests. Bad input now returns `None`, leaving the `1280x800` from `tauri.conf.json` untouched, and a computed size is never below the configured `minWidth`/`minHeight`. The work area and the resulting size are written to the log, so the next report comes with the evidence attached.

## 2. A WebView2 data folder that could not be created was still exported

```rust
let _ = std::fs::create_dir_all(&webview_dir);          // failure swallowed
std::env::set_var("WEBVIEW2_USER_DATA_FOLDER", &webview_dir);  // set anyway
```

Controlled Folder Access, antivirus folder protection and OneDrive locks all make that `create_dir_all` fail. The variable was set regardless, so WebView2 got an unusable path and failed to initialise — window and tray present, nothing inside. Pointing at a broken path is worse than not pointing at all: unset, WebView2 falls back to the system default and at least opens.

The variable is now only set when the directory really exists, and the log file is initialised *before* this runs — otherwise the one record that matters here is never written.

## 3. It re-synced the account on every launch

The last line of `initialize()` was unconditional: with auto-sync on and an account connected, **every process start** ran an incremental sync, and the UI showed "Syncing the last 30 days…" plus a progress bar. The `silent: true` passed to it only covers the "a sync is already running" branch — the notice and `sync://progress` were written either way.

This also explains why it never reproduced locally by minimising to the tray and reopening: that path does not re-run `initialize()`.

The launch sync is now gated on **how long it has been since the last successful sync**, using the interval the user already chose for auto-sync. Close it for five minutes and reopen — no sync. Come back the next day — it syncs, and showing that is correct.

## 4. Two libraries on one machine now leave a log line

The NSIS build installs to `%LOCALAPPDATA%` (writable, so it uses `data/` next to the exe); the MSI installs to `Program Files` (not writable, so it falls back to `%APPDATA%`). Anyone who has installed both ends up with a library in each, while the app only uses one — and the other one looks like lost data.

`paths::other_libraries_on_this_machine()` reports the fact and names `ZEPPBRIDGE_DATA_DIR`. It does not move or delete anything, following the rule `fall_back_to_user_data_dir` already established.

## On the "CMD-like window" report

Checked every `Command::new` in the tree: `explorer`, `open`, `xdg-open`, and the portable→installed update relaunch. All of them start GUI executables, none can produce a console, and `windows_subsystem = "windows"` is set for release builds. So no process spawn explains it.

Issue 1 does: a window sized to a few negative pixels appears as a small dark rectangle for an instant and then is gone. That reads exactly like a CMD window flashing. If the flash persists after this change, `logs/zeppbridge.log` now carries the version, exe path, data dir, work area and computed size — enough to finish the diagnosis.

## Verification

- `cargo test -p zeppbridge` — 71 passed (5 new window-sizing cases)
- `cargo test -p zeppbridge-core --lib paths::` — 9 passed
- `npm run test` — 106 passed (7 new cases for the launch-sync rule)
- `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
