### PR TITLE
Watch-recorded laps in .fit, and no more Chinese on the headless path

### DIFF
--- a/src-tauri/crates/cli/src/main.rs
+++ b/src-tauri/crates/cli/src/main.rs
@@ -26,6 +26,7 @@ use zeppbridge_core::contract;
 use zeppbridge_core::export_fit;
 use zeppbridge_core::export_formats;
 use zeppbridge_core::fetcher::DataFetcher;
+use zeppbridge_core::models::error::HeadlessProblem;
 use zeppbridge_core::models::{error::ZeppBridgeError, ExportDetail, ExportScope, ExportSelection};
 use zeppbridge_core::paths;
 use zeppbridge_core::storage::write_lock::{self, WriteLockError, WritePurpose};
@@ -66,7 +67,7 @@ const EXIT_FAILED: u8 = 1;
 /// 中文提示。`--json` 的字段名和退出码是契约，一个字都没动。
 ///
 /// **边界在哪：** 这个文件里的每一句人读文案都是英文了。从 `zeppbridge-core`
-/// 冒上来的错误（`error.user_message()`）**还是中文**——那些字符串散在 core 的
+/// 冒上来的错误（`user_text(&error)`）**还是中文**——那些字符串散在 core 的
 /// 七百多处，桌面端靠错误码查本地文案、根本不显示它们（`i18n/backendText.ts`
 /// 在英文界面下会把带中文的后端原文整句换掉）。把 core 翻过来是另一件事，
 /// 不能顺手做一半：翻一半的结果是中英文混在同一条错误里，比全中文更难读。
@@ -285,7 +286,28 @@ fn exit_code_for(error: &ZeppBridgeError) -> (u8, &'static str) {
         ZeppBridgeError::Busy(_) => (EXIT_BUSY, "busy"),
         ZeppBridgeError::DatabaseError(_) => (EXIT_DATABASE, "database"),
         ZeppBridgeError::ConfigError(_) | ZeppBridgeError::InvalidHost(_) => (EXIT_USAGE, "usage"),
+        // 库要先升级和「拿不到令牌」是两码事：前者重试没用、要先跑一次
+        // reprocess（调度脚本按这个码决定别再试了），后者要人把凭据给进来。
+        ZeppBridgeError::Headless(HeadlessProblem::SchemaUpgradeRequired { .. }) => {
+            (EXIT_SCHEMA, "schema")
+        }
+        ZeppBridgeError::Headless(_) => (EXIT_NOT_CONFIGURED, "auth"),
         _ => (EXIT_FAILED, "failed"),
+    }
+}
+
+/// 这条错误给命令行用户看的那句话。
+///
+/// `user_text(&error)` 是中文——桌面端按错误码取本地化文案，所以那边一直
+/// 没问题；命令行没有 i18n 层，直接印它就是给英文用户一句中文。issue #40 那位
+/// Linux 用户正是这么收到「无法读取系统密钥环…」和「本机数据库还是 v19…」的。
+///
+/// 所以在这里做一次语言边界：认得的错误出英文，认不得的仍然回落到原文——
+/// 看不懂的中文也好过一句空白，而回落的范围会随着核心那边逐条挪走而缩小。
+fn user_text(error: &ZeppBridgeError) -> String {
+    match error {
+        ZeppBridgeError::Headless(problem) => problem.english(),
+        other => user_text(other),
     }
 }
 
@@ -395,7 +417,7 @@ fn open_read_only() -> Result<Database, (u8, String)> {
         ZeppBridgeError::ConfigError(message) => (EXIT_SCHEMA, message),
         other => {
             let (code, _) = exit_code_for(&other);
-            (code, other.user_message())
+            (code, user_text(&other))
         }
     })
 }
@@ -523,7 +545,7 @@ fn run_replay(
 
 fn replay_failure(error: &ZeppBridgeError) -> (u8, &'static str, String) {
     let (code, kind) = exit_code_for(error);
-    (code, kind, error.user_message())
+    (code, kind, user_text(error))
 }
 
 /// 只读地问一句「这个库欠不欠重放」，欠就给一句提示。
@@ -561,7 +583,7 @@ fn open_writable() -> Result<(std::path::PathBuf, Database), (u8, String)> {
     }
     let db = Database::open_migrated(&db_path).map_err(|error| {
         let (code, _) = exit_code_for(&error);
-        (code, error.user_message())
+        (code, user_text(&error))
     })?;
     Ok((dir, db))
 }
@@ -587,7 +609,7 @@ fn cmd_reprocess(args: &[String]) -> u8 {
         Ok(plan) => plan,
         Err(error) => {
             let (code, kind) = exit_code_for(&error);
-            return fail(json_mode, code, kind, &error.user_message());
+            return fail(json_mode, code, kind, &user_text(&error));
         }
     };
 
@@ -621,7 +643,7 @@ fn cmd_reprocess(args: &[String]) -> u8 {
             Ok(count) => count,
             Err(error) => {
                 let (code, kind) = exit_code_for(&error);
-                return fail(json_mode, code, kind, &error.user_message());
+                return fail(json_mode, code, kind, &user_text(&error));
             }
         };
         forced
@@ -700,7 +722,7 @@ fn cmd_status(args: &[String]) -> u8 {
         Ok(health) => health,
         Err(error) => {
             let (code, kind) = exit_code_for(&error);
-            return fail(json_mode, code, kind, &error.user_message());
+            return fail(json_mode, code, kind, &user_text(&error));
         }
     };
     // 只读的一问：这个库欠不欠一次重放。status 说出来，但绝不代跑——
@@ -843,7 +865,7 @@ fn cmd_sync(args: &[String]) -> u8 {
         }
         Err(error) => {
             let (code, kind) = exit_code_for(&error);
-            return fail(json_mode, code, kind, &error.user_message());
+            return fail(json_mode, code, kind, &user_text(&error));
         }
     };
 
@@ -852,14 +874,14 @@ fn cmd_sync(args: &[String]) -> u8 {
         Ok(connector) => connector,
         Err(error) => {
             let (code, kind) = exit_code_for(&error);
-            return fail(json_mode, code, kind, &error.user_message());
+            return fail(json_mode, code, kind, &user_text(&error));
         }
     };
     let db = match Database::open_migrated(&dir.join("zepp.db")) {
         Ok(db) => db,
         Err(error) => {
             let (code, kind) = exit_code_for(&error);
-            return fail(json_mode, code, kind, &error.user_message());
+            return fail(json_mode, code, kind, &user_text(&error));
         }
     };
 
@@ -893,7 +915,7 @@ fn cmd_sync(args: &[String]) -> u8 {
             Err(error) => {
                 eprintln!(
                     "Could not read the parser revision; skipping the replay: {}",
-                    error.user_message()
+                    user_text(&error)
                 );
                 None
             }
@@ -958,7 +980,7 @@ fn cmd_sync(args: &[String]) -> u8 {
             // 写锁冲突不是失败：桌面应用正开着同步，调度脚本稍后重试即可。
             // 靠类型判断，不靠匹配错误文案——文案是会改的。
             let (code, kind) = exit_code_for(&error);
-            fail(json_mode, code, kind, &error.user_message())
+            fail(json_mode, code, kind, &user_text(&error))
         }
     }
 }
@@ -1078,7 +1100,7 @@ fn cmd_export(args: &[String]) -> u8 {
         Ok(value) => value,
         Err(error) => {
             let (code, kind) = exit_code_for(&error);
-            return fail(json_mode, code, kind, &error.user_message());
+            return fail(json_mode, code, kind, &user_text(&error));
         }
     };
 
