### PR TITLE
CLI: say where it looked, and which half is actually missing

### DIFF
--- a/docs/guides/linux.md
+++ b/docs/guides/linux.md
@@ -72,6 +72,7 @@ The AppImage needs FUSE. On systems that only ship FUSE 3, either install
 | deb / rpm | `~/.local/share/zeppbridge/data/` |
 | AppImage, unpacked tarball | `data/` next to the executable |
 | Anywhere, when set | `$ZEPPBRIDGE_DATA_DIR` |
+| Built from source | the repository `data/` folder, **not** next to the binary |
 
 The split is deliberate. A package manager owns `/usr/bin` and a Flatpak's
 `/app/bin` is read-only, so for those two the data cannot live next to the
@@ -80,6 +81,15 @@ really is yours, so it keeps the same install-local layout Windows uses. Setting
 `ZEPPBRIDGE_DATA_DIR` to an absolute path overrides all of it; a relative path
 is rejected rather than resolved against whatever the working directory happened
 to be.
+
+If you built from source and are running `src-tauri/target/release/zeppbridge-cli`,
+the data directory is **not** the folder the binary sits in. ZeppBridge treats any
+`target/debug`, `target/release` or cargo target cache as a build directory and uses
+the repository `data/` folder instead, so that `cargo run` never drops a multi-gigabyte
+library into a build cache you are about to delete. Put `zepp.db` and `auth.json` in
+`<repo>/data/`, or point `ZEPPBRIDGE_DATA_DIR` wherever you want them. Every
+"no local database" and "no account connected" message prints the directory it actually
+looked in, so you never have to guess which rule applied.
 
 `zeppbridge-cli` and `zeppbridge-mcp` resolve the same directory by the same
 rules, so they read the database the app writes without being configured.

--- a/src-tauri/crates/cli/src/main.rs
+++ b/src-tauri/crates/cli/src/main.rs
@@ -308,13 +308,83 @@ fn data_dir() -> Result<std::path::PathBuf, String> {
         .map_err(|error| format!("Could not resolve the data directory: {error}"))
 }
 
