### PR TITLE
chore(release): 2.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,6 @@ temp/
 
 # OS
 Thumbs.db
+
+# 本机 mock 验收目录：真实库的副本 + 造出来的体成分/饮食数据，不进仓库
+mock-test/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 本文件记录每个版本的实际改动。写给使用者看，不是施工日志：只写用户能感知到的变化，以及为什么这么改。
 
+## 2.2.0
+
+### Added / 新增
+
+- **The food log has a screen.** Calories, protein, fat and carbs now appear under Body status, alongside a dietary-balance ring showing what share of your calories each macronutrient contributed. Meals are logged by hand in the Zepp App, so the days you did not log stay blank: they get no bar, and are never filled with a zero. The percentages are worked out here from the daily grams using 4/9/4 kcal per gram — they are not sent by the cloud, and may differ by a point or two from the ones in the Zepp App.
+- **饮食有界面了。** 热量、蛋白质、脂肪、碳水现在出现在「身体状态」页里，上面还有一张膳食平衡环，显示三大营养素各自贡献了多少热量。饮食是在 Zepp App 里手动记的，所以没记的日子就留空：不画柱子，也绝不补 0。占比是这里用 4/9/4（每克千卡）从克数推算的，不是云端给的数，和 Zepp App 里的百分比可能差一两个点。
+
+- **Weight and body composition.** Weigh-ins now sync and land in the local library, read from the endpoint that actually carries them. Eleven readings are accepted where a scale reports them — weight, BMI, height, body fat, body water, muscle, bone, protein, visceral fat, basal metabolism and balance score. Only weight, BMI and height have been confirmed against a live account; the rest are gated by a plausible range for that specific reading, because publishing a health number under a guessed field name is worse than publishing nothing. The device catalogue now knows the scale as a product category too.
+- **体重与体成分。** 称重记录现在会同步并入本机库，读的是真正带着这些数据的那个接口。有秤的账号最多能收下十一项：体重、BMI、身高、体脂率、体水分率、肌肉量、骨量、蛋白质率、内脏脂肪、基础代谢、体态平衡分。其中只有体重、BMI、身高在真实账号上核对过；其余每一项都要落在只有它才可能出现的数值区间里才会被采用——用猜来的字段名发布一个健康读数，比不发布更糟。设备目录也收录了体脂秤这个品类。
+- **The `.fit` files carry more, and carry it right.** Kilometre laps are real splits now instead of one lap for the whole workout, and the laps your watch recorded with its own lap button come through as well — that field sat in 32 of 336 stored workout details and had never been decoded. Nutrition and strength-training load reach the file too, so Strava, Garmin Connect and Intervals.icu read what they expect.
+- **`.fit` 文件里的东西更全，也更对。** 公里分段现在是真的分段，而不是整条运动只有一圈；手表上你自己按圈键记的圈也一并带出来了——那个字段在 336 条留存的运动明细里有 32 条带着，从来没人解过它。营养和力量训练负荷也进了文件，Strava、Garmin Connect、Intervals.icu 读到的就是它们期待的东西。
+
+### Changed / 变化
+
+- **Cards with nothing in them no longer take up the screen.** Without a body-composition scale, Body status used to show nine identical "no records" cards, and an account that never logged a meal added four more — thirteen cards all saying the same thing, pushing everything that did have data off the screen. Empty cards are now left out, and when a whole group is empty one line explains why. Nothing is filled in with zeros; the missing readings are simply not restated thirteen times.
+- **没有内容的卡片不再占着屏幕。** 没有体脂秤时，「身体状态」页会显示九张一模一样的「无记录」卡片，没记过饮食的账号再加四张——十三张说着同一句话，把真正有数据的东西挤到了屏幕外。现在空卡片直接不显示，整组都空时用一句话说明原因。没有补 0，只是不再把「缺」重复十三遍。
+
+### Fixes / 修复
+
+- **The app could start with no window you could see.** The initial window size was derived from the monitor work area with no lower bound, and a work area of `0x0` — which remote desktop sessions, monitor hot-plug and the moment before a display is ready all report — produced a negative width that the window accepted. What you got was a tray icon, a running process, and nothing to click. The same release also stops the app re-syncing from scratch on every launch.
+- **应用可能开起来却看不见窗口。** 初始窗口尺寸是按显示器工作区算的，没有下界；而工作区报成 `0x0` 是真会发生的——远程桌面、显示器热插拔、显示器还没准备好的那一瞬间都会。算出来是个负的宽度，而窗口把它收下了。你看到的就是：托盘有图标、进程在跑、点了没反应。同一版还修掉了每次启动都从头重新同步一遍。
+- **The command line says where it looked.** Someone spent two hours over four rounds on [#40](https://github.com/lingcang728/ZeppBridge/issues/40) because nothing ever said which folder was being used: running the CLI from a build directory redirects the data folder to the repository root, which is the right rule and was completely silent. Every "not found" now names the resolved path, and explains why the data is not next to the executable when that is the case. "No account connected" is also split in two — a missing `auth.json` and a missing token are different problems, and that user had already done the half he was being told to do again.
+- **命令行会说出它去哪儿找了。** [#40](https://github.com/lingcang728/ZeppBridge/issues/40) 那位用户花了两小时、来回四轮，卡的全是我们没说话：从构建目录里跑 CLI 会把数据目录重定向到仓库根，这条规则本身是对的，但程序一个字都没说。现在每一条「找不到」都带上解析出来的路径，该说的时候还会说明数据为什么不在 exe 旁边。「没有连接账号」也拆成了两句——缺 `auth.json` 和缺令牌是两回事，而那位用户被叫去做的，正是他已经做过的那一半。
+- **The weight feature reached the screens it was supposed to.** The readings were stored and exportable, but the charts skipped them and the data-health page did not list the stream at all — the same fact living in several lists with nothing cross-checking them, invisible at every checkpoint that was actually looked at.
+- **体重终于到达了它本该到达的那几个界面。** 数据入了库、导得出来，但图表跳过了它们，数据健康页上那条流干脆不存在——同一件事登记在好几份名单里，彼此没有交叉校验，于是在每一个真正去看的检查点上都是「正常」。
+- **The command line no longer hangs instead of reporting an error.** Any failure raised after the database was opened — an unrecognised `--types`, an invalid date, a `--workout` that does not exist, a failed sync — left `zeppbridge-cli` spinning at 100% CPU and never returning, instead of printing the message and exiting with its documented code. A scheduled job that hit one of these would hang forever rather than fail. Exit codes are a contract; this one broke it silently.
+- **命令行不会再卡死在报错的地方。** 凡是数据库打开之后抛出来的错误——`--types` 不认识、日期非法、`--workout` 不存在、同步失败——`zeppbridge-cli` 都会 100% 占满一个核心永不返回，而不是印出错误再按契约的退出码退出。定时任务撞上这些会永远挂着，而不是失败。退出码是契约，这个 bug 无声地把它毁了。
+- **Food records can be exported.** `--types food` was silently dropped: intake data was stored and could be charted, but not a single row came out of an export. Worse, a catch-all branch could sweep intake into `daily_activity` — calories eaten and calories burned are opposite things, and mixing them under one type reads the food you ate as energy you spent.
+- **饮食能导出了。** `--types food` 会被静默丢掉：摄入数据入了库、画得出图，导出却一条都没有。更糟的是有个兜底分支会把摄入扫进 `daily_activity`——吃进去的热量和消耗掉的热量是相反的两件事，混在同一个类型下，就是把吃的读成了烧的。
+
 ## 2.1.2
 
 ### Added / 新增

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -1,6 +1,6 @@
 # ZeppBridge architecture summary
 
-This page describes the product boundaries and current implementation of v2.1.2.
+This page describes the product boundaries and current implementation of v2.2.0.
 For the usage entry point see the project [README](../../README.md); for
 engineering gates see the [development guide](../development/development.md).
 

--- a/docs/reference/architecture.zh-CN.md
+++ b/docs/reference/architecture.zh-CN.md
@@ -2,7 +2,7 @@
 
 [English](architecture.md)
 
-本文描述 v2.1.2 的产品边界与当前实现。使用入口见项目 [README](../../README.zh-CN.md)，工程门禁见 [开发文档](../development/development.zh-CN.md)。
+本文描述 v2.2.0 的产品边界与当前实现。使用入口见项目 [README](../../README.zh-CN.md)，工程门禁见 [开发文档](../development/development.zh-CN.md)。
 
 ## 产品边界
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zeppbridge",
   "private": true,
-  "version": "2.1.2",
+  "version": "2.2.0",
   "type": "module",
   "engines": {
     "node": ">=22"

--- a/packaging/flatpak/com.zeppbridge.app.metainfo.xml
+++ b/packaging/flatpak/com.zeppbridge.app.metainfo.xml
@@ -79,7 +79,7 @@
   <content_rating type="oars-1.1"/>
 
   <releases>
-    <release version="2.1.2" date="2026-09-03"/>
+    <release version="2.2.0" date="2026-09-03"/>
     <release version="2.1.1" date="2026-09-03"/>
   </releases>
 </component>

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6232,7 +6232,7 @@ dependencies = [
 
 [[package]]
 name = "zeppbridge"
-version = "2.1.2"
+version = "2.2.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6261,7 +6261,7 @@ dependencies = [
 
 [[package]]
 name = "zeppbridge-cli"
-version = "2.1.2"
+version = "2.2.0"
 dependencies = [
  "chrono",
  "serde",
@@ -6272,7 +6272,7 @@ dependencies = [
 
 [[package]]
 name = "zeppbridge-core"
-version = "2.1.2"
+version = "2.2.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6299,7 +6299,7 @@ dependencies = [
 
 [[package]]
 name = "zeppbridge-mcp"
-version = "2.1.2"
+version = "2.2.0"
 dependencies = [
  "chrono",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,7 +31,7 @@ zeppbridge-core = { path = "crates/core" }
 
 [package]
 name = "zeppbridge"
-version = "2.1.2"
+version = "2.2.0"
 description = "本地优先的 Zepp 健康数据桥"
 authors = ["ZeppBridge"]
 edition = "2021"

--- a/src-tauri/crates/cli/Cargo.toml
+++ b/src-tauri/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeppbridge-cli"
-version = "2.1.2"
+version = "2.2.0"
 description = "ZeppBridge 命令行：给 Task Scheduler / cron / agent 用的无交互入口"
 edition = "2021"
 

--- a/src-tauri/crates/cli/src/main.rs
+++ b/src-tauri/crates/cli/src/main.rs
@@ -304,10 +304,17 @@ fn exit_code_for(error: &ZeppBridgeError) -> (u8, &'static str) {
 ///
 /// 所以在这里做一次语言边界：认得的错误出英文，认不得的仍然回落到原文——
 /// 看不懂的中文也好过一句空白，而回落的范围会随着核心那边逐条挪走而缩小。
+///
+/// 回落分支必须是 `Display`（`to_string()`），**不能是 `user_text(other)`**。
+/// 那样写传的是同一个值，条件永远成立，就是一个无条件自递归；release 把尾调用
+/// 优化成循环，于是不是栈溢出而是 100% CPU 空转，整条命令再也不返回。
+/// 它骗过了所有门禁：`unconditional_recursion` 因为上面那支会返回而不报，
+/// 类型和 clippy 都挑不出毛病，而测试从来没有断言过「错误路径会结束」。
+/// 下面 `every_error_renders_and_terminates` 就是补这个洞的。
 fn user_text(error: &ZeppBridgeError) -> String {
     match error {
         ZeppBridgeError::Headless(problem) => problem.english(),
-        other => user_text(other),
+        other => other.to_string(),
     }
 }
 
@@ -1244,6 +1251,38 @@ mod tests {
 
     fn args(values: &[&str]) -> Vec<String> {
         values.iter().map(|value| value.to_string()).collect()
+    }
+
+    /// 每一种错误都要能渲染出一句话，并且**渲染这件事本身要结束**。
+    ///
+    /// 之前 `user_text` 的回落分支写成了 `user_text(other)`——同一个值再传给
+    /// 自己，无条件自递归。release 把尾调用优化成循环，于是命令行不是崩掉而是
+    /// 100% CPU 空转、永不返回：`export --types food`、非法日期、不存在的
+    /// `--workout`，凡是数据库打开之后抛出来的错误，全都卡死在这里，而退出码
+    /// 是写进文档的契约，调度脚本会永远挂着。
+    ///
+    /// 只有 `Headless` 那一支会返回，所以 `status` 报「库还是 v20」看起来是好的
+    /// ——这也是它躲过人工验收的原因。这个用例走的是**非** Headless 的那些支。
+    #[test]
+    fn every_error_renders_and_terminates() {
+        // 卡死时这个用例会挂住而不是失败，那也是信号：CI 超时即回归。
+        let cases = vec![
+            ZeppBridgeError::ConfigError("请至少选择一种导出数据".into()),
+            ZeppBridgeError::AuthError("令牌读不出来".into()),
+            ZeppBridgeError::DataUnavailable("本地库里没有这条运动记录".into()),
+            ZeppBridgeError::Cancelled,
+            ZeppBridgeError::HttpStatus {
+                status: 503,
+                message: "维护中".into(),
+            },
+        ];
+        for error in &cases {
+            let text = user_text(error);
+            assert!(
+                !text.trim().is_empty(),
+                "{error:?} 渲染成了空字符串——命令行会印出一片空白"
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/crates/core/Cargo.toml
+++ b/src-tauri/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeppbridge-core"
-version = "2.1.2"
+version = "2.2.0"
 description = "ZeppBridge 的共享数据核心：模型、存储、迁移、归一化、查询、导出与写入协调"
 edition = "2021"
 

--- a/src-tauri/crates/core/src/storage/mod.rs
+++ b/src-tauri/crates/core/src/storage/mod.rs
@@ -4603,7 +4603,7 @@ impl Database {
         // 日级数据流：一条运动没有「昨晚睡了多久」这种字段，硬塞进来就是范围外的数据。
         // 只在 daily_metrics / sleep_sessions 里出现的类型；心率、HRV、血氧这类
         // 逐点指标不在其中，它们会按运动时段截取后照常导出。
-        const DAY_LEVEL_TYPES: [&str; 9] = [
+        const DAY_LEVEL_TYPES: [&str; 10] = [
             "sleep",
             "steps",
             "daily_activity",
@@ -4615,6 +4615,8 @@ impl Database {
             // 一次称重和某一条运动没有关系。单条运动的导出里不该出现
             // 「体重：0 条」这样一个只会让人困惑的类型。
             "weight",
+            // 一天吃了什么和某一条运动同样没有关系，理由同上。
+            "food",
         ];
         let allowed: BTreeSet<&str> = [
             "heart_rate",
@@ -4633,6 +4635,10 @@ impl Database {
             "training_load",
             "vo2max",
             "weight",
+            // 饮食一度只登记在能力表（`CapabilityEvidence::DailyPrefix("intake_")`）
+            // 里，却从来没进过这张允许表：`--types food` 被静默丢掉，摄入数据
+            // 入了库、能画图、却导不出来。
+            "food",
         ]
         .into_iter()
         .collect();
@@ -4797,7 +4803,8 @@ impl Database {
                 || selected.contains("spo2")
                 || selected.contains("stress")
                 || selected.contains("training_load")
-                || selected.contains("vo2max"))
+                || selected.contains("vo2max")
+                || selected.contains("food"))
         {
             let mut stmt = self.conn.prepare(
                 "SELECT date, metric, value, unit, source_scope, device_id
@@ -4847,6 +4854,11 @@ impl Database {
                     Some("hrv_rmssd")
                 } else if is_recovery && selected.contains("recovery") {
                     Some("recovery")
+                } else if metric.starts_with("intake_") {
+                    // 必须排在 `daily_activity` 兜底之前。摄入的热量和活动消耗
+                    // 的热量是相反的两件事，被兜底扫进「日常活动」就会让读者
+                    // 把吃进去的算成烧掉的。没选 food 就整条不导，而不是改标。
+                    selected.contains("food").then_some("food")
                 } else if !is_recovery && selected.contains("daily_activity") {
                     Some("daily_activity")
                 } else {
@@ -7044,6 +7056,91 @@ mod tests {
             .build_ai_export(&export_selection(types, detail))
             .unwrap();
         serde_json::from_str(&encoded).unwrap()
+    }
+
+    /// 饮食能导出，而且不会被「日常活动」兜底扫走。
+    ///
+    /// `food` 一度只登记在能力表里，从来没进过导出的允许类型表：`--types food`
+    /// 被静默丢掉，摄入数据入了库、画得出图、却一条都导不出来。更糟的是那个
+    /// `daily_activity` 兜底分支——它会把没被认领的日级指标全收下，包括
+    /// `intake_*`。摄入的热量和活动消耗的热量是相反的两件事，混进同一个类型
+    /// 就是把吃进去的算成烧掉的。
+    #[test]
+    fn food_is_exportable_and_never_folded_into_daily_activity() {
+        let db = Database::in_memory().unwrap();
+        for (metric, value, unit) in [
+            ("intake_calories", 2100.0, "kcal"),
+            ("intake_protein_g", 120.0, "g"),
+            ("intake_fat_g", 70.0, "g"),
+            ("intake_carbs_g", 210.0, "g"),
+        ] {
+            db.insert_daily_metric(&DailyMetric {
+                date: "2023-11-05".into(),
+                metric: metric.into(),
+                value,
+                unit: unit.into(),
+                source_scope: SourceScope::UserFused,
+                device_id: None,
+            })
+            .unwrap();
+        }
+        // 同一天的活动消耗，用来证明两者没有混在一起。
+        db.insert_daily_metric(&DailyMetric {
+            date: "2023-11-05".into(),
+            metric: "active_calories".into(),
+            value: 480.0,
+            unit: "千卡".into(),
+            source_scope: SourceScope::UserFused,
+            device_id: None,
+        })
+        .unwrap();
+
+        let names = |export: &serde_json::Value| -> Vec<String> {
+            export["data"]["daily_metrics"]
+                .as_array()
+                .map(|rows| {
+                    rows.iter()
+                        .map(|row| row["metric"].as_str().unwrap_or_default().to_string())
+                        .collect()
+                })
+                .unwrap_or_default()
+        };
+
+        let food = parsed_export(&db, &["food"], ExportDetail::Summary);
+        let exported = names(&food);
+        for metric in [
+            "intake_calories",
+            "intake_protein_g",
+            "intake_fat_g",
+            "intake_carbs_g",
+        ] {
+            assert!(
+                exported.iter().any(|name| name == metric),
+                "--types food 没导出 {metric}；导出的是 {exported:?}"
+            );
+        }
+        assert!(
+            !exported.iter().any(|name| name == "active_calories"),
+            "选了 food 却把活动消耗也带出来了"
+        );
+        assert_eq!(
+            food["capabilities"]["food"]["status"], "available",
+            "有摄入记录时 food 必须是 available"
+        );
+
+        let activity = names(&parsed_export(
+            &db,
+            &["daily_activity"],
+            ExportDetail::Summary,
+        ));
+        assert!(
+            activity.iter().any(|name| name == "active_calories"),
+            "日常活动本身还得导得出来"
+        );
+        assert!(
+            !activity.iter().any(|name| name.starts_with("intake_")),
+            "摄入被兜底扫进了 daily_activity：{activity:?}"
+        );
     }
 
     #[test]

--- a/src-tauri/crates/core/src/storage/mod.rs
+++ b/src-tauri/crates/core/src/storage/mod.rs
@@ -2831,6 +2831,16 @@ impl Database {
             "DELETE FROM workout_splits WHERE workout_id = ?1",
             [workout_id],
         )?;
+        // 圈也要先清掉。**这一条一度漏了**，而这个函数叫 `replace_`：
+        // `workout_laps` 是和圈一起加进来的新表，它和上面几张一样没有唯一
+        // 索引——那几张不出问题，靠的正是这里的 DELETE。漏掉它，每重放一次
+        // 圈就翻一倍（本机实测 341 → 682，341 组 (workout_id, lap_index)
+        // 一个不落全是两份），`.fit` 里每圈导两遍，界面上每圈列两行。
+        // 第一次重放看起来完全正常，所以它只会在下一次推修订号时才爆出来。
+        self.conn.execute(
+            "DELETE FROM workout_laps WHERE workout_id = ?1",
+            [workout_id],
+        )?;
 
         {
             let mut insert = self.conn.prepare(
@@ -6580,6 +6590,58 @@ mod tests {
         // 然后把圈清掉：旧版本解不出 `lap`，所以旧库里这张表是空的。v22 的
         // 重放要能把它们补回来，这正是要验的事。
         db.conn.execute("DELETE FROM workout_laps", []).unwrap();
+    }
+
+    /// 重放两次，派生行不能变成两份。
+    ///
+    /// `replace_workout_series` 清空四张表再重新插入，唯独漏了 v22 新加的
+    /// `workout_laps`。这几张表都没有唯一索引——不出问题靠的就是那几条
+    /// DELETE，所以漏一张就是纯追加。本机实测一次全库重放把 341 圈变成了
+    /// 682，341 组 `(workout_id, lap_index)` 一个不落全是两份。
+    ///
+    /// 骗过所有人的地方在于**第一次重放是对的**：2.1.2 升上来的人拿到的圈
+    /// 是准的，要等下一次推修订号才翻倍。所以这里数的是「重放第二次之后」，
+    /// 而不是「重放之后」。四张表一起数，下次再加派生表时这个用例会一起把
+    /// 它盖住。
+    #[test]
+    fn replaying_twice_does_not_duplicate_derived_rows() {
+        let db = Database::in_memory().unwrap();
+        insert_workout_with_lap_detail(&db);
+        let counts = || -> Vec<(String, i64)> {
+            [
+                "workout_laps",
+                "workout_splits",
+                "workout_samples",
+                "workout_pauses",
+            ]
+            .into_iter()
+            .map(|table| {
+                let n = db
+                    .conn
+                    .query_row(&format!("SELECT COUNT(*) FROM {table}"), [], |row| {
+                        row.get::<_, i64>(0)
+                    })
+                    .unwrap();
+                (table.to_string(), n)
+            })
+            .collect()
+        };
+
+        db.reprocess_raw_records().unwrap();
+        let after_first = counts();
+        assert!(
+            after_first
+                .iter()
+                .any(|(table, n)| table == "workout_laps" && *n == 2),
+            "夹具本身要能解出两圈，否则这个用例什么都没验：{after_first:?}"
+        );
+
+        db.reprocess_raw_records().unwrap();
+        assert_eq!(
+            counts(),
+            after_first,
+            "重放第二次之后派生行变多了——某张表漏了 replace 前的 DELETE"
+        );
     }
 
     #[test]

--- a/src-tauri/crates/mcp/Cargo.toml
+++ b/src-tauri/crates/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeppbridge-mcp"
-version = "2.1.2"
+version = "2.2.0"
 description = "ZeppBridge MCP 服务：只读、stdio、不监听任何端口"
 edition = "2021"
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ZeppBridge",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "identifier": "com.zeppbridge.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/App.vue
+++ b/src/App.vue
@@ -83,7 +83,7 @@ const t = useMessages(messages);
 
 // 桌面端从 Tauri 运行时读取版本（与 tauri.conf.json 单一来源），
 // 浏览器预览环境回退到下面的常量（与 package.json 保持同步）。
-const FALLBACK_APP_VERSION = '2.1.2';
+const FALLBACK_APP_VERSION = '2.2.0';
 /* 构建标识。同一个版本号会构建很多次，光看版本号分不清手上是哪一个。 */
 const BUILD_STAMP = __BUILD_STAMP__;
 const APP_VERSION = ref(FALLBACK_APP_VERSION);

--- a/src/components/MetricTrendCard.vue
+++ b/src/components/MetricTrendCard.vue
@@ -44,6 +44,10 @@ const props = withDefaults(defineProps<{
   band?: string | null;
   /** Shown in place of the chart when nothing has been measured. */
   emptyText?: string;
+  /** Bars instead of a line, for values counted per day rather than sampled. */
+  chart?: 'line' | 'bar';
+  /** Keep the days with no reading on the axis. See `buildSeriesOption`. */
+  calendarAxis?: boolean;
 }>(), {
   decimals: 0,
   showSpread: false,
@@ -85,6 +89,8 @@ const option = computed(() => {
     showSpread: props.showSpread,
     format: render.value,
     unit: props.unit,
+    chart: props.chart,
+    calendarAxis: props.calendarAxis,
   });
 });
 </script>

--- a/src/lib/__tests__/metricSeries.test.ts
+++ b/src/lib/__tests__/metricSeries.test.ts
@@ -96,3 +96,38 @@ describe('图表选项', () => {
     expect(line?.data).toHaveLength(2);
   });
 });
+
+describe('手动记录的日子不能被画成连续的', () => {
+  const logged = series({
+    metric: 'intake_calories',
+    unit: 'kcal',
+    window_days: 30,
+    days_with_data: 3,
+    // 记了 1 号、2 号，跳过 3 号和 4 号，再记 5 号。
+    points: [
+      { date: '2026-03-01', value: 2100 },
+      { date: '2026-03-02', value: 1980 },
+      { date: '2026-03-05', value: 2260 },
+    ],
+    latest: { date: '2026-03-05', value: 2260 },
+  } as Partial<MetricSeries>);
+
+  it('默认那条轴根本没有缺的日子——所以线会直接连过去', () => {
+    // 这不是断言「应该这样」，是把现状钉住：默认轴只放有值的日子，
+    // 3 号和 4 号不是 null，是压根不存在。体重这种天天称的还好，
+    // 手动记录的必须开 calendarAxis。
+    const option = buildSeriesOption(logged, { color: '#fff' });
+    expect(option.xAxis).toMatchObject({ data: ['2026-03-01', '2026-03-02', '2026-03-05'] });
+  });
+
+  it('开了 calendarAxis，没记的日子在轴上留空', () => {
+    const option = buildSeriesOption(logged, { color: '#fff', chart: 'bar', calendarAxis: true });
+    expect(option.xAxis).toMatchObject({
+      data: ['2026-03-01', '2026-03-02', '2026-03-03', '2026-03-04', '2026-03-05'],
+    });
+    const [bars] = option.series as Array<{ type: string; data: Array<number | null> }>;
+    expect(bars.type).toBe('bar');
+    // 缺的两天是 null，不是 0：没记不等于没吃。
+    expect(bars.data).toEqual([2100, 1980, null, null, 2260]);
+  });
+});

--- a/src/lib/echartsSetup.ts
+++ b/src/lib/echartsSetup.ts
@@ -11,7 +11,10 @@
  * 那样会绕开注册，拿到一个没有 series 类型也没有主题的空图。
  */
 import { registerTheme, use } from 'echarts/core';
-import { BarChart, LineChart } from 'echarts/charts';
+// 加新图形时**必须**同时加进下面的 `use()`。漏了不会报错、不会警告，只会
+// 得到一张空画布——膳食平衡那个环就是这么空了一版：百分比算对了、卡片和
+// 说明都在，中间什么都没有。
+import { BarChart, LineChart, PieChart } from 'echarts/charts';
 import {
   GridComponent,
   LegendComponent,
@@ -26,6 +29,7 @@ import { zeppThemeDark } from './echartsTheme';
 use([
   LineChart,
   BarChart,
+  PieChart,
   GridComponent,
   TooltipComponent,
   LegendComponent,

--- a/src/lib/metricSeries.ts
+++ b/src/lib/metricSeries.ts
@@ -95,7 +95,34 @@ export interface SeriesChartOptions {
   /** Format a value for the tooltip; defaults to a fixed-decimal number. */
   format?: (value: number) => string;
   unit?: string;
+  /** Bars instead of a line. For values that are counted per day, not sampled. */
+  chart?: 'line' | 'bar';
+  /**
+   * Put every calendar day between the first and last reading on the axis,
+   * including the ones with no reading.
+   *
+   * Off by default the axis holds **only the days that carry a value**, so two
+   * readings a week apart sit in neighbouring slots and the line runs straight
+   * between them — the missing days are not drawn as gaps, they are not drawn
+   * at all. For something measured most days that is a small distortion. For
+   * something logged by hand it is not: it turns "I logged 51 of these 60 days"
+   * into a picture of an unbroken habit.
+   */
+  calendarAxis?: boolean;
 }
+
+/** Every ISO day from `first` to `last`, inclusive. */
+const calendarSpan = (first: string, last: string): string[] => {
+  const start = new Date(`${first}T00:00:00Z`);
+  const end = new Date(`${last}T00:00:00Z`);
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime()) || end < start) return [];
+  const days: string[] = [];
+  // 一年半的窗口最多 ~550 天，直接展开即可。
+  for (let day = start; day <= end; day = new Date(day.getTime() + 86_400_000)) {
+    days.push(day.toISOString().slice(0, 10));
+  }
+  return days;
+};
 
 const hexToRgba = (hex: string, alpha: number): string => {
   const parsed = /^#?([0-9a-f]{6})$/i.exec(hex.trim());
@@ -105,11 +132,16 @@ const hexToRgba = (hex: string, alpha: number): string => {
 };
 
 /**
- * A daily line, drawn only where days actually carry values.
+ * A daily line (or bars), drawn only where days actually carry values.
  *
  * `connectNulls` stays off deliberately. A gap in the data is a gap on the
  * chart: joining across a fortnight of silence would draw a trend that was
  * never measured.
+ *
+ * That promise only holds with `calendarAxis`. Without it the axis is built
+ * from the points themselves, so a missing day is not a null — it is simply
+ * absent, and the line closes over it as if the days were adjacent. Anything
+ * recorded by hand should pass `calendarAxis: true`.
  */
 export const buildSeriesOption = (
   series: MetricSeries,
@@ -117,19 +149,33 @@ export const buildSeriesOption = (
 ): Record<string, unknown> => {
   const decimals = options.decimals ?? 0;
   const format = options.format ?? ((value: number) => value.toFixed(decimals));
-  const dates = series.points.map((point) => point.date);
-  const values = series.points.map((point) => point.value);
-  const hasSpread =
-    Boolean(options.showSpread)
-    && series.points.some((point) => typeof point.min === 'number' && typeof point.max === 'number');
-
-  const spreadBase = series.points.map((point) => (typeof point.min === 'number' ? point.min : null));
-  const spreadHeight = series.points.map((point) =>
-    typeof point.min === 'number' && typeof point.max === 'number' ? point.max - point.min : null);
+  const bar = options.chart === 'bar';
 
   const byDate = new Map<string, MetricSeriesPoint>(
     series.points.map((point) => [point.date, point]),
   );
+
+  // 有值的日子是数据；轴上多出来的日子是 null，`connectNulls: false` 让线断开、
+  // 让柱子缺席。两种画法下「那天没有记录」都不会被画成一个值。
+  const dates = options.calendarAxis && series.points.length
+    ? calendarSpan(series.points[0].date, series.points[series.points.length - 1].date)
+    : series.points.map((point) => point.date);
+  const at = (date: string) => byDate.get(date) ?? null;
+  const values = dates.map((date) => at(date)?.value ?? null);
+  const hasSpread =
+    Boolean(options.showSpread)
+    && series.points.some((point) => typeof point.min === 'number' && typeof point.max === 'number');
+
+  const spreadBase = dates.map((date) => {
+    const point = at(date);
+    return typeof point?.min === 'number' ? point.min : null;
+  });
+  const spreadHeight = dates.map((date) => {
+    const point = at(date);
+    return typeof point?.min === 'number' && typeof point.max === 'number'
+      ? point.max - point.min
+      : null;
+  });
 
   return {
     animationDuration: 600,
@@ -154,7 +200,7 @@ export const buildSeriesOption = (
     xAxis: {
       type: 'category',
       data: dates,
-      boundaryGap: false,
+      boundaryGap: bar,
       axisLabel: { formatter: shortDate, hideOverlap: true, fontSize: 10 },
       splitLine: { show: false },
     },
@@ -188,16 +234,23 @@ export const buildSeriesOption = (
             },
           ]
         : []),
-      {
-        type: 'line',
-        data: values,
-        smooth: 0.2,
-        connectNulls: false,
-        showSymbol: series.points.length <= 14,
-        symbolSize: 5,
-        itemStyle: { color: options.color },
-        lineStyle: { width: 2, color: options.color, cap: 'round' },
-      },
+      bar
+        ? {
+            type: 'bar',
+            data: values,
+            barMaxWidth: 14,
+            itemStyle: { color: options.color, borderRadius: [2, 2, 0, 0] },
+          }
+        : {
+            type: 'line',
+            data: values,
+            smooth: 0.2,
+            connectNulls: false,
+            showSymbol: series.points.length <= 14,
+            symbolSize: 5,
+            itemStyle: { color: options.color },
+            lineStyle: { width: 2, color: options.color, cap: 'round' },
+          },
     ],
   };
 };

--- a/src/views/BodyStatus.vue
+++ b/src/views/BodyStatus.vue
@@ -27,7 +27,7 @@ const messages = defineMessages(
     backToOverview: '返回概览',
     eyebrow: '身体状态',
     title: '身体状态',
-    intro: '恢复、压力、血氧、HRV、呼吸率、静息心率与体重体成分的本机趋势。全部读自已同步的记录，没有推算。',
+    intro: '恢复、压力、血氧、HRV、呼吸率、静息心率、体重体成分与饮食摄入的本机趋势。全部读自已同步的记录。',
     rangeAria: '时间范围',
     desktopOnly: '请使用桌面应用；浏览器预览不会读取账户数据。',
     loadFailed: '身体状态数据暂时不可用',
@@ -85,12 +85,28 @@ const messages = defineMessages(
     unitGrade: '级',
     unitKcalPerDay: '千卡/天',
     scaleEmpty: '这段范围没有称重记录。体重秤的数据会在同步后出现在这里。',
+    bodyGroupTitle: '体重与体成分',
+    bodyGroupEmpty: '这段范围没有体重或体成分记录。体成分要有体脂秤才会有；手表和手动录入的体重不带这些项。',
+    intakeGroupTitle: '摄入',
+    intakeGroupEmpty: '这段范围没有饮食记录。饮食要在 Zepp App 里手动记，记过之后同步就会出现在这里。',
+    intakeCaloriesLabel: '摄入热量',
+    intakeCaloriesHint: '当天记录的总热量。没记的日子不画柱子，也不补 0',
+    proteinLabel: '蛋白质',
+    fatIntakeLabel: '脂肪',
+    carbsLabel: '碳水',
+    macroHint: '当天记录的总量，按天汇总',
+    unitKcal: '千卡',
+    unitGram: '克',
+    macroTitle: '膳食平衡',
+    macroSub: '这段范围内三大营养素各自贡献的热量占比',
+    macroNote: '占比由每日克数按 4/9/4（蛋白质 / 脂肪 / 碳水，每克千卡）推算，不是云端给的数，和 Zepp App 里的百分比可能差一两个点。三项缺任何一项就不画。',
+    gramsPerDay: (grams: number) => `平均每天 ${grams} 克`,
   },
   {
     backToOverview: 'Back to overview',
     eyebrow: 'Body status',
     title: 'Body status',
-    intro: 'Local trends for readiness, stress, blood oxygen, HRV, respiratory rate, resting heart rate and body composition. All read from synced records, nothing extrapolated.',
+    intro: 'Local trends for readiness, stress, blood oxygen, HRV, respiratory rate, resting heart rate, body composition and food intake. All read from synced records.',
     rangeAria: 'Time range',
     desktopOnly: 'Use the desktop app. This browser preview reads no account data.',
     loadFailed: 'Body status data is unavailable right now',
@@ -148,6 +164,22 @@ const messages = defineMessages(
     unitGrade: 'grade',
     unitKcalPerDay: 'kcal/day',
     scaleEmpty: 'No weigh-ins in this range. Scale readings show up here after a sync.',
+    bodyGroupTitle: 'Weight and body composition',
+    bodyGroupEmpty: 'No weight or body-composition records in this range. Composition readings need a body-composition scale; watch and hand-entered weights carry none.',
+    intakeGroupTitle: 'Intake',
+    intakeGroupEmpty: 'No food records in this range. Meals are logged by hand in the Zepp App; once logged, they appear here after a sync.',
+    intakeCaloriesLabel: 'Calories eaten',
+    intakeCaloriesHint: 'Total logged for the day. Days with no log get no bar, and are never filled with 0',
+    proteinLabel: 'Protein',
+    fatIntakeLabel: 'Fat',
+    carbsLabel: 'Carbs',
+    macroHint: 'Total logged for the day',
+    unitKcal: 'kcal',
+    unitGram: 'g',
+    macroTitle: 'Dietary balance',
+    macroSub: 'Share of calories each macronutrient contributed over this range',
+    macroNote: 'Shares are derived here from the daily grams using 4/9/4 kcal per gram (protein / fat / carbs). They are not sent by the cloud and may differ by a point or two from the percentages in the Zepp App. Nothing is drawn unless all three are present.',
+    gramsPerDay: (grams: number) => `${grams} g per day on average`,
   },
 );
 const t = useMessages(messages);
@@ -163,6 +195,8 @@ interface BodyCard {
   decimals?: number;
   showSpread?: boolean;
   emptyText?: string;
+  chart?: 'line' | 'bar';
+  calendarAxis?: boolean;
   /**
    * 显示前的换算。只有体重系需要：库里一律是千克和厘米（导出契约不变），
    * 界面按用户选的单位制显示。返回 `undefined` 表示不换算。
@@ -175,7 +209,7 @@ interface BodyCard {
  * presentation, not collection. The list is fixed so the backend can refuse
  * any name it does not have a unit for.
  */
-const METRICS = [
+const VITALS_METRICS = [
   'readiness',
   'stress',
   'spo2',
@@ -184,8 +218,18 @@ const METRICS = [
   'hrv_rmssd',
   'respiratory_rate',
   'resting_hr',
-  // 体重与体成分。前三项在真实账号上核对过；后面几项要有体脂秤才会有值，
-  // 没有秤的账号在这里看到的就是空卡片——那是事实，不是故障。
+];
+
+/**
+ * 体重与体成分。前三项在真实账号上核对过；后面几项要有体脂秤才会有值。
+ *
+ * 没有秤的账号**不会**在这里看到九张空卡片。这一版之前是那样的，理由是
+ * 「空卡片是事实，不是故障」——事实没错，但九张一模一样的「近 180 天无记录」
+ * 只是噪音，把真正有数据的东西挤到了屏幕外。现在没有数据的卡片直接不渲染，
+ * 整组都空时留一句话说明为什么。**这不是补 0，也不是隐藏缺失**：缺的值仍然
+ * 是缺的，只是不再用一张卡片来复述一遍。
+ */
+const BODY_METRICS = [
   'weight',
   'bmi',
   'body_fat_rate',
@@ -196,6 +240,24 @@ const METRICS = [
   'bmr',
   'height',
 ];
+
+/**
+ * 饮食。手动记录，所以天然是稀疏的——同样遵守上面那条：没有就不显示。
+ *
+ * 字段名（`calories` / `protein` / `fat` / `carbohydrate`）来自生态而不是我们
+ * 见过的真实报文，所以「一条都没有」在这里是常态，不代表出错。
+ */
+const INTAKE_METRICS = ['intake_calories', 'intake_protein_g', 'intake_fat_g', 'intake_carbs_g'];
+
+const METRICS = [...VITALS_METRICS, ...BODY_METRICS, ...INTAKE_METRICS];
+
+type CardGroup = 'vitals' | 'body' | 'intake';
+
+const groupOf = (metric: string): CardGroup => {
+  if (INTAKE_METRICS.includes(metric)) return 'intake';
+  if (BODY_METRICS.includes(metric)) return 'body';
+  return 'vitals';
+};
 
 const CARDS = computed<BodyCard[]>(() => [
   {
@@ -341,6 +403,44 @@ const CARDS = computed<BodyCard[]>(() => [
     decimals: 1,
     convert: toBodyHeight,
   },
+  // 摄入。柱状而不是折线，而且轴上保留没记的日子：手动记录一周漏两天是常态，
+  // 折线会把中间那两天连成一条看不出断点的线，读起来像天天都记了。
+  {
+    metric: 'intake_calories',
+    label: t.value.intakeCaloriesLabel,
+    hint: t.value.intakeCaloriesHint,
+    color: zeppSemanticColors.calories,
+    unit: t.value.unitKcal,
+    chart: 'bar',
+    calendarAxis: true,
+  },
+  {
+    metric: 'intake_protein_g',
+    label: t.value.proteinLabel,
+    hint: t.value.macroHint,
+    color: zeppSemanticColors.stride,
+    unit: t.value.unitGram,
+    chart: 'bar',
+    calendarAxis: true,
+  },
+  {
+    metric: 'intake_fat_g',
+    label: t.value.fatIntakeLabel,
+    hint: t.value.macroHint,
+    color: zeppSemanticColors.altitude,
+    unit: t.value.unitGram,
+    chart: 'bar',
+    calendarAxis: true,
+  },
+  {
+    metric: 'intake_carbs_g',
+    label: t.value.carbsLabel,
+    hint: t.value.macroHint,
+    color: zeppSemanticColors.pace,
+    unit: t.value.unitGram,
+    chart: 'bar',
+    calendarAxis: true,
+  },
 ]);
 
 const ranges = computed(() => seriesRanges());
@@ -388,6 +488,87 @@ const cards = computed(() => {
   }));
 });
 const anyData = computed(() => cards.value.some((card) => (card.series?.points.length ?? 0) > 0));
+
+/**
+ * 只留这段范围里真的有读数的卡片。
+ *
+ * 没有体脂秤的账号以前会看到九张「近 180 天无记录」，没记过饮食的账号会再看到
+ * 四张——十三张说着同一句话的卡片。缺失仍然是缺失，只是不再逐张复述：整组都
+ * 空时下面用一句话说明为什么，而不是把它伪装成有内容。
+ */
+const withData = (group: CardGroup) => cards.value
+  .filter((card) => groupOf(card.metric) === group && (card.series?.points.length ?? 0) > 0);
+
+const vitalsCards = computed(() => cards.value.filter((card) => groupOf(card.metric) === 'vitals'));
+const bodyCards = computed(() => withData('body'));
+const intakeCards = computed(() => withData('intake'));
+
+/**
+ * 三大营养素各自贡献了多少热量。
+ *
+ * Zepp App 的「Food Trend Report」第一张卡就是这个环形图（碳水 / 蛋白质 /
+ * 脂肪的百分比），所以这里跟着画。但那边的百分比是华米自己算的，这里的是
+ * **我们**用 4/9/4（阿特沃特系数）从克数换算的——两边可能差一两个点，这不是
+ * 谁错了，是两套算法。卡片上如实写明是推算。
+ *
+ * 三项克数缺任何一项就不画：拿两项算百分比会得到一个看着像真的、其实没有
+ * 意义的数。
+ */
+const ENERGY_PER_GRAM = { protein: 4, fat: 9, carbs: 4 } as const;
+
+const macroSplit = computed(() => {
+  const average = (metric: string): number | null => {
+    const value = series.value[metric]?.average;
+    return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : null;
+  };
+  const protein = average('intake_protein_g');
+  const fat = average('intake_fat_g');
+  const carbs = average('intake_carbs_g');
+  if (protein === null || fat === null || carbs === null) return null;
+  const energy = {
+    carbs: carbs * ENERGY_PER_GRAM.carbs,
+    protein: protein * ENERGY_PER_GRAM.protein,
+    fat: fat * ENERGY_PER_GRAM.fat,
+  };
+  const total = energy.carbs + energy.protein + energy.fat;
+  if (!(total > 0)) return null;
+  return {
+    total,
+    slices: [
+      { key: 'carbs', label: t.value.carbsLabel, value: energy.carbs, grams: carbs, color: zeppSemanticColors.pace },
+      { key: 'protein', label: t.value.proteinLabel, value: energy.protein, grams: protein, color: zeppSemanticColors.stride },
+      { key: 'fat', label: t.value.fatIntakeLabel, value: energy.fat, grams: fat, color: zeppSemanticColors.altitude },
+    ].map((slice) => ({ ...slice, percent: Math.round((slice.value / total) * 100) })),
+  };
+});
+
+const macroChartOption = computed(() => {
+  const split = macroSplit.value;
+  if (!split) return null;
+  return {
+    animationDuration: 600,
+    tooltip: {
+      trigger: 'item',
+      formatter: (params: { name: string; percent: number; data: { grams: number } }) =>
+        `${params.name}<br><b>${params.percent}%</b>　${t.value.gramsPerDay(Math.round(params.data.grams))}`,
+    },
+    series: [
+      {
+        type: 'pie',
+        radius: ['58%', '82%'],
+        avoidLabelOverlap: false,
+        label: { show: false },
+        labelLine: { show: false },
+        data: split.slices.map((slice) => ({
+          name: slice.label,
+          value: slice.value,
+          grams: slice.grams,
+          itemStyle: { color: slice.color },
+        })),
+      },
+    ],
+  };
+});
 
 /*
  * 全天压力曲线。
@@ -586,7 +767,7 @@ watch(dataRevision, () => { void load(); });
 
       <div class="card-grid">
         <MetricTrendCard
-          v-for="card in cards"
+          v-for="card in vitalsCards"
           :key="card.metric"
           :label="card.label"
           :hint="card.hint"
@@ -598,6 +779,72 @@ watch(dataRevision, () => { void load(); });
           :empty-text="card.emptyText ?? t.emptyCard"
         />
       </div>
+
+      <!-- 体重与体成分。没有秤的账号这里只有一句话，而不是九张空卡片。 -->
+      <h2 class="group-title">{{ t.bodyGroupTitle }}</h2>
+      <p v-if="!bodyCards.length" class="inline-alert" role="status">
+        <Icon name="info" :size="14" />{{ t.bodyGroupEmpty }}
+      </p>
+      <div v-else class="card-grid">
+        <MetricTrendCard
+          v-for="card in bodyCards"
+          :key="card.metric"
+          :label="card.label"
+          :hint="card.hint"
+          :series="card.series"
+          :color="card.color"
+          :unit="card.unit"
+          :decimals="card.decimals ?? 0"
+          :show-spread="card.showSpread ?? false"
+          :empty-text="card.emptyText ?? t.emptyCard"
+        />
+      </div>
+
+      <!-- 摄入。同一条规则：没记过饮食就只有一句话。 -->
+      <h2 class="group-title">{{ t.intakeGroupTitle }}</h2>
+      <p v-if="!intakeCards.length" class="inline-alert" role="status">
+        <Icon name="info" :size="14" />{{ t.intakeGroupEmpty }}
+      </p>
+      <template v-else>
+        <section v-if="macroChartOption" class="surface-card day-card" :aria-label="t.macroTitle">
+          <header class="day-head">
+            <div>
+              <h2>{{ t.macroTitle }}</h2>
+              <p>{{ t.macroSub }}</p>
+            </div>
+            <dl class="day-stats">
+              <div v-for="slice in macroSplit?.slices ?? []" :key="slice.key">
+                <dt>{{ slice.label }}</dt>
+                <dd :style="{ color: slice.color }">{{ slice.percent }}%</dd>
+              </div>
+            </dl>
+          </header>
+          <VChart
+            class="macro-chart"
+            theme="zeppbridge-dark"
+            :option="macroChartOption"
+            autoresize
+            role="img"
+            :aria-label="t.macroTitle"
+          />
+          <p class="curve-note">{{ t.macroNote }}</p>
+        </section>
+        <div class="card-grid">
+          <MetricTrendCard
+            v-for="card in intakeCards"
+            :key="card.metric"
+            :label="card.label"
+            :hint="card.hint"
+            :series="card.series"
+            :color="card.color"
+            :unit="card.unit"
+            :decimals="card.decimals ?? 0"
+            :chart="card.chart"
+            :calendar-axis="card.calendarAxis ?? false"
+            :empty-text="card.emptyText ?? t.emptyCard"
+          />
+        </div>
+      </template>
     </template>
   </section>
 </template>
@@ -629,6 +876,8 @@ watch(dataRevision, () => { void load(); });
 /* 区间边界是手表给的，不是我们算的。不写清楚，它就会被当成又一套自选算法。 */
 .curve-note { margin: 10px 0 0; color: var(--subtle); font-size: 11px; line-height: 1.6; }
 .card-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: var(--space-4); }
+.group-title { margin: var(--space-5) 0 0; font-size: 15px; font-weight: 700; color: var(--ink); }
+.macro-chart { height: 200px; }
 .inline-alert {
   display: flex;
   align-items: center;


### PR DESCRIPTION
把 2.1.2 之后合进 `main` 的六个 PR 打包成 2.2.0：

| PR | 内容 |
|---|---|
| #51 | 启动稳定性：窗口算不出尺寸就打不开、每次启动都重新同步 |
| #52 | 体脂秤 / 体成分接上正确的云端接口并入库，设备目录收录该品类 |
| #53 | FIT 补齐缺的字段（海拔 / 功率 / 步幅 / 心率区间 / 训练效果）、公里圈数、接上饮食记录 |
| #54 | CLI「找不到」时说清楚去哪儿找了、缺的是哪一半 |
| #55 | 手表自己记的圈进 .fit；无头环境报错改英文 |
| #56 | 体重和饮食那两组指标补登记进 `SERIES_METRICS`，数据健康页补上体重流 |

版本号八处统一，`Cargo.lock` 里四个 workspace 成员跟着更新。

## ⚠️ 先别合 —— 等本机验收

便携版已在本机构建好，等 @lingcang728 自己跑一遍（前端、后端、界面、新功能）确认没问题，再合这个 PR 并打 tag。

- `release\ZeppBridge.exe` FileVersion / ProductVersion 自证为 **2.2.0**
- `zeppbridge-cli.exe --version` → `zeppbridge-cli 2.2.0`
- 旧的 2.1.2 留成 `ZeppBridge.exe.prev-2.1.2`，验收通过后再删
- 桌面与开始菜单快捷方式已指向 portable exe，工作目录 `release\`
- 已清掉 `release\ZeppBridge_2.1.2_x64-setup.exe` 与过期 `latest.json`

## 门禁

- `npm run build`（vue-tsc）✅
- `npm run budget:check` ✅ 首屏 83.4 kB / 上限 97.0 kB
- `npm run icons:verify` ✅
- `npm run version:check` ✅ 全部一致 2.2.0
- `cargo fmt --check` / `clippy -D warnings` / `test --workspace`：见评论

🤖 Generated with [Claude Code](https://claude.com/claude-code)