### PR TITLE
feat(开放平台): 登记 Zepp 回调地址，两个接口一律拒收

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,8 @@ target/
 
 # Local data and database files
 data/
+!functions/api/zepp/data/
+!functions/api/zepp/data/callback.js
 *.db
 *.db-*
 *.sqlite
@@ -66,6 +68,8 @@ data/
 *.sqlite3-*
 
 # Credentials and local configuration
+.dev.vars
+.dev.vars.*
 .env
 .env.*
 !.env.example

--- a/functions/api/zepp/data/callback.js
+++ b/functions/api/zepp/data/callback.js
@@ -1,0 +1,28 @@
+import { callbackResponse } from '../../../../server/zepp/callback-response.js';
+
+export function onRequest({ request }) {
+  if (request.method === 'POST' || (
+    (request.method === 'GET' || request.method === 'HEAD') && new URL(request.url).search
+  )) {
+    // Do not acknowledge delivery before authenticated durable ingestion exists.
+    // Deliberately leave the body unread; no health data is parsed or persisted.
+    return callbackResponse(request, {
+      error: 'data_ingestion_not_enabled',
+      message: 'ZeppBridge data ingestion is not enabled yet. No data was accepted.',
+    }, 503, { 'Retry-After': '3600' });
+  }
+
+  if (request.method !== 'GET' && request.method !== 'HEAD') {
+    return callbackResponse(request, { error: 'method_not_allowed' }, 405, {
+      Allow: 'GET, HEAD, POST',
+    });
+  }
+
+  return callbackResponse(request, {
+    service: 'ZeppBridge',
+    endpoint: 'data_callback',
+    status: 'registration_only',
+    dataIngestionEnabled: false,
+    message: 'Callback endpoint is deployed. Zepp data ingestion is not enabled yet.',
+  });
+}

