### PR TITLE
Fix: the weight feature never reached three of the surfaces it should have

### DIFF
--- a/src-tauri/crates/core/src/storage/mod.rs
+++ b/src-tauri/crates/core/src/storage/mod.rs
@@ -269,7 +269,7 @@ fn merge_workout_type(
 /// `metric_samples` metrics are aggregated to one point per local day; the
 /// spread of that day's samples becomes `min` / `max`, which is real rather
 /// than derived.
-const SERIES_METRICS: [(&str, MetricSource, &str); 41] = [
+const SERIES_METRICS: [(&str, MetricSource, &str); 56] = [
     ("readiness", MetricSource::Daily(None), "score"),
     ("physical_readiness", MetricSource::Daily(None), "score"),
     ("mental_readiness", MetricSource::Daily(None), "score"),
@@ -326,6 +326,28 @@ const SERIES_METRICS: [(&str, MetricSource, &str); 41] = [
     ("active_minutes_goal", MetricSource::Daily(None), "分钟"),
     ("hrv", MetricSource::Samples, "ms"),
     ("hrv_rmssd", MetricSource::Samples, "ms"),
+    // 体重与体成分。一天可能称好几次，所以存在 `metric_samples` 里，按天折成
+    // 一个点由这里完成。
+    //
+    // **这张表和归一化那边是两份名单，两份都要有。** 只写进库、忘了登记在
+    // 这里，`metric_series` 会在那个 `continue` 上悄悄跳过它——导出和契约都
+    // 正常，唯独界面上是一张空卡片，而且什么都不报错。
+    ("weight", MetricSource::Samples, "kg"),
+    ("bmi", MetricSource::Samples, "kg/m2"),
+    ("height", MetricSource::Samples, "cm"),
+    ("body_fat_rate", MetricSource::Samples, "%"),
+    ("body_water_rate", MetricSource::Samples, "%"),
+    ("muscle_mass", MetricSource::Samples, "kg"),
+    ("bone_mass", MetricSource::Samples, "kg"),
+    ("protein_rate", MetricSource::Samples, "%"),
+    ("visceral_fat", MetricSource::Samples, "grade"),
+    ("bmr", MetricSource::Samples, "kcal/day"),
+    ("body_balance_score", MetricSource::Samples, "score"),
+    // 饮食记录。按天汇总，落在 `daily_metrics`。
+    ("intake_calories", MetricSource::Daily(None), "kcal"),
+    ("intake_protein_g", MetricSource::Daily(None), "g"),
+    ("intake_fat_g", MetricSource::Daily(None), "g"),
+    ("intake_carbs_g", MetricSource::Daily(None), "g"),
 ];
 
 /// Sample-backed metrics that are not in `SERIES_METRICS` above because they
@@ -8328,5 +8350,77 @@ mod tests {
             .any(|entry| entry.file_name().to_string_lossy().starts_with("corrupt-"));
         assert!(quarantined);
         let _ = std::fs::remove_dir_all(dir);
+    }
+    /// 写得进库，就得画得出来。
+    ///
+    /// `metric_series` 对不认识的指标名是**静默跳过**（那个 `continue`），所以
+    /// 一个只登记在归一化那边、忘了写进 `SERIES_METRICS` 的指标，会一路正常：
+    /// 库里有行、导出有值、契约里也有它，唯独界面上是一张永远空着的卡片，而且
+    /// 没有任何一处报错。体重那一版正是这么漏的。
+    #[test]
+    fn every_metric_the_contract_promises_can_be_charted() {
+        let chartable: std::collections::BTreeSet<&str> = SERIES_METRICS
+            .iter()
+            .map(|(name, _, _)| *name)
+            .chain(SAMPLE_ONLY_SERIES_METRICS.iter().map(|(name, _)| *name))
+            .collect();
+        // 体重系和饮食：这两组都是「写进库了但界面读不到」翻过车的地方。
+        let must_chart = crate::storage::BODY_COMPOSITION_METRICS
+            .iter()
+            .copied()
+            .chain([
+                "intake_calories",
+                "intake_protein_g",
+                "intake_fat_g",
+                "intake_carbs_g",
+            ]);
+        let missing: Vec<&str> = must_chart
+            .filter(|metric| !chartable.contains(metric))
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "这些指标写得进库却画不出来，界面上会是空卡片：{missing:?}"
+        );
+    }
+
+    /// 登记成 `Samples` 的指标，真的要能从 `metric_samples` 里读出来。
+    ///
+    /// 光在名单里有一行不够：源写错了（比如把只存在 metric_samples 里的东西
+    /// 标成 Daily），查的是另一张表，结果同样是空的。
+    #[test]
+    fn weight_samples_come_back_as_a_series() {
+        let db = Database::in_memory().unwrap();
+        let now = Utc::now();
+        for (metric, value, unit) in [
+            ("weight", 68.2_f64, "kg"),
+            ("bmi", 22.1, "kg/m2"),
+            ("body_fat_rate", 18.5, "%"),
+        ] {
+            db.insert_metric_sample(&MetricSample {
+                metric: metric.to_string(),
+                timestamp: now,
+                value,
+                unit: unit.to_string(),
+                source_scope: SourceScope::UserFused,
+                device_id: None,
+            })
+            .unwrap();
+        }
+
+        let series = db
+            .metric_series(
+                &[
+                    "weight".to_string(),
+                    "bmi".to_string(),
+                    "body_fat_rate".to_string(),
+                ],
+                30,
+            )
+            .unwrap();
+        assert_eq!(series.len(), 3, "三条都要回来，一条都不能被静默跳过");
+        let weight = series.iter().find(|s| s.metric == "weight").unwrap();
+        assert_eq!(weight.source, "metric_samples");
+        assert_eq!(weight.unit, "kg");
+        assert_eq!(weight.latest.as_ref().map(|point| point.value), Some(68.2));
     }
 }

--- a/src-tauri/crates/core/src/storage/provenance.rs
+++ b/src-tauri/crates/core/src/storage/provenance.rs
@@ -302,7 +302,7 @@ pub struct DataHealth {
 }
 
 /// 同步流目录。顺序即界面顺序。
-const STREAM_CATALOG: [(&str, &str, StreamCadence); 7] = [
+const STREAM_CATALOG: [(&str, &str, StreamCadence); 8] = [
     ("heart_rate", "心率", StreamCadence::Continuous),
     ("daily_summary", "每日概览", StreamCadence::Daily),
     ("sleep", "睡眠", StreamCadence::Nightly),
@@ -310,6 +310,9 @@ const STREAM_CATALOG: [(&str, &str, StreamCadence); 7] = [
     ("wellness", "压力 / 血氧等可选指标", StreamCadence::Daily),
     ("workouts", "运动记录", StreamCadence::PerEvent),
     ("workout_detail", "运动明细与轨迹", StreamCadence::PerEvent),
+    // 称重是「称了才有」，不是每天都该有的东西——一周没上秤不是故障，所以
+    // 是 Occasional 而不是 Daily，那样这一行才不会常年画成红色缺口。
+    ("weight", "体重与体成分", StreamCadence::Occasional),
 ];
 
 /// 已知节奏的指标。没列在这里的指标一律按 `Occasional` 处理 —— 宁可少报
@@ -1369,6 +1372,43 @@ mod tests {
                 .pending_normalization,
             1,
             "没产出任何记录的报文还是要算进来"
+        );
+    }
+    /// 同步会跑的每一条流，数据健康页都得认识。
+    ///
+    /// `STREAM_CATALOG` 是那一页的全部内容：不在这张表里的流，页面上根本没有
+    /// 它的行——没有「上次取到什么时候」，没有缺口判断，它开始失败了也不会有
+    /// 任何一处变红。而同步那边加一条流是不需要动这张表就能跑通的，所以两份
+    /// 名单会无声地分叉。体重那一版就是这么漏的：抓取、入库、导出、契约全对，
+    /// 唯独这一页当它不存在。
+    ///
+    /// 这里不去 grep 源码，而是把同步真正会 emit 的那几个名字写死一份对照：
+    /// 加流的人必须同时改两处，改漏了这条会红。
+    #[test]
+    fn every_synced_stream_appears_on_the_health_page() {
+        // 和 `SyncManager::run` 里那串 `emit(...)` 的第一个参数一一对应。
+        const SYNCED_STREAMS: [&str; 8] = [
+            "heart_rate",
+            "daily_summary",
+            "workouts",
+            "workout_detail",
+            "sleep",
+            "hrv",
+            "wellness",
+            "weight",
+        ];
+        let known: std::collections::BTreeSet<&str> = STREAM_CATALOG
+            .iter()
+            .map(|(stream, _, _)| *stream)
+            .collect();
+        let missing: Vec<&str> = SYNCED_STREAMS
+            .iter()
+            .copied()
+            .filter(|stream| !known.contains(stream))
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "这些流会同步，数据健康页却不认识它们：{missing:?}"
         );
     }
 }