@@ -1409,5 +1431,60 @@ mod tests {
         );
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+    /// 命令行印给人看的那句话必须是英文。
+    ///
+    /// issue #40 那位 Linux 用户在一个英文命令行上收到了两句中文：
+    /// 「无法读取系统密钥环…」和「本机数据库还是 v19…」。2.1.2 把命令行**自己**
+    /// 的文案换成了英文，但从核心冒上来的 `user_message()` 还是中文。
+    #[test]
+    fn headless_failures_are_reported_in_english() {
+        use zeppbridge_core::models::error::HeadlessProblem;
+
+        let cases = [
+            HeadlessProblem::NoCredentialStore {
+                detail: "could not read the keyring".into(),
+            },
+            HeadlessProblem::SchemaUpgradeRequired {
+                found: 19,
+                required: 21,
+            },
+            HeadlessProblem::TokenNotInStore,
+        ];
+        for problem in cases {
+            let error = ZeppBridgeError::Headless(problem);
+            let text = user_text(&error);
+            assert!(
+                !text
+                    .chars()
+                    .any(|character| ('\u{4e00}'..='\u{9fff}').contains(&character)),
+                "命令行不该出现中文：{text}"
+            );
+            // 中文原文仍然留着，桌面端的中文界面要用它。
+            assert!(error
+                .user_message()
+                .chars()
+                .any(|character| ('\u{4e00}'..='\u{9fff}').contains(&character)));
+        }
+    }
+
+    /// 「库要先升级」和「拿不到令牌」给调度脚本的应对完全不同，退出码必须分开。
+    ///
+    /// 前者重试多少次都没用，得先跑一次 reprocess；后者要人把凭据交进来。
+    #[test]
+    fn a_schema_upgrade_and_a_missing_token_do_not_share_an_exit_code() {
+        use zeppbridge_core::models::error::HeadlessProblem;
+
+        let (schema, _) = exit_code_for(&ZeppBridgeError::Headless(
+            HeadlessProblem::SchemaUpgradeRequired {
+                found: 19,
+                required: 21,
+            },
+        ));
+        let (token, _) =
+            exit_code_for(&ZeppBridgeError::Headless(HeadlessProblem::TokenNotInStore));
+        assert_eq!(schema, EXIT_SCHEMA);
+        assert_eq!(token, EXIT_NOT_CONFIGURED);
+        assert_ne!(schema, token);
     }
 }

--- a/src-tauri/crates/core/src/auth/mod.rs
+++ b/src-tauri/crates/core/src/auth/mod.rs
@@ -1,5 +1,6 @@
 pub mod har;
 
+use crate::models::error::HeadlessProblem;
 use crate::models::{error::Result, AuthInfo, ZeppBridgeError};
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
@@ -202,12 +203,12 @@ impl CredentialBackend for SecretServiceCredentialBackend {
 fn describe_secret_service_error(action: &str, error: &keyring::Error) -> String {
     let base = describe_keyring_error(action, error);
     match error {
-        keyring::Error::NoStorageAccess(_) | keyring::Error::PlatformFailure(_) => format!(
-            "{base}。这台机器上可能没有运行 Secret Service（GNOME Keyring / KWallet）——\
-             无头服务器和容器通常没有。改用 {CREDENTIAL_STORE_ENV}=file（令牌以 0600 \
-             写在数据目录的 {CREDENTIAL_FILE} 里），或 {CREDENTIAL_STORE_ENV}=env \
-             配合 {APP_TOKEN_ENV}"
-        ),
+        // 走 `HeadlessProblem`，这样它有自己的错误码。命令行没有 i18n 层，
+        // 只能按码取英文——issue #40 那位 Linux 用户就是在英文命令行上收到了
+        // 这一句的中文原文。
+        keyring::Error::NoStorageAccess(_) | keyring::Error::PlatformFailure(_) => {
+            HeadlessProblem::NoCredentialStore { detail: base }.to_string()
+        }
         _ => base,
     }
 }
@@ -581,18 +582,13 @@ impl AuthManager {
                     // 这句话最常见的出处不是「凭据坏了」，而是**有人把另一台
                     // 机器的 data 文件夹整个拷了过来**（issue #40）：库和
                     // auth.json 都在，令牌却从来不在文件里——它在那台机器的
-                    // 凭据管理器 / 钥匙串 / Secret Service 里。所以这里不能只
-                    // 说「请重新配对」，得说清楚往哪配。两个环境变量名是 ASCII，
-                    // 即使这句中文原文原样落到英文用户的命令行里，能动手的那
-                    // 部分他也读得懂。
+                    // 凭据管理器 / 钥匙串 / Secret Service 里。所以不能只说
+                    // 「请重新配对」，得说清楚往哪配。
                     //
-                    // 长度受 `sanitize_user_text` 的 140 字上限约束，别加地址：
-                    // URL 会被替换成「[已隐藏地址]」。
-                    return Err(ZeppBridgeError::AuthError(
-                        "认证元数据在，但凭据管理器里没有这个账号的令牌。库能跨机器拷，令牌不能。\
-                         请重新登录，或设 ZEPPBRIDGE_CREDENTIAL_STORE=file / =env 后重试"
-                            .to_string(),
-                    ));
+                    // 用 `HeadlessProblem` 而不是 `AuthError`，是为了让它有自己
+                    // 的错误码：命令行没有 i18n 层，只有按码才出得了英文，而
+                    // 撞上这一条的人多半正在一台无头 Linux 上。
+                    return Err(ZeppBridgeError::Headless(HeadlessProblem::TokenNotInStore));
                 }
             }
         };

--- a/src-tauri/crates/core/src/decoder/workout_detail.rs
+++ b/src-tauri/crates/core/src/decoder/workout_detail.rs
@@ -111,6 +111,29 @@ pub struct WorkoutSplit {
     pub partial: bool,
 }
 
+/// One lap the watch itself recorded.
+///
+/// Not a [`WorkoutSplit`]. A split is our own cut at every kilometre; a lap is
+/// what the watch marked at the time — the lap button, an auto-lap by distance,
+/// or the intervals of a structured session. A 5820 m run can carry five
+/// kilometre splits *and* fourteen 415 m laps, and they mean different things.
+///
+/// Read from the `lap` field of the workout detail, which is populated on 32 of
+/// the 336 stored details in a real library. A .fit comparison on GitHub asked
+/// for exactly this: "I use the lap button often, if you could add lap data to
+/// your .fit file that would be my first choice."
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WorkoutLap {
+    /// 1-based lap number.
+    pub index: i32,
+    pub start_time: DateTime<Utc>,
+    pub end_time: DateTime<Utc>,
+    pub distance_m: f64,
+    pub duration_seconds: i64,
+    pub avg_hr: Option<i32>,
+    pub max_hr: Option<i32>,
+}
+
 /// Altitude has to move by at least this much before it counts as climbing.
 /// Barometric drift of a few centimetres per second would otherwise accumulate
 /// into hundreds of metres of imaginary ascent over an hour.
@@ -193,6 +216,125 @@ impl SplitBuilder {
         }
     }
 }