+/// 「在哪儿找的」这句话，附在每一条「找不到」后面。
+///
+/// issue #40 的两个小时全花在这上面：那位用户在
+/// `~/ZeppBridge/src-tauri/target/release/` 下跑 CLI，而
+/// `paths::is_build_artifact_dir()` 认出 `target/release` 是构建产物目录，
+/// 把数据目录重定向到了**仓库根**的 `~/ZeppBridge/data/`。那条规则是对的
+/// （否则 `cargo run` 会往构建缓存里丢一个上 GB 的库），但程序自己一个字
+/// 都没说——他把 data 文件夹放在了 exe 旁边，看到的却是「没有本地数据库」，
+/// 无从知道该往哪儿放。最后是维护者手动告诉他的。
+///
+/// 所以每一条「找不到」都要带上解析出来的路径；是构建目录时还要说明
+/// 为什么它和 exe 不在一起。
+/// 「没有连接账号」到底缺了什么。
+///
+/// 连接一个账号要两样东西：`auth.json`（用户 id 和区域），和凭据存储里的
+/// 令牌。以前无论缺哪一样，这里都印同一句「请设 ZEPPBRIDGE_CREDENTIAL_STORE
+/// =env 并提供 ZEPPBRIDGE_APP_TOKEN」——而 issue #40 那位用户**两个都设了**，
+/// 缺的是 `auth.json`。程序把他已经做过的那件事又叫他做了一遍，来回四轮。
+///
+/// 现在先看 `auth.json` 在不在，再决定说哪一句。
+fn not_connected_message(dir: &std::path::Path) -> String {
+    let auth_file = dir.join("auth.json");
+    if !auth_file.is_file() {
+        return format!(
+            "No Zepp account is connected: {} does not exist. It holds the account id \
+             and region, and it is not created by the command line -- sign in from the \
+             desktop app, or copy auth.json here from a machine that already has one. \
+             Note that the token is NOT in that file: it lives in the platform \
+             credential store and does not copy across machines, so supply it with \
+             ZEPPBRIDGE_CREDENTIAL_STORE=env and ZEPPBRIDGE_APP_TOKEN. {}",
+            auth_file.display(),
+            where_it_looked(dir)
+        );
+    }
+    format!(
+        "No Zepp account is connected. The command line does not sign in: sign in from \
+         the desktop app, or set ZEPPBRIDGE_CREDENTIAL_STORE=env and supply \
+         ZEPPBRIDGE_APP_TOKEN. Moving a library between machines: see \
+         docs/guides/linux.md. {}",
+        where_it_looked(dir)
+    )
+}
+
+fn where_it_looked(dir: &std::path::Path) -> String {
+    let exe_dir = std::env::current_exe()
+        .ok()
+        .and_then(|exe| exe.parent().map(std::path::Path::to_path_buf));
+    where_it_looked_from(dir, exe_dir.as_deref())
+}
+
+/// 同上，但 exe 的位置由调用方给——`current_exe()` 在测试里指向测试二进制，
+/// 而这个分支的全部意义就是「exe 在构建目录里」，那种情况没法靠跑测试凑出来。
+fn where_it_looked_from(dir: &std::path::Path, exe_dir: Option<&std::path::Path>) -> String {
+    let mut text = format!("Looked in: {}", dir.display());
+    if exe_dir.is_some_and(paths::is_build_artifact_dir) {
+        text.push_str(
+            ". That is not next to the executable because this binary sits in a build \
+             directory (target/debug, target/release or a cargo target cache), and \
+             ZeppBridge keeps data out of build directories -- it uses the repository \
+             data/ folder instead",
+        );
+    }
+    text.push_str(&format!(". Override it with {}", paths::DATA_DIR_ENV));
+    text
+}
+
 fn open_read_only() -> Result<Database, (u8, String)> {
     let dir = data_dir().map_err(|message| (EXIT_FAILED, message))?;
     let db_path = dir.join("zepp.db");
     if !db_path.exists() {
         return Err((
             EXIT_NOT_CONFIGURED,
-            "No local database yet. Connect an account in the ZeppBridge desktop app and sync once first.".into(),
+            format!(
+                "No local database yet. Connect an account in the ZeppBridge desktop app \
+                 and sync once first, or copy an existing zepp.db here. {}",
+                where_it_looked(&dir)
+            ),
         ));
     }
     // 只读连接：CLI 的查询路径不拿写锁，也就不会在一次长同步期间被挡住。
@@ -481,7 +551,11 @@ fn open_writable() -> Result<(std::path::PathBuf, Database), (u8, String)> {
     if !db_path.exists() {
         return Err((
             EXIT_NOT_CONFIGURED,
-            "No local database yet. Connect an account in the ZeppBridge desktop app and sync once first.".into(),
+            format!(
+                "No local database yet. Connect an account in the ZeppBridge desktop app \
+                 and sync once first, or copy an existing zepp.db here. {}",
+                where_it_looked(&dir)
+            ),
         ));
     }
     let db = Database::open_migrated(&db_path).map_err(|error| {
@@ -763,10 +837,7 @@ fn cmd_sync(args: &[String]) -> u8 {
                 json_mode,
                 EXIT_NOT_CONFIGURED,
                 "not_configured",
-                "No Zepp account is connected. The command line does not sign in: \
-                 sign in from the desktop app, or set ZEPPBRIDGE_CREDENTIAL_STORE=env \
-                 and supply ZEPPBRIDGE_APP_TOKEN. Moving a library between machines: \
-                 see docs/guides/linux.md",
+                &not_connected_message(&dir),
             )
         }
         Err(error) => {
@@ -1255,5 +1326,75 @@ mod tests {
         }
         // 隐私边界要出现在 help 里，用户不该为了知道它去读源码。
         assert!(HELP.contains("Listens on no port"));
+    }
+    /// issue #40 的整整两个小时，就卡在这一句上。
+    ///
+    /// 那位用户在 `~/ZeppBridge/src-tauri/target/release/` 下跑 CLI，把 data
+    /// 文件夹放在了 exe 旁边，而程序去仓库根的 `data/` 找——两边都没说话，他
+    /// 只看到「没有本地数据库」。这里钉的就是「报错必须说出它去哪儿找了」。
+    #[test]
+    fn a_not_found_message_always_names_the_directory_it_looked_in() {
+        let dir = std::path::Path::new("/home/x/ZeppBridge/data");
+        let text = where_it_looked_from(dir, None);
+        assert!(text.contains("/home/x/ZeppBridge/data"), "{text}");
+        // 用户唯一能拿来固定落点的东西，也要出现。
+        assert!(text.contains("ZEPPBRIDGE_DATA_DIR"), "{text}");
+    }
+
+    /// 从构建目录里跑的时候，还要说明数据为什么不在 exe 旁边。
+    #[test]
+    fn running_from_a_build_directory_explains_why_data_is_elsewhere() {
+        let dir = std::path::Path::new("/home/x/ZeppBridge/data");
+        let exe_dir = std::path::Path::new("/home/x/ZeppBridge/src-tauri/target/release");
+        let text = where_it_looked_from(dir, Some(exe_dir));
+        assert!(text.contains("build"), "要点明这是构建目录：{text}");
+        assert!(text.contains("data/"), "要指向仓库的 data/ 目录：{text}");
+
+        // 装好的版本不该看到这段解释——它只会让人困惑。
+        let installed = std::path::Path::new("/usr/bin");
+        assert!(!where_it_looked_from(dir, Some(installed)).contains("build directory"));
+    }
+
+    /// 缺 `auth.json` 和缺令牌是两件事，不能给同一句话。
+    ///
+    /// 以前无论缺哪一样都印「请设 ZEPPBRIDGE_CREDENTIAL_STORE=env 并提供
+    /// ZEPPBRIDGE_APP_TOKEN」——而 issue #40 那位用户两个都设了，缺的是
+    /// `auth.json`。程序把他刚做过的事又叫他做一遍，来回四轮。
+    #[test]
+    fn a_missing_auth_file_is_reported_as_such_not_as_a_missing_token() {
+        let dir = std::env::temp_dir().join("zeppbridge-cli-not-connected-test");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let missing = not_connected_message(&dir);
+        assert!(
+            missing.contains("auth.json"),
+            "要点名缺的是哪个文件：{missing}"
+        );
+        assert!(
+            missing.contains("does not exist"),
+            "要说清它不存在，而不是叫人再设一遍环境变量：{missing}"
+        );
+        // 令牌那一半仍然要讲：库能跨机器拷，令牌不能——这是最容易踩的坑。
+        assert!(missing.contains("ZEPPBRIDGE_APP_TOKEN"), "{missing}");
+
+        // auth.json 在了，缺的就是令牌，这时才印原来那句。
+        std::fs::write(dir.join("auth.json"), "{}").unwrap();
+        let token_missing = not_connected_message(&dir);
+        assert!(
+            !token_missing.contains("does not exist"),
+            "文件在的时候不该再说它不存在：{token_missing}"
+        );
+        assert!(
+            token_missing.contains("ZEPPBRIDGE_CREDENTIAL_STORE"),
+            "{token_missing}"
+        );
+        // 两句都要带上目录。
+        assert!(
+            token_missing.contains(&dir.display().to_string()),
+            "{token_missing}"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }


### PR DESCRIPTION
Closes the loop on [#40](https://github.com/lingcang728/ZeppBridge/issues/40). That user spent two hours and four round-trips, and every one of them was caused by the CLI not saying something it already knew.

## The messages never named the data directory

He was running `~/ZeppBridge/src-tauri/target/release/zeppbridge-cli` with his copied data folder next to the binary. `paths::is_build_artifact_dir()` recognises `target/release` as a build directory and redirects the data folder to the repository root, `~/ZeppBridge/data/`.

That rule is correct — it stops `cargo run` from dropping a multi-gigabyte library into a build cache someone is about to `rm -rf`. But the CLI held the resolved path in a local variable and printed "No local database yet" without it, so there was no way to discover the rule except by asking. It ended up being explained by hand in the issue thread.

Every "not found" message now carries the directory it actually looked in, and names `ZEPPBRIDGE_DATA_DIR`. When the binary is running from a build directory, it also explains why the data is not beside it.

## "No account connected" told him to do the thing he had already done

Connecting an account needs two separate things: `auth.json` (account id and region) and a token in the credential store. Whichever was missing, the message was the same — *set `ZEPPBRIDGE_CREDENTIAL_STORE=env` and supply `ZEPPBRIDGE_APP_TOKEN`*. He had set both. What was missing was `auth.json`.

It now checks which one is absent first. When `auth.json` is missing it says so and names the file, while still explaining the part that actually catches people out: **a library copies between machines, a token does not** — the token lives in the platform credential store and has to be supplied separately.

## Before / after

```
No local database yet. Connect an account in the ZeppBridge desktop app and sync once first.
```

```
No local database yet. Connect an account in the ZeppBridge desktop app and sync once
first, or copy an existing zepp.db here. Looked in: /home/x/ZeppBridge/data. That is not
next to the executable because this binary sits in a build directory (target/debug,
target/release or a cargo target cache), and ZeppBridge keeps data out of build
directories -- it uses the repository data/ folder instead. Override it with
ZEPPBRIDGE_DATA_DIR
```

## Also

`docs/guides/linux.md` gains the source-build row in the "where things go" table — it was the one layout the table did not cover, and it is the one a source build hits.

Three new tests. `where_it_looked` was split into a version taking the executable directory as a parameter so it can be tested at all: `current_exe()` points at the test binary under `cargo test`, and "the executable is in a build directory" is precisely the branch that matters.

## Verification

- `cargo test --workspace` — 328 passed (3 new)
- `cargo fmt --check`, `cargo clippy -D warnings` — clean
- `npm run build / test / test:functions / i18n:check / docs:check / version:check / budget:check` — all pass
- Reproduced the original situation against an empty data directory and confirmed both messages now name the path

## Still open from that thread

Two things this PR does **not** fix, recorded so they are not lost:

1. **Chinese error text still reaches English users.** He pasted two: `无法读取系统密钥环…` and `本机数据库还是 v19…`. 2.1.2 translated the CLI's own strings, but anything raised inside `zeppbridge-core` still comes through in Chinese. The specifics live in the error payloads rather than in the error codes, so this needs the messages themselves reworked, not a lookup table.
2. **The local REST API serves only `/workouts/{id}/series`.** He wanted Home Assistant and MQTT, found nothing usable, and wrote his own Python bridge. There is no "latest weight / steps / sleep / resting heart rate" endpoint — that is a real gap, not something he overlooked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