### PR DESCRIPTION
Three bugs of the same shape, all from the scale work in [#52](https://github.com/lingcang728/ZeppBridge/pull/52) / [#53](https://github.com/lingcang728/ZeppBridge/pull/53). Each is one fact living in two lists with nothing cross-checking them, and each was invisible at every checkpoint I did verify.

## 1. The metrics could be stored but never charted

`metric_series()` **silently skips** metric names it doesn't recognise — the `continue` in its loop. A metric registered in the normalizer but missing from `SERIES_METRICS` looks correct everywhere:

- rows exist in `metric_samples` ✅
- `export --types weight` returns them ✅
- `contract.rs` lists them ✅
- the capability overview reports "has records" ✅
- **`BodyStatus.vue` asks for them and gets nothing** ❌ — silently, with no error

In #52 I verified ingestion, export and the capability overview. I did not verify the query the UI actually makes. 15 entries added: 11 body-composition metrics via `MetricSource::Samples` (a person can weigh in several times a day, so per-day folding belongs in the series layer), 4 nutrition metrics via `MetricSource::Daily`.

## 2. The weight stream does not exist on the data-health page

`STREAM_CATALOG` is that page's entire content. A stream not in it has no row — no "last fetched", no gap detection, and nothing turns red if it starts failing. Adding a stream to sync does not require touching this table, so the two lists drift apart silently. `weight` is now there, as `Occasional` rather than `Daily`: a weigh-in happens when someone steps on a scale, and a week without one is not a fault to paint red.

## 3. (already fixed in #52) `BODY_COMPOSITION_METRICS` vs `BODY_METRICS`

Caught at the time and covered by a test — but it is the same failure mode, which is why the tests below aim at the class rather than the instances.

## Three tests, each aimed at the class

- **`every_metric_the_contract_promises_can_be_charted`** — list against list; the next metric added without registering it turns the build red.
- **`weight_samples_come_back_as_a_series`** — being listed is not enough. A wrong `MetricSource` queries the wrong table and comes back just as empty, so this one inserts real samples and reads them back, asserting source, unit and latest value.
- **`every_synced_stream_appears_on_the_health_page`** — the eight stream names sync actually emits, written out explicitly. Not grepped from source: that would produce a test that looks like it checks something and always passes.

The first two were confirmed to fail without the fix — removing the `weight` row makes one report `["weight"]` under "stored but not chartable" and the other fail on the count.

## The verification #52 should have had

Real build artifacts, a fake `__TAURI_INTERNALS__` feeding fixtures, whole Body status page walked through. The project's `index.html` is untouched — `dist` is copied to a scratch directory and the copy is patched.

| | metric | imperial |
|---|---|---|
| 体重 | 67.8 kg (avg 68.3, min 67.8, max 68.9, "4 days in 30") | **149.5 lb** |
| BMI | 22.1, **no unit** — a ratio reads the same either way | 22.1 |
| 身高 | 175.0 cm | **68.9 in** |
| body fat / muscle / bone | "no records in the last 30 days", subtitle "needs a body-composition scale" | units switch to lb |

Also ran the exact 11 metrics `BodyStatus.vue` requests against a copy of a real library: all 11 come back (ten were being silently dropped), with `被静默跳过的: []`. The body-composition rows are empty there because that account has no scale — a fact about the account, not a failure.

## Checks

- `cargo test --workspace` — 357 passed (3 new)
- `cargo fmt --check`, `cargo clippy -D warnings` — clean
- `npm run build / test / test:functions / i18n:check / docs:check / version:check / budget:check` — all pass

## Before the release

Two of these three would have shipped to the four people who asked for scale support, and they would have seen exactly what they saw before: nothing. The pattern is worth naming — a feature is not done when the data is in the database, it is done when it reaches the screen. Worth holding the release until a scale owner confirms real body-composition data end to end, since my account has no scale and cannot prove that half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