+
+/// Laps from the `lap` field of the workout detail.
+///
+/// Row layout, confirmed against **all 32** workouts in a real library that
+/// carry this field — rows come 60, 62 or 66 columns wide and the first six are
+/// the same in every one:
+///
+/// ```text
+/// 0,300,570,s00000000000,135,301,...
+/// │ │   │   │             │   └ elapsed seconds at the end of this lap
+/// │ │   │   │             └ average heart rate
+/// │ │   │   └ geohash placeholder, always zeroed in these payloads
+/// │ │   └ distance in metres
+/// │ └ duration in seconds
+/// └ 0-based lap number
+/// ```
+///
+/// The check is not the column widths — those vary, and on `kilo_pace` the same
+/// width was seen with the columns in different orders. It is that the numbers
+/// have to agree with the workout: sequential indices, a non-decreasing elapsed
+/// column, and heart rates in a range a heart can occupy. The caller adds the
+/// two strongest checks, which need the summary: the lap distances must sum to
+/// the workout distance and the last elapsed value must match its duration.
+/// On the 32 real workouts all five hold every time.
+///
+/// Column `[1]` is **moving** time and can be shorter than the gap between two
+/// elapsed values when the watch was paused, so lap boundaries are placed from
+/// the elapsed column and `[1]` is not used for timing.
+fn parse_laps(value: Option<&Value>, start: DateTime<Utc>) -> Vec<WorkoutLap> {
+    let Some(text) = value.and_then(Value::as_str).map(str::trim) else {
+        return Vec::new();
+    };
+    if text.is_empty() {
+        return Vec::new();
+    }
+    let mut laps = Vec::new();
+    let mut previous_elapsed = 0i64;
+    for (position, row) in text.split(';').filter(|row| !row.is_empty()).enumerate() {
+        let columns: Vec<&str> = row.split(',').collect();
+        if columns.len() < 6 {
+            return Vec::new();
+        }
+        let (Ok(index), Ok(distance_m), Ok(heart_rate), Ok(elapsed)) = (
+            columns[0].trim().parse::<i64>(),
+            columns[2].trim().parse::<f64>(),
+            columns[4].trim().parse::<i64>(),
+            columns[5].trim().parse::<i64>(),
+        ) else {
+            return Vec::new();
+        };
+        if index != position as i64
+            || !distance_m.is_finite()
+            || distance_m < 0.0
+            || elapsed < previous_elapsed
+            || elapsed > MAX_ACTIVITY_SECONDS
+            || !(0..=250).contains(&heart_rate)
+        {
+            return Vec::new();
+        }
+        let (Some(lap_start), Some(lap_end)) = (
+            start.checked_add_signed(chrono::Duration::seconds(previous_elapsed)),
+            start.checked_add_signed(chrono::Duration::seconds(elapsed)),
+        ) else {
+            return Vec::new();
+        };
+        laps.push(WorkoutLap {
+            index: position as i32 + 1,
+            start_time: lap_start,
+            end_time: lap_end,
+            distance_m,
+            duration_seconds: elapsed - previous_elapsed,
+            // 0 从手表来的时候是「这一圈没测到心率」，不是「心率为 0」。
+            avg_hr: (heart_rate > 0).then_some(heart_rate as i32),
+            max_hr: None,
+        });
+        previous_elapsed = elapsed;
+    }
+    laps
+}
+
+/// Do the laps agree with the workout they belong to?
+///
+/// The two checks that need the summary, and the two that carry the most weight:
+/// lap distances have to add up to the workout distance, and the last lap has to
+/// end when the workout ended. A column read as the wrong field passes neither.
+/// Either summary value being absent skips its own check rather than failing —
+/// an indoor workout has no distance, and that is not evidence against the laps.
+fn laps_agree_with_summary(
+    laps: &[WorkoutLap],
+    summary_distance_m: Option<f64>,
+    duration_seconds: i64,
+) -> bool {
+    if laps.is_empty() {
+        return false;
+    }
+    if let Some(distance) = summary_distance_m.filter(|value| value.is_finite() && *value > 0.0) {
+        let total: f64 = laps.iter().map(|lap| lap.distance_m).sum();
+        if (total - distance).abs() / distance > LAP_SUMMARY_TOLERANCE {
+            return false;
+        }
+    }
+    if duration_seconds > 0 {
+        let last = laps
+            .last()
+            .map(|lap| (lap.end_time - laps[0].start_time).num_seconds())
+            .unwrap_or_default();
+        let drift = (last - duration_seconds).abs() as f64 / duration_seconds as f64;
+        if drift > LAP_SUMMARY_TOLERANCE {
+            return false;
+        }
+    }
+    true
+}
+
+/// 圈的总距离 / 总时长和汇总之间允许差多少。
+///
+/// 5% 不是随手取的：真实的 32 条里最大的一条差 2%（手表在停表和记圈之间
+/// 有几秒的差），而一次「把列读错了」的偏差是成倍的，不是几个百分点。
+const LAP_SUMMARY_TOLERANCE: f64 = 0.05;
 
 /// Kilometre boundaries from the server's own `kilo_pace` series.
 ///
@@ -378,6 +520,8 @@ pub struct DecodedWorkout {
     pub samples: Vec<WorkoutSample>,
     pub pauses: Vec<PauseInterval>,
     pub splits: Vec<WorkoutSplit>,
+    /// 手表自己记的圈。和 `splits` 并存，不互相替代——见 [`WorkoutLap`]。
+    pub laps: Vec<WorkoutLap>,
 }
 
 /// 解码一条运动明细。
@@ -607,6 +751,21 @@ pub fn decode_workout_detail(
         }
     }
 
+    // 手表自己记的圈。解出来之后还要和汇总对一遍账：距离加起来对不上、
+    // 或者最后一圈不在运动结束的时刻，就说明列读错了，整份丢掉。
+    let laps = {
+        let candidate = parse_laps(data.get("lap"), start_time);
+        if laps_agree_with_summary(
+            &candidate,
+            summary_distance_m,
+            (end_time - start_time).num_seconds(),
+        ) {
+            candidate
+        } else {
+            Vec::new()
+        }
+    };
+
     Ok(DecodedWorkout {
         track_id,
         source,
@@ -616,6 +775,7 @@ pub fn decode_workout_detail(
         samples,
         pauses,
         splits,
+        laps,
     })
 }
 
@@ -1241,5 +1401,125 @@ mod tests {
         assert_eq!(decoded.splits.len(), 1, "只有那一个整公里");
         assert!(!decoded.splits[0].partial);
         assert_eq!(decoded.splits[0].distance_m, 1000.0);
+    }
+    /// 手表自己记的圈，从 `lap` 字段来。
+    ///
+    /// 这个字段一直在留存的报文里（本机 336 条明细中 32 条带它），从来没被解过。
+    /// GitHub 上那份 .fit 对拍报告里点名要的就是它：「我经常按圈键，如果你的
+    /// .fit 里能带上圈数据，那会是我的首选。」
+    #[test]
+    fn watch_recorded_laps_are_read_from_the_lap_field() {
+        let raw = json!({
+            "trackid": 1_700_000_000i64,
+            "time": "0;300;300;",
+            "heart_rate": "0,150;300,2;300,-2;",
+            // 两圈各 500 m / 300 s；第 6 列是累计秒数。
+            "lap": "0,300,500,s00000000000,150,300,-20000;\
+        1,300,500,s00000000000,152,600,-20000;",
+        });
+        let decoded = decode_workout_detail(&raw, None, Some(1000.0)).unwrap();
+        assert_eq!(decoded.laps.len(), 2);
+        assert_eq!(decoded.laps[0].index, 1);
+        assert_eq!(decoded.laps[0].distance_m, 500.0);
+        assert_eq!(decoded.laps[0].duration_seconds, 300);
+        assert_eq!(decoded.laps[0].avg_hr, Some(150));
+        // 第二圈从第一圈结束的地方开始，不是从运动开头。
+        assert_eq!(decoded.laps[1].start_time, decoded.laps[0].end_time);
+        assert_eq!(decoded.laps[1].duration_seconds, 300);
+    }
+
+    /// 圈和每公里分段是两回事，谁也不替代谁。
+    ///
+    /// 一次 5820 m 的跑步可以同时有 5 段公里分段和 14 个 415 m 的圈。塞进同一张
+    /// 表、或者让其中一个覆盖另一个，「每公里配速」那张图就会突然变成别的东西。
+    #[test]
+    fn laps_and_kilometre_splits_coexist() {
+        let raw = json!({
+            "trackid": 1_700_000_000i64,
+            "time": "0;300;300;",
+            "currentDistance": "0,0;300,50000;300,100000;",
+            "heart_rate": "0,150;300,2;300,-2;",
+            "lap": "0,300,500,s00000000000,150,300,-20000;\
+        1,300,500,s00000000000,152,600,-20000;",
+        });
+        let decoded = decode_workout_detail(&raw, None, Some(1000.0)).unwrap();
+        assert_eq!(decoded.laps.len(), 2, "手表的圈");
+        assert!(!decoded.splits.is_empty(), "我们自己切的公里分段还在");
+    }
+
+    /// 和汇总对不上就整份丢掉，而不是拿一半当真。
+    ///
+    /// 这是最强的两条对账：圈距离加起来要等于运动距离，最后一圈要在运动结束的
+    /// 时刻收尾。列读错了，两条都过不去——真实的 32 条则两条都过得去。
+    #[test]
+    fn laps_that_do_not_add_up_to_the_workout_are_refused() {
+        // 圈距离合计 1000 m，汇总说这次跑了 5000 m。
+        let wrong_distance = json!({
+            "trackid": 1_700_000_000i64,
+            "time": "0;300;300;",
+            "heart_rate": "0,150;300,2;300,-2;",
+            "lap": "0,300,500,s00000000000,150,300,-20000;\
+        1,300,500,s00000000000,152,600,-20000;",
+        });
+        assert!(
+            decode_workout_detail(&wrong_distance, None, Some(5000.0))
+                .unwrap()
+                .laps
+                .is_empty(),
+            "距离对不上就不要"
+        );
+
+        // 序号跳号。
+        let out_of_order = json!({
+            "trackid": 1_700_000_000i64,
+            "time": "0;300;300;",
+            "heart_rate": "0,150;300,2;300,-2;",
+            "lap": "0,300,500,s00000000000,150,300,-20000;\
+        7,300,500,s00000000000,152,600,-20000;",
+        });
+        assert!(decode_workout_detail(&out_of_order, None, Some(1000.0))
+            .unwrap()
+            .laps
+            .is_empty());
+
+        // 累计秒数往回走。
+        let backwards = json!({
+            "trackid": 1_700_000_000i64,
+            "time": "0;300;300;",
+            "heart_rate": "0,150;300,2;300,-2;",
+            "lap": "0,300,500,s00000000000,150,600,-20000;\
+        1,300,500,s00000000000,152,300,-20000;",
+        });
+        assert!(decode_workout_detail(&backwards, None, Some(1000.0))
+            .unwrap()
+            .laps
+            .is_empty());
+    }
+
+    /// 没有 `lap` 字段是常态，不是错误：336 条明细里只有 32 条带它。
+    #[test]
+    fn a_workout_without_laps_is_not_an_error() {
+        let raw = json!({
+            "trackid": 1_700_000_000i64,
+            "time": "0;300;",
+            "heart_rate": "0,150;300,2;",
+            "lap": "",
+        });
+        let decoded = decode_workout_detail(&raw, None, Some(1000.0)).unwrap();
+        assert!(decoded.laps.is_empty());
+    }
+
+    /// 心率 0 是「这一圈没测到」，不是「心率为 0」。
+    #[test]
+    fn a_zero_heart_rate_on_a_lap_is_absent_not_zero() {
+        let raw = json!({
+            "trackid": 1_700_000_000i64,
+            "time": "0;300;",
+            "heart_rate": "0,150;300,2;",
+            "lap": "0,300,1000,s00000000000,0,300,-20000;",
+        });
+        let decoded = decode_workout_detail(&raw, None, Some(1000.0)).unwrap();
+        assert_eq!(decoded.laps.len(), 1);
+        assert_eq!(decoded.laps[0].avg_hr, None);
     }
 }