--- a/functions/api/zepp/oauth/callback.js
+++ b/functions/api/zepp/oauth/callback.js
@@ -1,0 +1,27 @@
+import { callbackResponse } from '../../../../server/zepp/callback-response.js';
+
+export function onRequest({ request }) {
+  if (request.method !== 'GET' && request.method !== 'HEAD') {
+    return callbackResponse(request, { error: 'method_not_allowed' }, 405, {
+      Allow: 'GET, HEAD',
+    });
+  }
+
+  // A bare URL is a reachability check, not an authorization attempt.
+  // Until the full state/session + token-exchange flow exists, reject ALL
+  // callback parameters. Do not read env, exchange codes, redirect, or log them.
+  if (new URL(request.url).search) {
+    return callbackResponse(request, {
+      error: 'oauth_not_enabled',
+      message: 'ZeppBridge authorization is not enabled yet. No authorization was completed. Please close this page.',
+    }, 503, { 'Retry-After': '3600' });
+  }
+
+  return callbackResponse(request, {
+    service: 'ZeppBridge',
+    endpoint: 'authorization_callback',
+    status: 'registration_only',
+    oauthEnabled: false,
+    message: 'Callback endpoint is deployed. Zepp authorization is not enabled yet.',
+  });
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "vue-tsc --noEmit && vite build",
     "build:web": "vite build",
     "test:feedback": "node --test tests/feedback-function.test.mjs",
-    "test:functions": "node --test tests/dialog-capability.test.mjs tests/feedback-function.test.mjs tests/release-function.test.mjs",
+    "test:functions": "node --test tests/dialog-capability.test.mjs tests/feedback-function.test.mjs tests/release-function.test.mjs tests/zepp-callback-functions.test.mjs",
     "preview": "vite preview",
     "tauri": "tauri",
     "package:release": "pwsh -NoProfile -File scripts/windows/package-release.ps1",

--- a/scripts/verify/zepp-callback-smoke.mjs
+++ b/scripts/verify/zepp-callback-smoke.mjs
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict';
+
+const base = new URL(process.argv[2] ?? 'https://zeppbridge.pages.dev');
+assert.ok(base.protocol === 'https:' || (base.protocol === 'http:' && base.hostname === '127.0.0.1'));
+assert.ok(base.hostname === '127.0.0.1' || /^(?:[a-z0-9-]+\.)?zeppbridge\.pages\.dev$/.test(base.hostname));
+assert.ok(!base.username && !base.password && base.pathname === '/' && !base.search && !base.hash);
+
+const cases = [
+  ['/api/zepp/oauth/callback', 'GET', 200, 'authorization_callback'],
+  ['/api/zepp/data/callback', 'GET', 200, 'data_callback'],
+  ['/api/zepp/oauth/callback/', 'GET', 200, 'authorization_callback'],
+  ['/api/zepp/data/callback/', 'GET', 200, 'data_callback'],
+  ['/api/zepp/oauth/callback', 'HEAD', 200],
+  ['/api/zepp/data/callback', 'HEAD', 200],
+  ['/api/zepp/oauth/callback?code=synthetic-smoke-only&state=synthetic-smoke-only', 'GET', 503, 'oauth_not_enabled'],
+  ['/api/zepp/oauth/callback?error=access_denied', 'GET', 503, 'oauth_not_enabled'],
+  ['/api/zepp/data/callback?challenge=synthetic-smoke-only', 'GET', 503, 'data_ingestion_not_enabled'],
+  ['/api/zepp/data/callback', 'POST', 503, 'data_ingestion_not_enabled'],
+  ['/api/zepp/oauth/callback', 'POST', 405, 'method_not_allowed'],
+  ['/api/zepp/data/callback', 'OPTIONS', 405, 'method_not_allowed'],
+  ['/api/zepp/data/callback', 'PUT', 405, 'method_not_allowed'],
+];
+
+const results = [];
+for (const [path, method, expected, identifier] of cases) {
+  const response = await fetch(new URL(path, base), {
+    method,
+    redirect: 'manual',
+    signal: AbortSignal.timeout(30_000),
+    ...(method === 'POST' ? { body: '[]', headers: { 'Content-Type': 'text/plain' } } : {}),
+  });
+  const label = `${method} ${path.split('?')[0]}`;
+  assert.equal(response.status, expected, label);
+  assert.equal(response.headers.get('cache-control'), 'no-store', label);
+  assert.equal(response.headers.get('referrer-policy'), 'no-referrer', label);
+  assert.equal(response.headers.get('x-content-type-options'), 'nosniff', label);
+  assert.match(response.headers.get('content-type'), /^application\/json/, label);
+  assert.match(response.headers.get('content-security-policy'), /default-src 'none'/, label);
+  const body = await response.text();
+  assert.ok(!body.includes('synthetic-smoke-only'), `${label}: reflected input`);
+  if (method === 'HEAD') {
+    assert.equal(body, '', label);
+  } else {
+    const payload = JSON.parse(body);
+    assert.equal(payload.endpoint ?? payload.error, identifier, label);
+    if (expected === 200) {
+      assert.equal(payload.status, 'registration_only', label);
+      assert.equal(payload.oauthEnabled ?? payload.dataIngestionEnabled, false, label);
+    }
+  }
+  results.push({ method, path: path.split('?')[0], status: response.status, queryTest: path.includes('?') });
+}
+
+// Read-only regression checks: never submit a feedback report during smoke.
+const homepage = await fetch(base, { signal: AbortSignal.timeout(30_000) });
+assert.equal(homepage.status, 200);
+const html = await homepage.text();
+assert.match(html, /ZeppBridge/);
+const modulePath = html.match(/<script[^>]*type="module"[^>]*src="([^"]+)"/);
+assert.ok(modulePath, 'Homepage module entry is missing');
+const entry = await fetch(new URL(modulePath[1], base), { signal: AbortSignal.timeout(30_000) });
+assert.equal(entry.status, 200);
+assert.match(entry.headers.get('content-type'), /javascript/);
+const feedback = await fetch(new URL('/api/feedback', base), { signal: AbortSignal.timeout(30_000) });
+assert.equal(feedback.status, 405);
+assert.equal((await feedback.json()).error, 'method_not_allowed');
+console.log(JSON.stringify({ baseUrl: base.origin, callbacks: results, homepage: 'ok', module: 'ok', feedback: 'ok' }, null, 2));