--- a/src-tauri/crates/core/src/export_fit.rs
+++ b/src-tauri/crates/core/src/export_fit.rs
@@ -166,9 +166,26 @@ fn encode_workout(workout: &Value) -> Result<Option<(Vec<u8>, usize)>, String> {
     messages.push(timer_event(end_unix, typedef::EventType::STOP));
 
     let elapsed_seconds = (end_unix - start_unix).max(0) as f64;
+    // 手表自己记的圈优先于我们按公里切的分段。
+    //
+    // 「我经常按圈键，如果你的 .fit 里能带上圈数据，那会是我的首选」——
+    // GitHub 上那份逐字段对拍报告里的原话。手表记了圈，那就是这次运动真实
+    // 发生的分段；每公里是我们事后切的，两者都在库里，写进文件的只能有一组。
+    let lap_source = if array(workout, "laps").is_empty() {
+        LapSource {
+            field: "splits",
+            trigger: typedef::LapTrigger::DISTANCE,
+        }
+    } else {
+        LapSource {
+            field: "laps",
+            trigger: watch_lap_trigger(workout),
+        }
+    };
     let mut lap_count = push_laps(
         &mut messages,
         workout,
+        lap_source,
         sport,
         sub_sport,
         start_unix,
@@ -395,21 +412,66 @@ fn record_message(unix: i64, point: &Point, sport: typedef::Sport) -> Message {
     }
 }
 
-/// 每公里一条 `lap`，取自导出 JSON 的 `splits`——那是服务端自己的累积距离
-/// 切出来的，不是拿速度积分估的。
+/// 手表那组圈是按距离自动分的，还是人按出来的？
 ///
-/// 没有 splits 时这里返回 0，由调用方补一条覆盖全程的 lap
+/// 手表不告诉我们，但圈的长度会：自动分段每一圈一样长（真实数据里见过一次
+/// 5820 m 的跑步被切成 14 个 415 m 的圈），人按出来的长短不一（同一份数据里
+/// 另一次是 570 / 2310 / 320 / 150 / 530 m 的间歇）。
+///
+/// 分不出来的时候宁可报 `MANUAL`：它的意思是「这一圈是有人划出来的」，而这
+/// 组圈确实来自手表的圈列表，不是我们切的。反过来把人按的圈标成 `DISTANCE`，
+/// 是在替手表宣称一件它没说过的事。
+fn watch_lap_trigger(workout: &Value) -> typedef::LapTrigger {
+    let distances: Vec<f64> = array(workout, "laps")
+        .iter()
+        .filter_map(|lap| lap.get("distance_m").and_then(Value::as_f64))
+        .filter(|value| value.is_finite() && *value > 0.0)
+        .collect();
+    // 最后一圈是零头，长度天然不同，不参与判断。
+    let considered = distances.len().saturating_sub(1);
+    if considered < 2 {
+        return typedef::LapTrigger::MANUAL;
+    }
+    let first = distances[0];
+    let uniform = distances[..considered]
+        .iter()
+        .all(|value| (value - first).abs() / first < 0.01);
+    if uniform {
+        typedef::LapTrigger::DISTANCE
+    } else {
+        typedef::LapTrigger::MANUAL
+    }
+}
+
+/// 这组 `lap` 从导出 JSON 的哪个数组来，以及该报成什么触发方式。
+#[derive(Debug, Clone, Copy)]
+struct LapSource {
+    field: &'static str,
+    trigger: typedef::LapTrigger,
+}
+
+/// 一组 `lap`，来自导出 JSON 的 `laps.field` 数组。
+///
+/// `source` 有两个取值，含义不同：
+///
+/// * `laps` —— **手表自己记的圈**。按圈键、按距离自动分段、或者间歇课的每
+///   一段。这是运动当时真实发生的事，所以优先用它。
+/// * `splits` —— 我们按每公里切的分段，取自服务端的累积距离（不是拿速度
+///   积分估的）。手表没记圈时用这个。
+///
+/// 两者都没有时返回 0，由调用方补一条覆盖全程的 lap
 /// （`push_whole_activity_lap`）——文件里绝不能一条 lap 都没有。
 fn push_laps(
     messages: &mut Vec<Message>,
     workout: &Value,
+    laps: LapSource,
     sport: typedef::Sport,
     sub_sport: typedef::SubSport,
     fallback_start: i64,
     points: &[(i64, Point)],
 ) -> u16 {
     let mut count = 0u16;
-    for split in array(workout, "splits") {
+    for split in array(workout, laps.field) {
         let start = parse_unix(text(split.get("start_time"))).unwrap_or(fallback_start);
         let end = parse_unix(text(split.get("end_time"))).unwrap_or(start);
         let duration = split
@@ -426,7 +488,7 @@ fn push_laps(
             enum_field(mesgdef::Lap::SPORT, sport.0),
             enum_field(mesgdef::Lap::SUB_SPORT, sub_sport.0),
             enum_field(mesgdef::Lap::INTENSITY, typedef::Intensity::ACTIVE.0),
-            enum_field(mesgdef::Lap::LAP_TRIGGER, typedef::LapTrigger::DISTANCE.0),
+            enum_field(mesgdef::Lap::LAP_TRIGGER, laps.trigger.0),
             u32_field(
                 mesgdef::Lap::TOTAL_ELAPSED_TIME,
                 (duration * 1000.0).max(0.0) as u32,

--- a/src-tauri/crates/core/src/local_api.rs
+++ b/src-tauri/crates/core/src/local_api.rs
@@ -875,6 +875,7 @@ mod tests {
             route: vec![],
             pauses: vec![],
             splits: vec![],
+            laps: vec![],
             summary: WorkoutSeriesSummary::default(),
         }
     }

--- a/src-tauri/crates/core/src/models/error.rs
+++ b/src-tauri/crates/core/src/models/error.rs
@@ -1,9 +1,102 @@
 use thiserror::Error;
 
+/// 只有无头环境才会撞上的那几种失败。
+///
+/// 单独列出来，是因为它们需要**自己的错误码**。桌面端按码取本地化文案，
+/// 所以那边一直没问题；而命令行没有 i18n 层，它把 `user_message()` 原样
+/// 印出来——那是中文。issue #40 那位 Linux 用户就是这样在一个英文命令行上
+/// 收到了两句中文：「无法读取系统密钥环…」和「本机数据库还是 v19…」。
+///
+/// 有了码，命令行就能自己出英文，而桌面端两种语言都不受影响。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HeadlessProblem {
+    /// 这台机器上没有在跑 Secret Service。无头服务器和容器通常没有。
+    NoCredentialStore {
+        /// keyring 给的原话，用来分辨是没装还是被策略挡了。
+        detail: String,
+    },
+    /// 库的 schema 比这个程序旧，而只读连接升不了级。
+    SchemaUpgradeRequired { found: i64, required: i64 },
+    /// `auth.json` 在，但凭据存储里没有这个账号的令牌。
+    ///
+    /// 最常见的出处不是「凭据坏了」，而是**有人把另一台机器的 data 文件夹
+    /// 整个拷了过来**：库和 auth.json 都能拷，令牌不能——它在那台机器的
+    /// 凭据管理器 / 钥匙串 / Secret Service 里。
+    TokenNotInStore,
+}
+
+impl HeadlessProblem {
+    fn code(&self) -> &'static str {
+        match self {
+            Self::NoCredentialStore { .. } => "err.headless.no_credential_store",
+            Self::SchemaUpgradeRequired { .. } => "err.headless.schema_upgrade",
+            Self::TokenNotInStore => "err.headless.token_not_in_store",
+        }
+    }
+
+    /// 中文原文。桌面端的中文界面直接用它；英文界面按码取自己的文案。
+    fn message(&self) -> String {
+        match self {
+            Self::NoCredentialStore { detail } => format!(
+                "{detail}。这台机器上可能没有运行 Secret Service（GNOME Keyring / \
+                 KWallet）——无头服务器和容器通常没有。改用 \
+                 ZEPPBRIDGE_CREDENTIAL_STORE=file（令牌以 0600 写在数据目录里），\
+                 或 ZEPPBRIDGE_CREDENTIAL_STORE=env 配合 ZEPPBRIDGE_APP_TOKEN"
+            ),
+            Self::SchemaUpgradeRequired { found, required } => format!(
+                "本机数据库还是 v{found}，这个程序需要 v{required}。只读连接无法\
+                 升级——无头环境请跑一次 `zeppbridge-cli reprocess`，有桌面应用就\
+                 启动一次（两条路都会在升级前自动生成备份），再重试。"
+            ),
+            Self::TokenNotInStore => "认证元数据在，但凭据管理器里没有这个账号的\
+                 令牌。库能跨机器拷，令牌不能。请重新登录，或设 \
+                 ZEPPBRIDGE_CREDENTIAL_STORE=file / =env 后重试"
+                .to_string(),
+        }
+    }
+
+    /// 英文。命令行印这一份——它没有 i18n 层，而它的读者多半读不懂中文。
+    ///
+    /// 两个环境变量名和路径本来就是 ASCII，所以即使只读得懂其中一半，
+    /// 能动手的那部分也认得出来。
+    pub fn english(&self) -> String {
+        match self {
+            Self::NoCredentialStore { detail } => format!(
+                "{detail}. There may be no Secret Service running on this machine \
+                 (GNOME Keyring / KWallet) -- headless servers and containers \
+                 usually have none. Use ZEPPBRIDGE_CREDENTIAL_STORE=file (the token \
+                 is written 0600 into the data directory) or \
+                 ZEPPBRIDGE_CREDENTIAL_STORE=env together with ZEPPBRIDGE_APP_TOKEN"
+            ),
+            Self::SchemaUpgradeRequired { found, required } => format!(
+                "This library is still v{found} and this build needs v{required}. A \
+                 read-only connection cannot upgrade it: run `zeppbridge-cli \
+                 reprocess` on a headless machine, or launch the desktop app once. \
+                 Both take a backup before upgrading. Then try again."
+            ),
+            Self::TokenNotInStore => "The account metadata is here but the credential \
+                 store has no token for it. A library copies between machines; a token \
+                 does not. Sign in again, or set ZEPPBRIDGE_CREDENTIAL_STORE=file / \
+                 =env and retry"
+                .to_string(),
+        }
+    }
+}
+
+impl std::fmt::Display for HeadlessProblem {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.message())
+    }
+}
+
 #[derive(Error, Debug)]
 pub enum ZeppBridgeError {
     #[error("认证错误: {0}")]
     AuthError(String),
+
+    /// 无头环境才会撞上的那几种失败。见 [`HeadlessProblem`]。
+    #[error("{0}")]
+    Headless(HeadlessProblem),
 
     /// 系统凭据存储（Windows 凭据管理器 / macOS 钥匙串）拒绝了这次读写。
     ///
@@ -127,6 +220,7 @@ impl ZeppBridgeError {
             Self::CloudRejected { .. } => "err.core.cloud_rejected",
             Self::Cancelled => "err.core.cancelled",
             Self::AuthError(_) => "err.core.auth",
+            Self::Headless(problem) => problem.code(),
             Self::CredentialStore(_) => "err.core.credential_store",
             Self::InvalidHost(_) => "err.core.invalid_host",
             Self::ConfigError(_) => "err.core.config",
@@ -167,6 +261,10 @@ impl ZeppBridgeError {
             | Self::InvalidHost(message)
             | Self::ConfigError(message)
             | Self::Busy(message) => sanitize_user_text(message),
+            // 不过 `sanitize_user_text`：那一层有 140 字上限，而这几句的
+            // 全部价值就在于把两个环境变量名和该跑哪条命令说完整。它们是
+            // 我们自己写死的常量，里面没有地址，也没有云端回来的内容。
+            Self::Headless(problem) => problem.to_string(),
             Self::ParseError(_) => "Zepp 返回的数据无法解析".into(),
             Self::DatabaseError(_) => "本地数据库暂时不可用".into(),
             Self::IoError(_) => "读写本地文件失败".into(),

--- a/src-tauri/crates/core/src/models/types.rs
+++ b/src-tauri/crates/core/src/models/types.rs
@@ -366,6 +366,22 @@ pub struct WorkoutSplitRow {
     pub partial: bool,
 }
 
+/// 手表自己记的一圈，从库里读出来的形状。
+///
+/// 和 [`WorkoutSplitRow`] 并列而不是取代它：split 是我们按每公里切的，
+/// lap 是手表在运动当时记的（圈键、按距离自动分段、间歇课的每一段）。
+/// 一次跑步可以同时有两者，含义不同。
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WorkoutLapRow {
+    pub index: i32,
+    pub start_time: String,
+    pub end_time: String,
+    pub distance_m: f64,
+    pub duration_seconds: i64,
+    pub avg_hr: Option<i32>,
+    pub max_hr: Option<i32>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct WorkoutSeries {
     pub workout_id: String,
@@ -373,6 +389,9 @@ pub struct WorkoutSeries {
     pub route: Vec<WorkoutRoutePoint>,
     pub pauses: Vec<WorkoutPause>,
     pub splits: Vec<WorkoutSplitRow>,
+    /// 手表记的圈。空数组表示这次运动没有记圈——绝大多数运动如此。
+    #[serde(default)]
+    pub laps: Vec<WorkoutLapRow>,
     pub summary: WorkoutSeriesSummary,
 }
 

--- a/src-tauri/crates/core/src/storage/migrations.rs
+++ b/src-tauri/crates/core/src/storage/migrations.rs
@@ -681,6 +681,36 @@ impl Database {
             "INSERT OR IGNORE INTO schema_migrations(version, applied_at) VALUES(20, ?1)",
             [Utc::now().to_rfc3339()],
         )?;
+        // v21：手表自己记的圈。
+        //
+        // 和 `workout_splits` 是**两回事**，所以单独一张表而不是加一个
+        // 类型列：splits 是我们本地按每公里切出来的，圈是手表在运动当时
+        // 记下来的——按圈键、按距离自动分段，或者按训练课的间歇。
+        // 一次 5820 m 的跑步可以同时有 5 段公里分段和 14 个 415 m 的圈；
+        // 把它们塞进同一张表，「每公里配速」那张图就会突然变成别的东西。
+        //
+        // 表从空的开始，下一次归一化重放时填上——原始报文里一直有。
+        self.conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS workout_laps (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                workout_id TEXT NOT NULL,
+                lap_index INTEGER NOT NULL,
+                start_time TEXT NOT NULL,
+                end_time TEXT NOT NULL,
+                distance_m REAL NOT NULL,
+                duration_seconds INTEGER NOT NULL,
+                avg_hr INTEGER,
+                max_hr INTEGER,
+                FOREIGN KEY(workout_id) REFERENCES workouts(workout_id) ON DELETE CASCADE
+            );
+            CREATE INDEX IF NOT EXISTS idx_workout_laps_workout
+                ON workout_laps(workout_id, lap_index);
+            PRAGMA user_version = 21;",
+        )?;
+        self.conn.execute(
+            "INSERT OR IGNORE INTO schema_migrations(version, applied_at) VALUES(21, ?1)",
+            [Utc::now().to_rfc3339()],
+        )?;
         // Earlier migrations are intentionally idempotent and still stamp
         // their historical versions on every launch, so the current schema
         // marker is restored only after all of them have run.

--- a/src-tauri/crates/core/src/storage/mod.rs
+++ b/src-tauri/crates/core/src/storage/mod.rs
@@ -1330,9 +1330,14 @@ impl Database {
         let version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
         match version.cmp(&CURRENT_SCHEMA_VERSION) {
             std::cmp::Ordering::Equal => Ok(Self { conn }),
-            std::cmp::Ordering::Less => Err(ZeppBridgeError::ConfigError(format!(
-                "本机数据库还是 v{version}，这个程序需要 v{CURRENT_SCHEMA_VERSION}。只读连接无法升级——无头环境请跑一次 `zeppbridge-cli reprocess`，有桌面应用就启动一次（两条路都会在升级前自动生成备份），再重试。"
-            ))),
+            // 自己的错误码：撞上这一条的人几乎都在无头环境里，而命令行没有
+            // i18n 层，只有按码才出得了英文。见 `HeadlessProblem`。
+            std::cmp::Ordering::Less => Err(ZeppBridgeError::Headless(
+                crate::models::error::HeadlessProblem::SchemaUpgradeRequired {
+                    found: version,
+                    required: CURRENT_SCHEMA_VERSION,
+                },
+            )),
             std::cmp::Ordering::Greater => Err(ZeppBridgeError::ConfigError(format!(
                 "本机数据库是 v{version}，比这个程序（v{CURRENT_SCHEMA_VERSION}）新。请把命令行 / MCP 升级到与桌面应用相同的版本，不要用旧版去读新库。"
             ))),

--- a/src-tauri/crates/core/src/storage/mod.rs
+++ b/src-tauri/crates/core/src/storage/mod.rs
@@ -9,7 +9,7 @@ use std::path::{Path, PathBuf};
 
 /// 当前 SQLite schema 版本（`PRAGMA user_version`）。加新版本只能追加迁移
 /// 步骤，不要改已有 DDL。
-pub const CURRENT_SCHEMA_VERSION: i64 = 20;
+pub const CURRENT_SCHEMA_VERSION: i64 = 21;
 /// 写进备份 manifest 的应用版本。Core 是独立 crate，用它自己的包版本。
 const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
 /// 解析器修订号。**改了运动目录或任何归一化规则，就必须往前走一格。**
@@ -18,18 +18,20 @@ const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
 /// `raw_records` 重新跑一遍。不动它，新加的编号只对以后同步来的记录生效，
 /// 已经存成 `unknown:211` 的那 199 条记录会永远挂着——而报这个问题的人恰恰
 /// 是因为历史记录才来报的。
-pub const NORMALIZER_REVISION: &str = "zepp-normalizer-2026-09-v21-elliptical";
+pub const NORMALIZER_REVISION: &str = "zepp-normalizer-2026-09-v22-watch-laps";
 /// 上一版的修订号。从它升上来时只重放这几条流。
 ///
-/// v20 到 v21 只动了一件事：运动目录里加了 `12 -> elliptical`（椭圆机）。
-/// 编号只在 `normalize_workouts_*` 里被翻译成运动名（normalizer/mod.rs 的
-/// `zepp_sport_type_name`，全仓库唯一的调用点），所以只有 workouts 这一条流
-/// 需要重放。`workout_detail` 里没有类型编号，daily_summary / wellness /
-/// sleep / hrv / heart_rate 的解析一个字节都没动。
-const PREVIOUS_RELEASE_NORMALIZER_REVISION: &str = "zepp-normalizer-2026-09-v20-cloud-fields";
+/// v21 到 v22 只动了一件事：`workout_detail` 现在解 `lap` 字段——手表自己记
+/// 的圈。那个字段一直在留存的报文里（本机 336 条明细中有 32 条带它），只是
+/// 从来没被解过，所以重放能把历史记录的圈补齐，不用重新同步。
+///
+/// 只有 `workout_detail` 需要重放：`lap` 只出现在明细报文里，workouts 汇总、
+/// daily_summary / wellness / weight / sleep / hrv / heart_rate 的解析一个
+/// 字节都没动。
+const PREVIOUS_RELEASE_NORMALIZER_REVISION: &str = "zepp-normalizer-2026-09-v21-elliptical";
 /// 从上一版升上来时要重放的流。**改归一化规则时必须一起看这里**：漏掉一条
 /// 流，那条流的历史记录就永远停在旧规则上，而升级看起来是成功的。
-const PREVIOUS_RELEASE_REPLAY_STREAMS: [&str; 1] = ["workouts"];
+const PREVIOUS_RELEASE_REPLAY_STREAMS: [&str; 1] = ["workout_detail"];
 const LAST_CLOUD_SYNC_AT_KEY: &str = "last_cloud_sync_at";
 const LAST_CLOUD_SYNC_OUTCOME_KEY: &str = "last_cloud_sync_outcome";
 const LAST_LOCAL_REPROCESS_AT_KEY: &str = "last_local_reprocess_at";
@@ -2885,6 +2887,26 @@ impl Database {
                 ])?;
             }
         }
+        {
+            let mut insert = self.conn.prepare(
+                "INSERT INTO workout_laps
+                    (workout_id, lap_index, start_time, end_time, distance_m,
+                     duration_seconds, avg_hr, max_hr)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            )?;
+            for lap in &decoded.laps {
+                insert.execute(params![
+                    workout_id,
+                    lap.index,
+                    lap.start_time.to_rfc3339(),
+                    lap.end_time.to_rfc3339(),
+                    lap.distance_m,
+                    lap.duration_seconds,
+                    lap.avg_hr,
+                    lap.max_hr,
+                ])?;
+            }
+        }
 
         self.conn.execute(
             "UPDATE workouts
@@ -2966,6 +2988,7 @@ impl Database {
         let summary = workout_series_summary(&samples);
 
         let splits = self.load_workout_splits(workout_id)?;
+        let laps = self.load_workout_laps(workout_id)?;
 
         Ok(WorkoutSeries {
             workout_id: workout_id.to_owned(),
@@ -2973,6 +2996,7 @@ impl Database {
             route,
             pauses,
             splits,
+            laps,
             summary,
         })
     }
@@ -3038,6 +3062,26 @@ impl Database {
             )?;
         }
         Ok(total)
+    }
+
+    fn load_workout_laps(&self, workout_id: &str) -> Result<Vec<WorkoutLapRow>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT lap_index, start_time, end_time, distance_m, duration_seconds,
+                    avg_hr, max_hr
+             FROM workout_laps WHERE workout_id = ?1 ORDER BY lap_index",
+        )?;
+        let rows = stmt.query_map([workout_id], |row| {
+            Ok(WorkoutLapRow {
+                index: row.get(0)?,
+                start_time: row.get(1)?,
+                end_time: row.get(2)?,
+                distance_m: row.get(3)?,
+                duration_seconds: row.get(4)?,
+                avg_hr: row.get(5)?,
+                max_hr: row.get(6)?,
+            })
+        })?;
+        Ok(rows.collect::<std::result::Result<Vec<_>, _>>()?)
     }
 
     fn load_workout_splits(&self, workout_id: &str) -> Result<Vec<WorkoutSplitRow>> {
@@ -5006,6 +5050,9 @@ impl Database {
                     "route_point_count": series.route.len(),
                     "pauses": series.pauses,
                     "splits": series.splits,
+                    // 手表自己记的圈。和 splits 并列而不是二选一：一次跑步
+                    // 可以同时有每公里分段和手表按圈键记下的圈，含义不同。
+                    "laps": series.laps,
                 });
                 if full {
                     let samples = serde_json::to_value(series.samples)
@@ -5514,6 +5561,10 @@ impl Database {
         )?;
         self.conn.execute(
             "DELETE FROM workout_pauses WHERE start_time < ?1",
+            [&cutoff_timestamp],
+        )?;
+        self.conn.execute(
+            "DELETE FROM workout_laps WHERE start_time < ?1",
             [&cutoff_timestamp],
         )?;
         self.conn.execute(
@@ -6439,9 +6490,63 @@ mod tests {
         );
     }
 
+    /// 一条运动加上它的明细报文，明细里带手表记的圈。
+    ///
+    /// v22 重放的是 `workout_detail`：`lap` 字段一直躺在留存的报文里（本机
+    /// 336 条明细中有 32 条带它），只是从来没被解过。重放要能把历史记录的圈
+    /// 补齐，否则问这件事的人升级完看到的还是老样子——而他就是因为历史记录
+    /// 才来问的。
+    fn insert_workout_with_lap_detail(db: &Database) {
+        db.insert_raw_record(&RawRecord {
+            stream: "workouts".into(),
+            source_key: "sport_history:run:lap-fixture".into(),
+            source_scope: SourceScope::Device,
+            device_id: None,
+            start_utc: ts(),
+            end_utc: None,
+            payload: serde_json::json!({
+                "data": [{
+                    "trackid": 1_700_000_000i64,
+                    "end_time": 1_700_000_600i64,
+                    "type": 1,
+                    "dis": "1000"
+                }]
+            }),
+            capability: CapabilityStatus::Verified,
+        })
+        .unwrap();
+        db.insert_raw_record(&RawRecord {
+            stream: "workout_detail".into(),
+            source_key: "workout_detail:1700000000:run.huami.com".into(),
+            source_scope: SourceScope::Device,
+            device_id: None,
+            start_utc: ts(),
+            end_utc: None,
+            payload: serde_json::json!({
+                "data": {
+                    "trackid": 1_700_000_000i64,
+                    "time": "0;300;300;",
+                    "heart_rate": "0,150;300,2;300,-2;",
+                    // 两圈各 500 m / 300 s，累计 300 与 600 —— 正好对上汇总的
+                    // 1000 m 和 600 s，两条对账都过得去。
+                    "lap": "0,300,500,s00000000000,150,300,-20000;1,300,500,s00000000000,152,600,-20000;"
+                }
+            }),
+            capability: CapabilityStatus::Verified,
+        })
+        .unwrap();
+        // `insert_raw_record` 只存报文，派生行是重放时才建的。先整体归一化
+        // 一遍，把运动汇总和逐秒采样做出来——真实的旧库正是这个样子。
+        db.reprocess_raw_records().unwrap();
+        // 然后把圈清掉：旧版本解不出 `lap`，所以旧库里这张表是空的。v22 的
+        // 重放要能把它们补回来，这正是要验的事。
+        db.conn.execute("DELETE FROM workout_laps", []).unwrap();
+    }
+
     #[test]
     fn previous_release_upgrade_replays_only_the_changed_streams() {
         let db = Database::in_memory().unwrap();
+        insert_workout_with_lap_detail(&db);
         db.insert_raw_record(&RawRecord {
             stream: "daily_summary".into(),
             source_key: "daily-summary-test".into(),
@@ -6502,18 +6607,19 @@ mod tests {
 
         let counts = db.reprocess_raw_records_if_needed().unwrap().unwrap();
 
-        // v20 到 v21 只改了运动目录，所以只有 workouts 这一条流要重放，而且
-        // 报上来的条数是真的条数——那一条运动。
-        assert_eq!(counts.get("workouts"), Some(&1));
-        // 而且重放确实把编号翻译过来了：这正是这一版存在的理由——已经存成
-        // `unknown:12` 的历史记录必须变成椭圆机，不然报这个问题的人（他就是
-        // 因为历史记录才来报的）升级完看到的还是老样子。
+        // v21 到 v22 只动了明细里的 `lap`，所以只有 workout_detail 这一条流要
+        // 重放。运动汇总的解析一个字节都没改，不该被顺手再解一遍。
+        assert!(counts.contains_key("workout_detail"), "counts = {counts:?}");
+        assert!(!counts.contains_key("workouts"), "{counts:?}");
+        // 而且重放确实把圈解出来了：这正是这一版存在的理由——报文里一直有的
+        // 东西，不重放的话只有以后新同步的运动才会有圈。
         assert_eq!(
             db.conn
-                .query_row("SELECT workout_type FROM workouts", [], |row| row
-                    .get::<_, String>(0),)
+                .query_row("SELECT COUNT(*) FROM workout_laps", [], |row| row
+                    .get::<_, i64>(0),)
                 .unwrap(),
-            "elliptical"
+            2,
+            "两圈都要落库"
         );
         // daily_summary / wellness 一个字节都没动过，不该被顺手解一遍：白解
         // 一遍就是让升级后第一次启动干等。
@@ -6562,22 +6668,10 @@ mod tests {
     #[test]
     fn a_stale_library_can_be_recognized_without_writing_to_it() {
         let db = Database::in_memory().unwrap();
-        db.insert_raw_record(&RawRecord {
-            // 这一条必须落在**这一版要重放的那条流**上，否则 raw_records 会是
-            // 0，而 0 条报文的库本来就不欠重放——那样这个测试就在验一件不相干
-            // 的事。改归一化规则、换了重放的流时，这里要跟着换。
-            stream: "workouts".into(),
-            source_key: "workouts-plan".into(),
-            source_scope: SourceScope::Device,
-            device_id: None,
-            start_utc: ts(),
-            end_utc: None,
-            payload: serde_json::json!({
-                "data": [{ "trackid": 1_700_000_000i64, "end_time": 1_700_003_600i64, "type": 12 }]
-            }),
-            capability: CapabilityStatus::Verified,
-        })
-        .unwrap();
+        // 这份夹具必须落在**这一版要重放的那条流**上，否则 raw_records 会是 0，
+        // 而 0 条报文的库本来就不欠重放——那样这个测试就在验一件不相干的事。
+        // 改归一化规则、换了重放的流时，这里要跟着换。
+        insert_workout_with_lap_detail(&db);
         db.conn
             .execute(
                 "INSERT INTO app_meta(key, value, updated_at)
@@ -6634,20 +6728,8 @@ mod tests {
     #[test]
     fn health_reports_the_revision_the_library_actually_has() {
         let db = Database::in_memory().unwrap();
-        db.insert_raw_record(&RawRecord {
-            // 同上：要落在这一版会重放的那条流上，不然「欠不欠重放」根本不成立。
-            stream: "workouts".into(),
-            source_key: "workouts-health".into(),
-            source_scope: SourceScope::Device,
-            device_id: None,
-            start_utc: ts(),
-            end_utc: None,
-            payload: serde_json::json!({
-                "data": [{ "trackid": 1_700_000_000i64, "end_time": 1_700_003_600i64, "type": 12 }]
-            }),
-            capability: CapabilityStatus::Verified,
-        })
-        .unwrap();
+        // 同上：要落在这一版会重放的那条流上，不然「欠不欠重放」根本不成立。
+        insert_workout_with_lap_detail(&db);
         db.conn
             .execute(
                 "INSERT INTO app_meta(key, value, updated_at)

--- a/src-tauri/crates/core/src/storage/provenance.rs
+++ b/src-tauri/crates/core/src/storage/provenance.rs
@@ -134,10 +134,16 @@ impl StageErrorKind {
     /// `auth` 要去重新连接，`network` 值得重试，`not_available` 是这个账号
     /// 本来就没有这条流，重试多少次都没用。
     pub fn classify(error: &crate::models::ZeppBridgeError) -> Self {
+        use crate::models::error::HeadlessProblem;
         use crate::models::ZeppBridgeError as E;
         match error {
             E::Cancelled => StageErrorKind::Cancelled,
             E::NeedsReauth(_) | E::AuthError(_) | E::CredentialStore(_) => StageErrorKind::Auth,
+            // 无头环境的三种：两种是「令牌拿不到」，一种是「库要先升级」。
+            // 前两种按 auth 分类（用户要去把凭据给进来），第三种是本机存储
+            // 的事——重试解决不了，得先跑一次 reprocess。
+            E::Headless(HeadlessProblem::SchemaUpgradeRequired { .. }) => StageErrorKind::Storage,
+            E::Headless(_) => StageErrorKind::Auth,
             E::Unavailable(_) | E::DataUnavailable(_) => StageErrorKind::NotAvailable,
             E::NetworkError(_) | E::RetryExhausted { .. } | E::HttpStatus { .. } => {
                 StageErrorKind::Network

--- a/src/i18n/errors.ts
+++ b/src/i18n/errors.ts
@@ -25,6 +25,19 @@ const messages = defineMessages(
     'err.core.cloud_rejected': 'Zepp 云端收到了请求但拒绝了。如果反复出现，请在设置里重新连接 Zepp 账号',
     'err.core.cancelled': '操作已取消',
     'err.core.auth': '认证出错了',
+    // 无头环境（服务器、容器）才会撞上的三种。桌面上极少见到，但它们必须有
+    // 自己的码：命令行没有 i18n 层，只有按码才出得了英文——issue #40 那位
+    // Linux 用户就是在英文命令行上收到了它们的中文原文。
+    'err.headless.no_credential_store':
+      '这台机器上没有可用的系统密钥环（GNOME Keyring / KWallet）。无头服务器和容器通常没有。'
+      + '可以设 ZEPPBRIDGE_CREDENTIAL_STORE=file 把令牌以 0600 写在数据目录里，'
+      + '或者用 ZEPPBRIDGE_CREDENTIAL_STORE=env 配合 ZEPPBRIDGE_APP_TOKEN 交进来。',
+    'err.headless.schema_upgrade':
+      '本机数据库的版本比这个程序旧，而只读连接升不了级。启动一次桌面应用，'
+      + '或者在无头环境跑一次 zeppbridge-cli reprocess——两条路都会在升级前自动备份。',
+    'err.headless.token_not_in_store':
+      '账号信息在，但凭据里没有对应的令牌。数据库能跨机器拷贝，令牌不能——'
+      + '它在原来那台机器的凭据管理器里。请重新登录一次。',
     // 有人报上来的原话就是这一句加一个红条，然后没有下文（反馈 e5fb37a5）：
     // 登录明明走完了，凭据却存不下，而界面没告诉他还能怎么办。出路本来就
     // 有——设置里那个「手动填 App Token」——只是没人会想到去找它。
@@ -148,6 +161,19 @@ const messages = defineMessages(
       'Zepp received the request and refused it. If this keeps happening, reconnect the Zepp account in Settings',
     'err.core.cancelled': 'Cancelled',
     'err.core.auth': 'Something went wrong with authentication',
+    'err.headless.no_credential_store':
+      'No system credential store is available on this machine (GNOME Keyring / KWallet). '
+      + 'Headless servers and containers usually have none. Set '
+      + 'ZEPPBRIDGE_CREDENTIAL_STORE=file to write the token 0600 into the data directory, '
+      + 'or ZEPPBRIDGE_CREDENTIAL_STORE=env together with ZEPPBRIDGE_APP_TOKEN.',
+    'err.headless.schema_upgrade':
+      'This library is older than the build reading it, and a read-only connection cannot '
+      + 'upgrade it. Launch the desktop app once, or run zeppbridge-cli reprocess on a '
+      + 'headless machine. Both take a backup before upgrading.',
+    'err.headless.token_not_in_store':
+      'The account details are here but the credential store has no token for them. A '
+      + 'database copies between machines; a token does not -- it stays in the credential '
+      + 'store of the machine it was created on. Sign in again.',
     'err.core.credential_store':
       'The token could not be saved to the system credential store. Common causes: the credential store is '
       + 'disabled by a group policy or security software, or what was read is not an App Token at all '


### PR DESCRIPTION
The two follow-ups recorded at the end of [#54](https://github.com/lingcang728/ZeppBridge/pull/54).

## 1. The lap button reaches the .fit file

> "I use the lap button often, if you could add lap data to your .fit file that would be my first choice."

That was the GitHub `.fit` comparison, which concluded the data probably wasn't obtainable because Zepp's own export lacks manual laps either. **It is obtainable.** The `lap` field is populated on **32 of the 336** workout details in a real library. Nobody had ever decoded it.

### The columns were confirmed, not guessed

Rows come 60, 62 or 66 columns wide, and the first six are identical in all three:

```
0,300,570,s00000000000,135,301,...
│ │   │   │             │   └ elapsed seconds at the end of this lap
│ │   │   │             └ average heart rate
│ │   │   └ geohash placeholder, zeroed in these payloads
│ │   └ distance in metres
│ └ duration in seconds
└ 0-based lap number
```

Width is not the test — on `kilo_pace` the same width was seen with columns in different orders. The test is that the numbers have to agree with the workout: sequential indices, a non-decreasing elapsed column, heart rates a heart can produce, and the two that need the summary — **the lap distances must sum to the workout distance, and the last lap must end when the workout ended.** All five hold on all 32; a column read as the wrong field passes neither of the last two.

Column 2 is *moving* time and can be shorter than the gap between elapsed values when the watch was paused, so lap boundaries come from the elapsed column and column 2 is not used for timing.

### Laps are not splits

`workout_laps` is its own table, not a `kind` column on `workout_splits`. A split is our cut at every kilometre; a lap is what the watch marked at the time. One 5820 m run carries **five kilometre splits and fourteen 415 m laps** — put them in one table and the per-kilometre pace chart silently becomes something else. On the real library all 32 carry both.

A FIT file can only have one lap list, and the watch's wins: if it recorded laps, those are what actually happened.

### The trigger is inferred, and the reasoning is in the code

The watch doesn't say whether a lap set was auto-by-distance or pressed by hand — but the lengths do. Auto laps are all the same length (one real 5820 m run split into 14 × 415 m); pressed laps are not (another is 570 / 2310 / 320 / 150 / 530 m of intervals). When it can't be told apart it reports `manual`, which claims only that a person drew the boundary — and these did come from the watch's own lap list. Labelling a hand-pressed lap `distance` would assert something the watch never said.

Verified on both: the interval run exports 15 laps with `trigger=manual`, the even one exports 14 × 415 m with `trigger=distance`.

## 2. Chinese error text on the headless path

That Linux user got two Chinese sentences on an English command line: `无法读取系统密钥环…` and `本机数据库还是 v19…`. 2.1.2 translated the CLI's *own* strings, but anything raised in `zeppbridge-core` still came through in Chinese.

The desktop was never affected — it resolves text by error code, and `backendText` blanket-replaces any Chinese backend string in the English UI. The CLI has no such layer.

**This does not translate core.** That is 700-plus strings, and translating half of them would mix both languages inside one error, which is worse than all-Chinese. It uses the mechanism this repo already has — error codes — at a finer grain. A new `HeadlessProblem` covers the three failures only headless environments hit, each with its own code:

- `err.headless.no_credential_store`
- `err.headless.schema_upgrade`
- `err.headless.token_not_in_store`

The Chinese stays (the desktop's Chinese UI needs it) and an English rendering sits beside it. The CLI resolves English by code at its own boundary and still falls back to the original text for anything it doesn't recognise — an unreadable message beats a blank one, and the fallback shrinks as more are moved over.

Codes are named `err.headless.*` rather than `err.core.headless.*` on purpose: `check-i18n.mjs` matches `err.<area>.<name>` and would not have seen a three-segment code, so it would never have enforced that both translations exist. The gate now covers 94 codes instead of 91.

**Exit codes are unchanged.** `schema_upgrade` is still 7 and `token_not_in_store` still 3 — a scheduler's response to them is completely different (one needs a `reprocess`, the other needs a human to supply credentials), so they must not collapse into one. There is a test for exactly that.

## Verification

Against a copy of a real library:

- `reprocess --all` → **32 workouts, 341 laps** — matching exactly the payloads that carry the field
- the interval run's `.fit`: 15 laps, 570/2310/320/150/530/280 m, `trigger=manual`
- the even one: 14 laps of 415 m, `trigger=distance`
- 32 workouts carry splits and laps side by side
- schema forced to v19 reproduces the message he got, now in English, exit code 7, `errorKind: schema_mismatch` unchanged
- `cargo test --workspace` — 354 passed (7 new)
- `cargo fmt --check`, `cargo clippy -D warnings`, and every npm gate — clean

Schema goes to v21 (new table) and the normalizer to v22, replaying `workout_detail` only — `lap` appears nowhere else, so existing libraries pick their laps up without re-syncing. That matters: the person who asked for this asked because of his history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