--- a/server/zepp/callback-response.js
+++ b/server/zepp/callback-response.js
@@ -1,0 +1,15 @@
+// Registration-only callbacks must never reflect codes, tokens, or payloads.
+export function callbackResponse(request, payload, status = 200, extraHeaders = {}) {
+  return new Response(request.method === 'HEAD' ? null : JSON.stringify(payload), {
+    status,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': 'no-store',
+      'Referrer-Policy': 'no-referrer',
+      'X-Content-Type-Options': 'nosniff',
+      'X-Robots-Tag': 'noindex, nofollow, noarchive',
+      'Content-Security-Policy': "default-src 'none'; frame-ancestors 'none'; base-uri 'none'",
+      ...extraHeaders,
+    },
+  });
+}

--- a/tests/zepp-callback-functions.test.mjs
+++ b/tests/zepp-callback-functions.test.mjs
@@ -1,0 +1,106 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { onRequest as oauthCallback } from '../functions/api/zepp/oauth/callback.js';
+import { onRequest as dataCallback } from '../functions/api/zepp/data/callback.js';
+
+const endpoints = [
+  { handler: oauthCallback, path: '/api/zepp/oauth/callback', name: 'authorization_callback', flag: 'oauthEnabled', allow: 'GET, HEAD' },
+  { handler: dataCallback, path: '/api/zepp/data/callback', name: 'data_callback', flag: 'dataIngestionEnabled', allow: 'GET, HEAD, POST' },
+];
+
+function invoke(endpoint, method = 'GET', query = '', body) {
+  const request = new Request(`https://zeppbridge.pages.dev${endpoint.path}${query}`, {
+    method, body,
+  });
+  // Fail if these registration-only handlers ever access a secret, database,
+  // background task, or static fallback.
+  const context = new Proxy({ request }, {
+    get(target, key) {
+      assert.equal(key, 'request', `Unexpected context access: ${String(key)}`);
+      return target.request;
+    },
+  });
+  return { request, response: endpoint.handler(context) };
+}
+
+for (const endpoint of endpoints) {
+  test(`${endpoint.name}: GET advertises registration-only status`, async () => {
+    const { response } = invoke(endpoint);
+    assert.equal(response.status, 200);
+    const payload = await response.json();
+    assert.equal(payload.service, 'ZeppBridge');
+    assert.equal(payload.endpoint, endpoint.name);
+    assert.equal(payload.status, 'registration_only');
+    assert.equal(payload[endpoint.flag], false);
+  });
+
+  test(`${endpoint.name}: HEAD is bodyless`, async () => {
+    const { response } = invoke(endpoint, 'HEAD');
+    assert.equal(response.status, 200);
+    assert.equal(await response.text(), '');
+  });
+
+  test(`${endpoint.name}: unexpected methods do not fall through to the SPA`, async () => {
+    for (const method of ['OPTIONS', 'PUT', 'PATCH', 'DELETE']) {
+      const { response } = invoke(endpoint, method);
+      assert.equal(response.status, 405);
+      assert.equal(response.headers.get('allow'), endpoint.allow);
+      assert.deepEqual(await response.json(), { error: 'method_not_allowed' });
+    }
+  });
+
+  test(`${endpoint.name}: headers protect all response paths`, () => {
+    for (const [method, query] of [['GET', ''], ['HEAD', ''], ['GET', '?code=fixture-secret'], ['POST', ''], ['OPTIONS', '']]) {
+      const { response } = invoke(endpoint, method, query);
+      assert.equal(response.headers.get('cache-control'), 'no-store');
+      assert.equal(response.headers.get('referrer-policy'), 'no-referrer');
+      assert.equal(response.headers.get('x-content-type-options'), 'nosniff');
+      assert.match(response.headers.get('content-type'), /^application\/json; charset=utf-8$/);
+      assert.match(response.headers.get('content-security-policy'), /default-src 'none'/);
+      assert.match(response.headers.get('x-robots-tag'), /noindex/);
+      assert.equal(response.headers.get('access-control-allow-origin'), null);
+      assert.equal(response.headers.get('location'), null);
+      assert.equal(response.headers.get('set-cookie'), null);
+    }
+  });
+
+  test(`${endpoint.name}: query parameters are never echoed or treated as success`, async (context) => {
+    context.mock.method(globalThis, 'fetch', () => assert.fail('Unexpected outbound request'));
+    for (const query of [
+      '?code=fixture-secret&state=fixture-secret',
+      '?error=access_denied&error_description=fixture-secret',
+      '?access_token=fixture-secret',
+      '?challenge=fixture-secret',
+      '?code=&code=fixture-secret',
+      '?redirect_uri=https://example.test/fixture-secret',
+    ]) {
+      const { response } = invoke(endpoint, 'GET', query);
+      assert.equal(response.status, 503);
+      assert.equal(response.headers.get('retry-after'), '3600');
+      assert.doesNotMatch(await response.text(), /fixture-secret/);
+      const head = invoke(endpoint, 'HEAD', query).response;
+      assert.equal(head.status, 503);
+      assert.equal(await head.text(), '');
+    }
+  });
+}
+
+test('OAuth POST is rejected without consuming credentials', async () => {
+  const { request, response } = invoke(endpoints[0], 'POST', '', 'code=fixture-secret');
+  assert.equal(response.status, 405);
+  assert.equal(request.bodyUsed, false);
+  assert.doesNotMatch(await response.text(), /fixture-secret/);
+});
+
+test('data POST is never acknowledged or consumed, even for empty or malformed payloads', async (context) => {
+  context.mock.method(globalThis, 'fetch', () => assert.fail('Unexpected outbound request'));
+  for (const body of [undefined, '', '[]', 'not-json', '["{\\"userId\\":\\"fixture-secret\\"}"]', 'x'.repeat(1_000_000)]) {
+    const { request, response } = invoke(endpoints[1], 'POST', '', body);
+    assert.equal(response.status, 503);
+    assert.equal(request.bodyUsed, false);
+    const payload = await response.json();
+    assert.equal(payload.error, 'data_ingestion_not_enabled');
+    assert.doesNotMatch(JSON.stringify(payload), /fixture-secret/);
+  }
+});


### PR DESCRIPTION
Zepp 开放平台的开发者资格已下来，控制台里填的两个回调地址是：

- `https://zeppbridge.pages.dev/api/zepp/oauth/callback`
- `https://zeppbridge.pages.dev/api/zepp/data/callback`

这个 PR 把支撑这两个地址的代码放进仓库。**它们现在只证明地址活着，并拒收一切真实流量。**

## 为什么必须进 git

Pages 的部署走 `deploy-cloudflare-pages.yml`，从 `main` 检出后 `wrangler pages deploy dist`，Functions 取自仓库根的 `functions/`。这两个文件此前只在本地，下一次手动触发部署就会让两个路由消失——而 Zepp 正在审核这两个地址。

`package.json` 把 `tests/zepp-callback-functions.test.mjs` 加进了 `test:functions`，CI 会跑它，所以测试文件和这行改动必须同一个 PR 落地。

## 行为

| 请求 | 响应 |
|---|---|
| 裸 URL 的 GET / HEAD | 200，`status: registration_only`，`oauthEnabled/dataIngestionEnabled: false` |
| 带任何查询参数（code / state / error / challenge） | 503 + `Retry-After: 3600` |
| 往数据口 POST | 503，**body 完全不读** |
| 其他方法 | 405 + `Allow` |

拒收是刻意的。数据口读了 body 就等于收下，而收下却没落库，对面会认为推送成功不再重发；没有持久化能力之前，唯一诚实的回答是「我没收」。

## 安全边界

- 无 Client ID / Secret / token，无数据库绑定，无可误开的环境变量开关。测试用 Proxy 包住 context，除 `request` 外任何属性访问直接断言失败——将来有人顺手接上密钥或 D1，测试立刻红。
- 响应统一 `no-store` / `noindex` / `no-referrer` / `CSP default-src 'none'`，且绝不回显请求内容：测试拿 `fixture-secret` 灌进 code、state、error_description、access_token、redirect_uri 逐个反查。
- `.gitignore` 放行 `functions/api/zepp/data/`（它是路由目录，被 `data/` 规则误伤），并挡住 `.dev.vars*`。

## 验证

- `npm run test:functions` — 33 passed
- `scripts/verify/zepp-callback-smoke.mjs` 对已部署站点跑同一组断言，目标主机限死 `zeppbridge.pages.dev` 或 `127.0.0.1`
- 线上现状实测：两个地址均返回 200 `registration_only`

🤖 Generated with [Claude Code](https://claude.com/claude-code)