### PR TITLE
fix(ui): improve readability and accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@
 
 ### Changed / 变化
 
+- **The interface is readable at a normal desktop viewing distance.** Body text went from 13px to 16.5px and the small print — secondary labels, chart axes, legends, metadata — from 8–11px up to 11–14.5px. Secondary greys were lifted until every one of them clears WCAG AA on every surface it is used on (the darkest tier failed at 2.0:1 and is gone), the neutral surfaces were darkened for a further contrast lift, chart axis labels and grid lines came up with them, and the emphasis weights that the fonts could not actually render are now real. Green and red states — better/worse deltas, connection status — carry a symbol as well as a colour, so they still read without colour vision. If this is now too large, Settings → Interface scale goes back down.
+- **界面在正常的桌面视距下读得清了。** 正文从 13px 提到 16.5px，小字——次要标签、图表坐标轴、图例、元信息——从 8–11px 提到 11–14.5px。次要灰色全部抬到在它实际出现的每一种底色上都过 WCAG AA（最暗的那一档只有 2.0:1，已经删掉），中性底色也调暗来进一步拉开对比，图表的坐标轴文字和网格线一并跟上，字体根本渲染不出来的那几档字重也换成了真能生效的。绿/红状态——变好变坏的差值、连接状态——除了颜色还带一个符号，色觉障碍下照样读得出来。如果觉得反而太大了，设置 →「界面缩放」可以调回去。
+
 - **Cards with nothing in them no longer take up the screen.** Without a body-composition scale, Body status used to show nine identical "no records" cards, and an account that never logged a meal added four more — thirteen cards all saying the same thing, pushing everything that did have data off the screen. Empty cards are now left out, and when a whole group is empty one line explains why. Nothing is filled in with zeros; the missing readings are simply not restated thirteen times.
 - **没有内容的卡片不再占着屏幕。** 没有体脂秤时，「身体状态」页会显示九张一模一样的「无记录」卡片，没记过饮食的账号再加四张——十三张说着同一句话，把真正有数据的东西挤到了屏幕外。现在空卡片直接不显示，整组都空时用一句话说明原因。没有补 0，只是不再把「缺」重复十三遍。
 

--- a/docs/development/ui-guidelines.md
+++ b/docs/development/ui-guidelines.md
@@ -1,15 +1,14 @@
 # ZeppBridge UI design and interaction constraints
 
-Updated 2026-08-25 (aligned with the second UI round: the body-status and
-training-status pages, the heart-rate zone selector, the export data-stream
-selector). ZeppBridge is a bridge to the user's wearable health data, not a
-bloated analytics app.
+Updated 2026-09-05 (aligned with the accessibility and readability pass).
+ZeppBridge is a bridge to the user's wearable health data, not a bloated
+analytics app.
 
 [简体中文](ui-guidelines.zh-CN.md)
 
 The visual system is **cool grey with olive green**, dark throughout: brand
-colour `--brand: #7DA33E`, interface base `#131519` (sidebar `#0F1114`, cards
-`#1D2026`). No ubiquitous purple, no high-saturation neon. Category colours
+colour `--brand: #7DA33E`, interface base `#0C0E11` (sidebar `#08090C`, cards
+`#16191E`). No ubiquitous purple, no high-saturation neon. Category colours
 (heart-rate red, pace blue, sleep violet, activity cyan and so on) mark data
 categories only; they are never decoration.
 
@@ -49,12 +48,13 @@ panel are a deliberate local exception).
 
 | Purpose | Token |
 | --- | --- |
-| Layer backgrounds | `--bg` `#131519` / `--sidebar` `#0F1114` / `--canvas` `#14161A` / `--surface` `#1D2026` / `--surface-raised` `#24272F` / `--surface-hover` `#2C3039` |
-| Text | `--ink` `#F2F4EE` / `--muted` `#9AA1A9` / `--subtle` `#6E757D` / `--faint` `#4B5158` |
-| Strokes | `--line` / `--line-strong` (both low-opacity cool white) |
+| Layer backgrounds | `--bg` `#0C0E11` / `--sidebar` `#08090C` / `--canvas` `#0D0F12` / `--surface` `#16191E` / `--surface-raised` `#1D2128` / `--surface-hover` `#262B33` |
+| Text | `--ink` `#F2F4EE` / `--muted` `#B4BBC3` / `--subtle` `#949CA5` / `--faint` aliases `--subtle` |
+| Strokes | `--line` / `--line-strong` for quiet structure; `--line-control` for interactive boundaries |
+| Type scale | `--fs-2xs` 13px / `--fs-xs` 14.5px / `--fs-sm` 15.5px / `--fs-md` 16.5px / `--fs-lg` 17.5px / `--fs-xl` 18.5px / `--fs-2xl` 20px / `--fs-3xl` 22px |
 | Brand and actions | `--brand` `#7DA33E` = `--accent`, plus `--accent-hover` `#93B952`, `--accent-soft`, `--accent-ink` `#12170A`, `--action-green` |
 | Category colours | `--heart` `#F0616A`, `--pace` / `--cadence` `#4AA8E8`, `--calories` `#F5860B`, `--altitude` `#F5C33B`, `--activity` `#2BB3C0`, `--training` / `--readiness` `#3DD84C`, each with a translucent `*-wash` |
-| Sleep stages | `--sleep-deep` `#4458B8` / `--sleep-light` `#7C8FF0` / `--sleep-rem` `#8B5CF6` / `--sleep-awake` `#E8833A` |
+| Sleep stages | `--sleep-deep` `#6477D7` / `--sleep-light` `#7C8FF0` / `--sleep-rem` `#8B5CF6` / `--sleep-awake` `#E8833A` |
 | Status | `--danger` `#F0616A`, `--warning` `#F5C33B`, `--focus` `#7DA33E` |
 | Route pace spectrum | `--route-neutral` / `-mint` / `-cyan` / `-amber` / `-coral` |
 | Spacing / radius | `--space-1…8`, `--radius-sm` 10px / `-md` 14px / `-lg` 18px |
@@ -115,11 +115,11 @@ forbidden. The provenance of the algorithms and percentages is in the
   400 / 500 / 600 / 700), defined in `src/styles/fonts.css`.
 - `--font-sans: 'MiSans', 'Segoe UI', 'Microsoft YaHei UI', sans-serif`;
   `--font-mono: 'Cascadia Code', ...` for every numeric value.
-- Chinese never uses the 500 / 600 intermediate weights (MiSans ships only
-  400/700, and an intermediate triggers blurry faux-bold). Hierarchy comes from
-  size and brightness instead.
+- MiSans ships only 400 and 700. Use 400 for body copy and request 600 for
+  emphasis roles; font matching resolves 600 to the bundled bold face. Do not
+  use 500 because it resolves down to regular and adds no emphasis.
 - Numbers are always monospaced with `tabular-nums`, so nothing jumps on
-  refresh. The base is `font-size: 13px`.
+  refresh. The body base is `--fs-md: 16.5px`.
 
 ## Page structure
 

--- a/docs/development/ui-guidelines.zh-CN.md
+++ b/docs/development/ui-guidelines.zh-CN.md
@@ -2,9 +2,9 @@
 
 [English](ui-guidelines.md)
 
-更新时间：2026-08-25（对齐第二轮 UI：身体状态 / 训练状态两页、心率区间选择器、导出数据流选择器）。ZeppBridge 是用户的穿戴健康数据桥梁，不是臃肿的分析 App。
+更新时间：2026-09-05（对齐无障碍与可读性调整）。ZeppBridge 是用户的穿戴健康数据桥梁，不是臃肿的分析 App。
 
-视觉是**冷灰底 + 橄榄绿**的暗色系统：品牌色 `--brand: #7DA33E`，界面底色 `#131519`（侧栏 `#0F1114`、卡片 `#1D2026`），不使用泛滥的紫色或高饱和荧光色。分类色（心率红、配速蓝、睡眠紫、活动青等）只用于标记数据类别，不作装饰。
+视觉是**冷灰底 + 橄榄绿**的暗色系统：品牌色 `--brand: #7DA33E`，界面底色 `#0C0E11`（侧栏 `#08090C`、卡片 `#16191E`），不使用泛滥的紫色或高饱和荧光色。分类色（心率红、配速蓝、睡眠紫、活动青等）只用于标记数据类别，不作装饰。
 
 界面**只有深色一套**，这是已定的取舍，见下方「只做深色」。
 
@@ -25,12 +25,13 @@
 
 | 用途 | token |
 | --- | --- |
-| 层级底色 | `--bg` `#131519` / `--sidebar` `#0F1114` / `--canvas` `#14161A` / `--surface` `#1D2026` / `--surface-raised` `#24272F` / `--surface-hover` `#2C3039` |
-| 文字 | `--ink` `#F2F4EE` / `--muted` `#9AA1A9` / `--subtle` `#6E757D` / `--faint` `#4B5158` |
-| 描边 | `--line` / `--line-strong`（都是低透明度冷白） |
+| 层级底色 | `--bg` `#0C0E11` / `--sidebar` `#08090C` / `--canvas` `#0D0F12` / `--surface` `#16191E` / `--surface-raised` `#1D2128` / `--surface-hover` `#262B33` |
+| 文字 | `--ink` `#F2F4EE` / `--muted` `#B4BBC3` / `--subtle` `#949CA5` / `--faint` 复用 `--subtle` |
+| 描边 | `--line` / `--line-strong` 用于安静的结构线，`--line-control` 用于交互控件边界 |
+| 字号阶梯 | `--fs-2xs` 13px / `--fs-xs` 14.5px / `--fs-sm` 15.5px / `--fs-md` 16.5px / `--fs-lg` 17.5px / `--fs-xl` 18.5px / `--fs-2xl` 20px / `--fs-3xl` 22px |
 | 品牌与动作 | `--brand` `#7DA33E` = `--accent`，`--accent-hover` `#93B952`、`--accent-soft`、`--accent-ink` `#12170A`、`--action-green` |
 | 分类色 | `--heart` `#F0616A`、`--pace` / `--cadence` `#4AA8E8`、`--calories` `#F5860B`、`--altitude` `#F5C33B`、`--activity` `#2BB3C0`、`--training` / `--readiness` `#3DD84C`，各自配 `*-wash` 半透明底 |
-| 睡眠阶段 | `--sleep-deep` `#4458B8` / `--sleep-light` `#7C8FF0` / `--sleep-rem` `#8B5CF6` / `--sleep-awake` `#E8833A` |
+| 睡眠阶段 | `--sleep-deep` `#6477D7` / `--sleep-light` `#7C8FF0` / `--sleep-rem` `#8B5CF6` / `--sleep-awake` `#E8833A` |
 | 状态 | `--danger` `#F0616A`、`--warning` `#F5C33B`、`--focus` `#7DA33E` |
 | 轨迹配速色谱 | `--route-neutral` / `-mint` / `-cyan` / `-amber` / `-coral` |
 | 间距 / 圆角 | `--space-1…8`、`--radius-sm` 10px / `-md` 14px / `-lg` 18px |
@@ -65,8 +66,8 @@
 
 - 打包字体：MiSans（中文，仅 400 / 700）+ Inter（拉丁与数字，400 / 500 / 600 / 700），定义在 `src/styles/fonts.css`。
 - `--font-sans: 'MiSans', 'Segoe UI', 'Microsoft YaHei UI', sans-serif`；`--font-mono: 'Cascadia Code', ...` 用于所有数值。
-- 中文不使用 500 / 600 中间字重（MiSans 只打包了 400/700，用中间值会触发伪粗体发糊），层级靠字号与明度划分。
-- 数值一律等宽 + `tabular-nums`，避免刷新时跳动。基准 `font-size: 13px`。
+- MiSans 只打包了 400 / 700。正文用 400，强调角色写 600，由字体匹配到已打包的粗体；不要写 500，它会向下匹配到常规体，起不到强调作用。
+- 数值一律等宽 + `tabular-nums`，避免刷新时跳动。正文基准是 `--fs-md: 16.5px`。
 
 ## 页面架构
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -185,6 +185,13 @@ const statusTone = computed(() => {
   if (accountRecognized.value) return 'success';
   return 'neutral';
 });
+// 连接状态不能只用颜色区分：图标跟着 tone 换，红绿色觉障碍下也能读出来。
+const statusIcon = computed(() => {
+  if (statusTone.value === 'danger') return 'warning' as const;
+  if (statusTone.value === 'warning') return 'info' as const;
+  if (statusTone.value === 'success') return 'circle-check' as const;
+  return 'info' as const;
+});
 const lastSyncClock = computed(() => {
   const raw = appStatus.value?.last_cloud_sync_at;
   if (!raw) return t.value.notFetchedYet;
@@ -349,7 +356,7 @@ onUnmounted(() => {
           </button>
           <span v-if="statusError" class="sr-only" role="status">{{ statusError }}</span>
           <span :class="['connection-chip', `tone-${statusTone}`]" :title="t.connectionTitle" aria-live="polite">
-            <Icon name="circle-check" :size="14" /><span>{{ deviceStateLabel(statusLabel) }}</span>
+            <Icon :name="statusIcon" :size="15" /><span>{{ deviceStateLabel(statusLabel) }}</span>
           </span>
           <span class="sync-time">{{ t.lastSyncPrefix }}{{ lastSyncClock }}</span>
           <button
@@ -433,18 +440,20 @@ onUnmounted(() => {
 <style>
 :root {
   color-scheme: dark;
-  --bg: #131519;
-  --sidebar: #0F1114;
-  --canvas: #14161A;
-  --surface: #1D2026;
-  --surface-raised: #24272F;
-  --surface-hover: #2C3039;
+  --bg: #0C0E11;
+  --sidebar: #08090C;
+  --canvas: #0D0F12;
+  --surface: #16191E;
+  --surface-raised: #1D2128;
+  --surface-hover: #262B33;
   --ink: #F2F4EE;
-  --muted: #9AA1A9;
-  --subtle: #6E757D;
-  --faint: #4B5158;
-  --line: rgba(226, 234, 242, .07);
-  --line-strong: rgba(226, 234, 242, .14);
+  --muted: #B4BBC3;
+  --subtle: #949CA5;
+  /* 旧的 --faint 在任何表面上都过不了 WCAG AA，退回 --subtle。 */
+  --faint: var(--subtle);
+  --line: rgba(226, 234, 242, .12);
+  --line-control: rgba(226, 234, 242, .46);
+  --line-strong: rgba(226, 234, 242, .22);
   --brand: #7DA33E;
   --accent: var(--brand);
   --accent-hover: #93B952;
@@ -465,7 +474,7 @@ onUnmounted(() => {
   --cadence: #4AA8E8;
   --training: #3DD84C;
   --readiness: #3DD84C;
-  --sleep-deep: #4458B8;
+  --sleep-deep: #6477D7;
   --sleep-light: #7C8FF0;
   --sleep-rem: #8B5CF6;
   --sleep-awake: #E8833A;
@@ -484,6 +493,16 @@ onUnmounted(() => {
   --route-coral: #F0616A;
   --font-sans: 'MiSans', 'Segoe UI', 'Microsoft YaHei UI', sans-serif;
   --font-mono: 'Cascadia Code', 'SFMono-Regular', Consolas, monospace;
+  /* 字号阶梯（设计系统 v5）：默认界面缩放为 100%，通过 token 统一抬高 DOM 字号和图表文字。
+     用户仍可在界面缩放中调整整体大小，半像素值也会随所选缩放一起变化。 */
+  --fs-2xs: 13px;
+  --fs-xs: 14.5px;
+  --fs-sm: 15.5px;
+  --fs-md: 16.5px;
+  --fs-lg: 17.5px;
+  --fs-xl: 18.5px;
+  --fs-2xl: 20px;
+  --fs-3xl: 22px;
   --space-1: 4px;
   --space-2: 8px;
   --space-3: 12px;
@@ -525,7 +544,7 @@ body {
   background: var(--bg);
   color: var(--ink);
   font-family: var(--font-sans);
-  font-size: 13px;
+  font-size: var(--fs-md);
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
@@ -564,8 +583,9 @@ a { color: inherit; }
 
 /* ── 侧边栏 ─────────────────────────────── */
 .sidebar {
-  width: 236px;
-  flex: 0 0 236px;
+  /* 字号抬上去之后 236px 放不下「有近期数据」这类状态文案了，会折成两行。 */
+  width: 280px;
+  flex: 0 0 280px;
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -589,8 +609,8 @@ a { color: inherit; }
   color: var(--accent);
 }
 .brand-text { display: grid; gap: 1px; min-width: 0; }
-.brand-name { font-size: 16px; font-weight: 700; letter-spacing: .01em; }
-.brand-sub { color: var(--subtle); font-size: 11px; }
+.brand-name { font-size: var(--fs-2xl); font-weight: 700; letter-spacing: .01em; }
+.brand-sub { color: var(--subtle); font-size: var(--fs-xs); }
 .desktop-nav { display: grid; gap: 4px; min-width: 0; }
 .nav-link {
   display: flex;
@@ -602,7 +622,7 @@ a { color: inherit; }
   border: 1px solid transparent;
   border-radius: 11px;
   color: var(--muted);
-  font-size: 13px;
+  font-size: var(--fs-md);
   text-decoration: none;
   transition: color 150ms ease, background-color 150ms ease, border-color 150ms ease, transform 150ms ease;
 }
@@ -620,7 +640,7 @@ a { color: inherit; }
 .nav-link.is-active .design-icon { opacity: 1; filter: saturate(1.05); }
 
 .sources { margin-top: 20px; min-width: 0; display: grid; gap: 8px; }
-.sources-feedback { padding: 8px 10px; border: 1px dashed var(--line-strong); border-radius: 9px; color: var(--muted); font-size: 11px; line-height: 1.45; }
+.sources-feedback { padding: 8px 10px; border: 1px dashed var(--line-strong); border-radius: 9px; color: var(--muted); font-size: var(--fs-xs); line-height: 1.45; }
 .sources-feedback.error { color: var(--danger); border-color: rgba(240, 97, 106, .28); }
 .sources-head {
   display: flex;
@@ -628,7 +648,7 @@ a { color: inherit; }
   justify-content: space-between;
   padding: 0 6px;
   color: var(--subtle);
-  font-size: 12px;
+  font-size: var(--fs-sm);
 }
 .sources-head button {
   display: grid;
@@ -648,14 +668,14 @@ a { color: inherit; }
   gap: 12px;
   min-width: 0;
   padding: 11px 12px;
-  border: 1px solid var(--line);
+  border: 1px solid var(--line-control);
   border-radius: var(--radius-md);
   background: var(--surface);
   text-decoration: none;
   color: inherit;
   transition: border-color 150ms ease, background-color 150ms ease;
 }
-.source-card:hover { background: var(--surface-raised); border-color: var(--line-strong); }
+.source-card:hover { background: var(--surface-raised); border-color: var(--line-control); }
 .source-card:hover .source-chevron { color: var(--muted); }
 .source-icon {
   display: grid;
@@ -671,8 +691,8 @@ a { color: inherit; }
 .source-icon :deep(.device-visual) { width: 42px; max-width: 100%; height: 42px; max-height: 100%; min-width: 0; min-height: 0; flex: 0 0 42px; border: 0; border-radius: 11px; background: transparent; }
 .source-icon :deep(.device-visual img) { padding: 3px; }
 .source-copy { display: grid; gap: 2px; min-width: 0; flex: 1; }
-.source-copy strong { font-size: 13px; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.source-state { display: inline-flex; align-items: center; gap: 5px; color: var(--subtle); font-size: 11px; }
+.source-copy strong { font-size: var(--fs-md); font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.source-state { display: inline-flex; min-width: 0; align-items: center; gap: 5px; overflow: hidden; color: var(--subtle); font-size: var(--fs-xs); white-space: nowrap; text-overflow: ellipsis; }
 .source-state .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--subtle); }
 .source-state.on { color: var(--accent); }
 .source-state.on .dot { background: var(--accent); }
@@ -689,7 +709,7 @@ a { color: inherit; }
   display: grid;
   gap: 8px;
 }
-.cloud-row { display: flex; align-items: center; gap: 8px; min-width: 0; font-size: 12px; color: var(--ink); }
+.cloud-row { display: flex; align-items: center; gap: 8px; min-width: 0; font-size: var(--fs-sm); color: var(--ink); }
 .cloud-row svg:first-child { color: var(--muted); }
 .cloud-row span { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .cloud-check { color: var(--faint); }
@@ -703,16 +723,16 @@ a { color: inherit; }
   padding-top: 8px;
   border-top: 1px solid var(--line);
   color: var(--subtle);
-  font-size: 11px;
+  font-size: var(--fs-xs);
 }
 .cloud-account span { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .manage-btn {
   flex: 0 0 auto;
   padding: 2px 10px;
-  border: 1px solid var(--line);
+  border: 1px solid var(--line-control);
   border-radius: 7px;
   color: var(--muted);
-  font-size: 11px;
+  font-size: var(--fs-xs);
   text-decoration: none;
 }
 .manage-btn:hover { color: var(--accent); border-color: var(--accent); }
@@ -723,7 +743,7 @@ a { color: inherit; }
   min-width: 0;
   padding: 0 6px;
   color: var(--subtle);
-  font-size: 11px;
+  font-size: var(--fs-xs);
 }
 .version-row span:nth-child(2) { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .version-brand { display: grid; place-items: center; width: 18px; height: 18px; opacity: .8; }
@@ -762,31 +782,31 @@ a { color: inherit; }
   border-radius: 999px;
   background: var(--surface);
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   white-space: nowrap;
 }
 .connection-chip.tone-success { color: var(--accent); border-color: color-mix(in srgb, var(--accent) 34%, transparent); background: var(--accent-soft); }
 .connection-chip.tone-warning { color: var(--warning); }
 .connection-chip.tone-danger { color: var(--danger); }
-.sync-time { color: var(--muted); font-size: 12px; font-variant-numeric: tabular-nums; white-space: nowrap; }
+.sync-time { color: var(--muted); font-size: var(--fs-sm); font-variant-numeric: tabular-nums; white-space: nowrap; }
 .refresh-btn {
   display: inline-flex;
   align-items: center;
   gap: 6px;
   min-height: 30px;
   padding: 4px 13px;
-  border: 1px solid var(--line-strong);
+  border: 1px solid var(--line-control);
   border-radius: 999px;
   background: var(--surface);
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   cursor: pointer;
   white-space: nowrap;
 }
 .refresh-btn:hover:not(:disabled) { border-color: var(--accent); color: var(--accent); }
 .refresh-btn:disabled { opacity: .5; cursor: not-allowed; }
-.sync-progress-text { display: inline-flex; align-items: center; gap: 8px; color: var(--muted); font-size: 12px; }
-.cancel-link { border: 0; background: transparent; color: var(--accent); font-size: 12px; cursor: pointer; padding: 0; }
+.sync-progress-text { display: inline-flex; align-items: center; gap: 8px; color: var(--muted); font-size: var(--fs-sm); }
+.cancel-link { border: 0; background: transparent; color: var(--accent); font-size: var(--fs-sm); cursor: pointer; padding: 0; }
 .icon-round {
   display: grid;
   place-items: center;
@@ -800,7 +820,7 @@ a { color: inherit; }
 }
 .icon-round:hover { background: var(--surface-hover); color: var(--ink); }
 
-.sync-feedback { display: flex; min-height: 32px; min-width: 0; align-items: center; gap: 7px; padding: 6px 28px; border-bottom: 1px solid var(--line); background: var(--surface); color: var(--muted); font-size: 12px; }
+.sync-feedback { display: flex; min-height: 32px; min-width: 0; align-items: center; gap: 7px; padding: 6px 28px; border-bottom: 1px solid var(--line); background: var(--surface); color: var(--muted); font-size: var(--fs-sm); }
 .sync-feedback.tone-updated { color: var(--accent); }
 .sync-feedback.tone-partial { color: var(--warning); }
 .sync-feedback.tone-no_new_data { color: var(--muted); }
@@ -810,7 +830,7 @@ a { color: inherit; }
 .sync-feedback a { color: inherit; }
 .spinning { animation: spin 900ms linear infinite; }
 @keyframes spin { to { transform: rotate(360deg); } }
-.preview-banner, .route-notice { display: flex; align-items: center; gap: 8px; padding: 9px 28px; border-bottom: 1px solid var(--line); color: var(--muted); font-size: 12px; }
+.preview-banner, .route-notice { display: flex; align-items: center; gap: 8px; padding: 9px 28px; border-bottom: 1px solid var(--line); color: var(--muted); font-size: var(--fs-sm); }
 .preview-banner { background: var(--accent-soft); }
 .preview-banner svg { color: var(--accent); }
 .route-notice { background: var(--surface); color: var(--warning); }
@@ -826,7 +846,7 @@ a { color: inherit; }
 @media (max-width: 760px) {
   .sidebar { display: none; }
   .topbar { height: 56px; padding: 0 16px; }
-  .mobile-menu-button { display: inline-flex; width: 44px; height: 44px; align-items: center; justify-content: center; border: 1px solid var(--line); border-radius: var(--radius-sm); background: transparent; cursor: pointer; }
+  .mobile-menu-button { display: inline-flex; width: 44px; height: 44px; align-items: center; justify-content: center; border: 1px solid var(--line-control); border-radius: var(--radius-sm); background: transparent; cursor: pointer; }
   .sync-time { display: none; }
   .connection-chip { padding-inline: 8px; }
   .connection-chip span { display: none; }
@@ -836,26 +856,26 @@ a { color: inherit; }
   .preview-banner, .route-notice { padding-inline: 16px; }
   .main-content { padding-bottom: 64px; }
   .bottom-nav { position: fixed; right: 0; bottom: 0; left: 0; z-index: 20; display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); height: 60px; padding: 5px 8px calc(5px + env(safe-area-inset-bottom)); background: var(--canvas); border-top: 1px solid var(--line); }
-  .bottom-nav-link { display: flex; min-width: 0; min-height: 44px; flex-direction: column; align-items: center; justify-content: center; gap: 2px; border-radius: var(--radius-sm); color: var(--muted); font-size: 11px; text-decoration: none; }
+  .bottom-nav-link { display: flex; min-width: 0; min-height: 44px; flex-direction: column; align-items: center; justify-content: center; gap: 2px; border-radius: var(--radius-sm); color: var(--muted); font-size: var(--fs-xs); text-decoration: none; }
   .bottom-nav-link.is-active { color: var(--accent); background: var(--accent-soft); }
 }
 
 /* ── 页面通用 ───────────────────────────── */
 .page { width: 100%; max-width: none; min-width: 0; margin: 0; padding: 20px 28px 24px; }
 .page-header { display: flex; align-items: flex-end; justify-content: space-between; gap: 20px; margin-bottom: 16px; min-width: 0; }
-.eyebrow { margin: 0 0 6px; color: var(--muted); font-size: 12px; letter-spacing: .06em; }
+.eyebrow { margin: 0 0 6px; color: var(--muted); font-size: var(--fs-sm); letter-spacing: .06em; }
 h1, h2, p { margin-top: 0; }
-.page h1 { margin-bottom: 6px; font-size: 26px; font-weight: 700; letter-spacing: -.02em; line-height: 1.2; }
-.page-intro { margin-bottom: 0; color: var(--muted); font-size: 13px; }
-.button { display: inline-flex; min-height: 34px; align-items: center; justify-content: center; gap: 6px; padding: 6px 14px; border: 1px solid transparent; border-radius: var(--radius-sm); background: transparent; font-size: 12px; text-decoration: none; cursor: pointer; }
+.page h1 { margin-bottom: 6px; font-size: 28.5px; font-weight: 700; letter-spacing: -.02em; line-height: 1.2; }
+.page-intro { margin-bottom: 0; color: var(--muted); font-size: var(--fs-md); }
+.button { display: inline-flex; min-height: 34px; align-items: center; justify-content: center; gap: 6px; padding: 6px 14px; border: 1px solid transparent; border-radius: var(--radius-sm); background: transparent; font-size: var(--fs-sm); text-decoration: none; cursor: pointer; }
 .button:disabled { opacity: .5; cursor: not-allowed; }
 .button-primary, .button.primary { background: var(--accent); color: var(--accent-ink); font-weight: 600; }
 .button-primary:hover:not(:disabled), .button.primary:hover:not(:disabled) { background: var(--accent-hover); }
-.button-secondary, .button.secondary, .button-quiet, .button.quiet { border-color: var(--line-strong); color: var(--muted); background: var(--surface-raised); }
+.button-secondary, .button.secondary, .button-quiet, .button.quiet { border-color: var(--line-control); color: var(--muted); background: var(--surface-raised); }
 .button-secondary:hover:not(:disabled), .button.secondary:hover:not(:disabled), .button-quiet:hover:not(:disabled) { border-color: var(--accent); color: var(--accent); }
 .button-danger, .button.danger-button { border-color: rgba(240, 97, 106, .35); color: var(--danger); }
 .surface-card { border: 1px solid var(--line); border-radius: var(--radius-md); background: var(--surface); overflow: hidden; min-width: 0; }
-.section-label { margin: 0 0 8px; padding: 0 2px; color: var(--ink); font-size: 13px; font-weight: 700; }
+.section-label { margin: 0 0 8px; padding: 0 2px; color: var(--ink); font-size: var(--fs-md); font-weight: 700; }
 @media (max-width: 760px) {
   .page { padding: 24px 16px 38px; }
 }

--- a/src/components/BackupPanel.vue
+++ b/src/components/BackupPanel.vue
@@ -450,17 +450,17 @@ const cancelRestore = async () => {
 <style scoped>
 /* 与设置页共用的视觉基元。子组件拿不到父组件的 scoped 样式，
    所以这里按同一套 token 重述一遍，保证看起来是同一套东西。 */
-h2 { margin: 0 0 14px; font-size: 15px; font-weight: 700; color: var(--ink); }
+h2 { margin: 0 0 14px; font-size: var(--fs-xl); font-weight: 700; color: var(--ink); }
 .settings-card { padding: 18px 20px; border: 1px solid var(--line); border-radius: var(--radius-md); background: var(--surface); min-width: 0; }
-.section-description { margin: 0 0 var(--space-3); color: var(--muted); font-size: 12px; line-height: 1.6; }
+.section-description { margin: 0 0 var(--space-3); color: var(--muted); font-size: var(--fs-sm); line-height: 1.6; }
 .section-description.compare { padding: 10px 12px; border-left: 2px solid var(--line-strong); background: var(--surface-raised); border-radius: 0 var(--radius-sm) var(--radius-sm) 0; }
-.section-description b { color: var(--ink); font-weight: 500; }
-.section-description code { padding: 1px 5px; border-radius: 5px; background: var(--surface-raised); font-size: 11px; }
-.retain-note { margin: 8px 0 0; color: var(--muted); font-size: 12px; line-height: 1.6; }
+.section-description b { color: var(--ink); font-weight: 600; }
+.section-description code { padding: 1px 5px; border-radius: 5px; background: var(--surface-raised); font-size: var(--fs-xs); }
+.retain-note { margin: 8px 0 0; color: var(--muted); font-size: var(--fs-sm); line-height: 1.6; }
 .inline-actions { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 12px; }
-.hint-line { display: inline-flex; align-items: center; gap: 6px; margin: 12px 0 0; color: var(--muted); font-size: 12px; }
+.hint-line { display: inline-flex; align-items: center; gap: 6px; margin: 12px 0 0; color: var(--muted); font-size: var(--fs-sm); }
 .hint-line.ok { color: var(--accent); }
-.api-error { margin: 12px 0 0; color: var(--danger); font-size: 12px; line-height: 1.55; }
+.api-error { margin: 12px 0 0; color: var(--danger); font-size: var(--fs-sm); line-height: 1.55; }
 
 .pending-banner {
   display: grid;
@@ -475,8 +475,8 @@ h2 { margin: 0 0 14px; font-size: 15px; font-weight: 700; color: var(--ink); }
 }
 .pending-banner > svg { color: var(--warning); }
 .pending-banner div { display: grid; gap: 2px; min-width: 0; }
-.pending-banner strong { color: var(--ink); font-size: 12px; }
-.pending-banner span { color: var(--subtle); font-size: 11px; line-height: 1.55; }
+.pending-banner strong { color: var(--ink); font-size: var(--fs-sm); }
+.pending-banner span { color: var(--subtle); font-size: var(--fs-xs); line-height: 1.55; }
 
 .backup-list { display: grid; gap: 8px; margin-top: 14px; }
 .backup-row {
@@ -488,17 +488,17 @@ h2 { margin: 0 0 14px; font-size: 15px; font-weight: 700; color: var(--ink); }
   background: var(--surface-raised);
 }
 .backup-head { display: flex; align-items: center; flex-wrap: wrap; gap: 8px; }
-.backup-head strong { color: var(--ink); font-size: 12px; font-weight: 500; font-variant-numeric: tabular-nums; }
+.backup-head strong { color: var(--ink); font-size: var(--fs-sm); font-weight: 600; font-variant-numeric: tabular-nums; }
 .kind-tag {
   padding: 2px 7px;
   border: 1px solid var(--line-strong);
   border-radius: 999px;
   color: var(--muted);
-  font-size: 10px;
+  font-size: var(--fs-2xs);
 }
 .kind-tag.manual { border-color: color-mix(in srgb, var(--accent) 36%, transparent); color: var(--accent); }
-.pin-tag { display: inline-flex; align-items: center; gap: 3px; color: var(--accent); font-size: 10px; }
-.backup-meta { color: var(--subtle); font-size: 11px; line-height: 1.55; }
+.pin-tag { display: inline-flex; align-items: center; gap: 3px; color: var(--accent); font-size: var(--fs-2xs); }
+.backup-meta { color: var(--subtle); font-size: var(--fs-xs); line-height: 1.55; }
 .backup-meta .good { color: var(--accent); }
 .backup-meta .bad { color: var(--danger); font-style: normal; }
 .backup-row .inline-actions { margin-top: 6px; }
@@ -512,12 +512,12 @@ h2 { margin: 0 0 14px; font-size: 15px; font-weight: 700; color: var(--ink); }
   border-radius: var(--radius-sm);
   background: var(--surface-raised);
 }
-.preview-panel > strong { color: var(--ink); font-size: 12px; }
-.preview-panel > p { margin: 0; color: var(--subtle); font-size: 11px; line-height: 1.55; }
-.preview-table { width: 100%; border-collapse: collapse; margin-top: 4px; font-size: 11px; }
+.preview-panel > strong { color: var(--ink); font-size: var(--fs-sm); }
+.preview-panel > p { margin: 0; color: var(--subtle); font-size: var(--fs-xs); line-height: 1.55; }
+.preview-table { width: 100%; border-collapse: collapse; margin-top: 4px; font-size: var(--fs-xs); }
 .preview-table th, .preview-table td { padding: 5px 8px; text-align: right; border-bottom: 1px solid var(--line); }
 .preview-table th:first-child, .preview-table td:first-child { text-align: left; }
-.preview-table th { color: var(--muted); font-weight: 500; }
+.preview-table th { color: var(--muted); font-weight: 600; }
 .preview-table td { color: var(--ink); font-variant-numeric: tabular-nums; }
 .preview-table td.loss { color: var(--danger); }
 </style>

--- a/src/components/CoverageNotice.vue
+++ b/src/components/CoverageNotice.vue
@@ -145,7 +145,7 @@ const syncNow = () => { void runSync('incremental'); };
   border-radius: var(--radius-sm);
   background: var(--surface-raised);
   color: var(--muted);
-  font-size: 13px;
+  font-size: var(--fs-md);
   line-height: 1.5;
 }
 .coverage-notice span { flex: 1 1 240px; min-width: 0; }

--- a/src/components/DeviceCard.vue
+++ b/src/components/DeviceCard.vue
@@ -55,12 +55,12 @@ withDefaults(defineProps<{
 .device-card:hover { border-color: var(--line-strong); transform: translateY(-1px); }
 .device-card.compact { padding: 8px 10px; gap: 9px; border-radius: var(--radius-sm); }
 .device-card-copy { display: grid; gap: 3px; min-width: 0; align-content: start; }
-.device-card-copy strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 13px; font-weight: 700; }
-.device-display { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--muted); font-size: 11px; }
-.device-state { display: inline-flex; align-items: center; gap: 5px; color: var(--muted); font-size: 11px; }
+.device-card-copy strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: var(--fs-md); font-weight: 700; }
+.device-display { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--muted); font-size: var(--fs-xs); }
+.device-state { display: inline-flex; align-items: center; gap: 5px; color: var(--muted); font-size: var(--fs-xs); }
 .dot { width: 7px; height: 7px; flex: 0 0 7px; border-radius: 50%; background: var(--subtle); }
 .dot.has-data { background: var(--readiness); }
 .dot.identified { background: var(--accent); }
-.device-meta { color: var(--subtle); font-size: 11px; line-height: 1.55; font-variant-numeric: tabular-nums; }
+.device-meta { color: var(--subtle); font-size: var(--fs-xs); line-height: 1.55; font-variant-numeric: tabular-nums; }
 @media (prefers-reduced-motion: reduce) { .device-card { transition: none; } .device-card:hover { transform: none; } }
 </style>

--- a/src/components/DevicePicker.vue
+++ b/src/components/DevicePicker.vue
@@ -256,17 +256,17 @@ const heroSub = computed(() => (current.value && current.value.canonical_name !=
 .picker-filters { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; }
 .filter-chip {
   padding: 4px 12px;
-  border: 1px solid var(--line);
+  border: 1px solid var(--line-control);
   border-radius: 999px;
   background: transparent;
   color: var(--muted);
-  font-size: 11px;
+  font-size: var(--fs-xs);
   cursor: pointer;
 }
 .filter-chip.on { border-color: var(--accent); color: var(--accent); }
 .picker-search { flex: 1 1 160px; min-width: 140px; }
 
-.picker-empty { padding: 24px 12px; color: var(--muted); font-size: 12px; text-align: center; }
+.picker-empty { padding: 24px 12px; color: var(--muted); font-size: var(--fs-sm); text-align: center; }
 
 .picker-stage { display: grid; grid-template-columns: auto minmax(0, 1fr) auto; align-items: center; gap: 8px; }
 .picker-arrow {
@@ -274,7 +274,7 @@ const heroSub = computed(() => (current.value && current.value.canonical_name !=
   place-items: center;
   width: 34px;
   height: 34px;
-  border: 1px solid var(--line);
+  border: 1px solid var(--line-control);
   border-radius: 50%;
   background: transparent;
   color: var(--ink);
@@ -302,9 +302,9 @@ const heroSub = computed(() => (current.value && current.value.canonical_name !=
 .picker-hero { display: grid; justify-items: center; gap: 2px; text-align: center; }
 /* 主图给足高度：竖长的表身在正方框里会被上下切掉。 */
 .picker-hero .hero-visual { width: 132px; height: 150px; flex-basis: 150px; border: 0; background: transparent; }
-.hero-name { margin: 6px 0 0; color: var(--ink); font-size: 14px; font-weight: 500; }
-.hero-sub { margin: 0; color: var(--subtle); font-size: 11px; }
-.hero-count { margin: 4px 0 0; color: var(--muted); font-size: 11px; font-family: var(--font-mono); }
+.hero-name { margin: 6px 0 0; color: var(--ink); font-size: var(--fs-lg); font-weight: 600; }
+.hero-sub { margin: 0; color: var(--subtle); font-size: var(--fs-xs); }
+.hero-count { margin: 4px 0 0; color: var(--muted); font-size: var(--fs-xs); font-family: var(--font-mono); }
 
 .picker-actions { display: flex; flex-wrap: wrap; gap: 8px; }
 .picker-contribute {
@@ -313,17 +313,17 @@ const heroSub = computed(() => (current.value && current.value.canonical_name !=
   gap: 8px;
   align-items: start;
   padding: 10px 12px;
-  border: 1px solid var(--line);
+  border: 1px solid var(--line-control);
   border-radius: 12px;
   background: var(--surface-raised);
   color: var(--subtle);
-  font-size: 11px;
+  font-size: var(--fs-xs);
   line-height: 1.6;
   cursor: pointer;
 }
 .picker-contribute input { margin-top: 2px; }
-.picker-contribute strong { display: block; margin-bottom: 2px; color: var(--ink); font-weight: 500; }
-.picker-note { margin: 0; color: var(--subtle); font-size: 11px; line-height: 1.55; }
+.picker-contribute strong { display: block; margin-bottom: 2px; color: var(--ink); font-weight: 600; }
+.picker-note { margin: 0; color: var(--subtle); font-size: var(--fs-xs); line-height: 1.55; }
 
 @media (prefers-reduced-motion: no-preference) {
   .picker-hero img { animation: picker-in 180ms ease-out; }

--- a/src/components/DeviceVisual.vue
+++ b/src/components/DeviceVisual.vue
@@ -115,5 +115,5 @@ const kindLabel = computed(() => {
 .device-visual img { display: block; width: 100%; height: 100%; object-fit: contain; padding: 2px; }
 .device-fallback { display: grid; justify-items: center; gap: 1px; width: 100%; height: 100%; padding: 5px; color: var(--muted); }
 .device-fallback svg { display: block; width: 100%; height: calc(100% - 12px); }
-.device-fallback-label { max-width: 100%; overflow: hidden; color: var(--subtle); font-size: 9px; line-height: 11px; text-overflow: ellipsis; white-space: nowrap; }
+.device-fallback-label { max-width: 100%; overflow: hidden; color: var(--subtle); font-size: var(--fs-2xs); line-height: 11px; text-overflow: ellipsis; white-space: nowrap; }
 </style>

--- a/src/components/EmptyState.vue
+++ b/src/components/EmptyState.vue
@@ -33,7 +33,7 @@ defineProps<{
   border-radius: var(--radius-md);
   background: var(--surface);
 }
-.state-panel h2 { margin: 0 0 6px; font-size: 18px; }
+.state-panel h2 { margin: 0 0 6px; font-size: var(--fs-3xl); }
 .state-panel p { margin: 0 0 16px; color: var(--muted); }
 .state-panel p:last-child { margin-bottom: 0; }
 .state-mark {

--- a/src/components/HeartRateZonePicker.vue
+++ b/src/components/HeartRateZonePicker.vue
@@ -408,11 +408,11 @@ watch(() => props.revision, () => { void load(); });
   min-width: 0;
 }
 .zone-head { display: flex; align-items: flex-start; justify-content: space-between; gap: var(--space-4); }
-.zone-head h2 { margin: 0 0 4px; color: var(--ink); font-size: 15px; font-weight: 700; }
-.zone-intro { margin: 0; max-width: 68ch; color: var(--muted); font-size: 12px; line-height: 1.7; }
-.zone-alert { display: flex; align-items: center; gap: var(--space-2); margin: 0; color: var(--danger); font-size: 12px; }
-.zone-empty { margin: 0; color: var(--subtle); font-size: 12px; }
-.group-label { margin: 0; color: var(--subtle); font-size: 11px; }
+.zone-head h2 { margin: 0 0 4px; color: var(--ink); font-size: var(--fs-xl); font-weight: 700; }
+.zone-intro { margin: 0; max-width: 68ch; color: var(--muted); font-size: var(--fs-sm); line-height: 1.7; }
+.zone-alert { display: flex; align-items: center; gap: var(--space-2); margin: 0; color: var(--danger); font-size: var(--fs-sm); }
+.zone-empty { margin: 0; color: var(--subtle); font-size: var(--fs-sm); }
+.group-label { margin: 0; color: var(--subtle); font-size: var(--fs-xs); }
 
 .model-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: var(--space-3); }
 .model-card {
@@ -420,7 +420,7 @@ watch(() => props.revision, () => { void load(); });
   gap: 5px;
   align-content: start;
   padding: var(--space-3);
-  border: 1px solid var(--line-strong);
+  border: 1px solid var(--line-control);
   border-radius: var(--radius-sm);
   background: var(--surface-raised);
   color: var(--muted);
@@ -430,11 +430,11 @@ watch(() => props.revision, () => { void load(); });
 .model-card:hover:not(:disabled) { border-color: var(--accent); }
 .model-card:disabled { opacity: .55; cursor: not-allowed; }
 .model-card.is-on { border-color: var(--accent); background: var(--accent-soft); }
-.model-name { display: flex; align-items: center; gap: 5px; color: var(--ink); font-size: 13px; font-weight: 700; }
+.model-name { display: flex; align-items: center; gap: 5px; color: var(--ink); font-size: var(--fs-md); font-weight: 700; }
 .model-card.is-on .model-name { color: var(--accent); }
-.model-formula { font-size: 11px; line-height: 1.6; }
-.model-bands { color: var(--subtle); font-family: var(--font-mono); font-size: 11px; }
-.model-missing { color: var(--warning); font-size: 11px; }
+.model-formula { font-size: var(--fs-xs); line-height: 1.6; }
+.model-bands { color: var(--subtle); font-family: var(--font-mono); font-size: var(--fs-xs); }
+.model-missing { color: var(--warning); font-size: var(--fs-xs); }
 
 .basis-block { display: grid; gap: var(--space-2); }
 .basis-list { display: grid; gap: var(--space-2); }
@@ -445,7 +445,7 @@ watch(() => props.revision, () => { void load(); });
   gap: var(--space-3);
   min-height: 44px;
   padding: var(--space-2) var(--space-3);
-  border: 1px solid var(--line);
+  border: 1px solid var(--line-control);
   border-radius: var(--radius-sm);
   background: var(--surface-raised);
   text-align: left;
@@ -453,30 +453,30 @@ watch(() => props.revision, () => { void load(); });
 }
 .basis-row:hover:not(:disabled) { border-color: var(--accent); }
 .basis-row.is-on { border-color: var(--accent); background: var(--accent-soft); }
-.basis-value { color: var(--ink); font-family: var(--font-mono); font-size: 19px; font-variant-numeric: tabular-nums; }
-.basis-value i { margin-left: 3px; color: var(--subtle); font-size: 10px; font-style: normal; }
+.basis-value { color: var(--ink); font-family: var(--font-mono); font-size: 21px; font-variant-numeric: tabular-nums; }
+.basis-value i { margin-left: 3px; color: var(--subtle); font-size: var(--fs-2xs); font-style: normal; }
 .basis-copy { display: grid; gap: 1px; min-width: 0; }
-.basis-copy strong { color: var(--ink); font-size: 12px; font-weight: 700; }
-.basis-source { color: var(--subtle); font-family: var(--font-mono); font-size: 11px; overflow-wrap: anywhere; }
-.basis-note { color: var(--muted); font-size: 11px; line-height: 1.6; }
+.basis-copy strong { color: var(--ink); font-size: var(--fs-sm); font-weight: 700; }
+.basis-source { color: var(--subtle); font-family: var(--font-mono); font-size: var(--fs-xs); overflow-wrap: anywhere; }
+.basis-note { color: var(--muted); font-size: var(--fs-xs); line-height: 1.6; }
 .basis-check { color: var(--accent); }
 
-.zone-summary { display: flex; align-items: baseline; justify-content: space-between; gap: var(--space-3); color: var(--ink); font-size: 12px; font-weight: 700; }
-.zone-window { color: var(--subtle); font-size: 11px; font-weight: 400; }
+.zone-summary { display: flex; align-items: baseline; justify-content: space-between; gap: var(--space-3); color: var(--ink); font-size: var(--fs-sm); font-weight: 700; }
+.zone-window { color: var(--subtle); font-size: var(--fs-xs); font-weight: 400; }
 .zone-list { display: grid; gap: var(--space-2); margin: 0; padding: 0; list-style: none; }
 .zone-list li {
   display: grid;
   grid-template-columns: 108px 74px minmax(60px, 1fr) 86px;
   align-items: center;
   gap: var(--space-3);
-  font-size: 12px;
+  font-size: var(--fs-sm);
 }
 .zone-name { color: var(--ink); }
 .zone-range, .zone-time { color: var(--muted); font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
 .zone-time { text-align: right; }
 .zone-bar { height: 8px; overflow: hidden; border-radius: 999px; background: var(--surface-raised); }
 .zone-bar i { display: block; height: 100%; border-radius: 999px; background: var(--heart); }
-.zone-outside, .zone-formula { margin: 0; color: var(--subtle); font-size: 11px; line-height: 1.7; }
+.zone-outside, .zone-formula { margin: 0; color: var(--subtle); font-size: var(--fs-xs); line-height: 1.7; }
 @media (max-width: 720px) {
   .zone-card { padding: var(--space-4); }
   .zone-list li { grid-template-columns: minmax(0, 1fr) auto; }

--- a/src/components/HistoryArchivePanel.vue
+++ b/src/components/HistoryArchivePanel.vue
@@ -571,28 +571,28 @@ const resetLedger = async () => {
 .failed-block { margin-top: 12px; padding: 12px 14px; border: 1px solid var(--line); border-radius: var(--radius-sm); background: var(--surface-raised); }
 .failed-list { margin: 8px 0 0; padding: 0; list-style: none; display: grid; gap: 8px; }
 .failed-list li { display: grid; gap: 2px; }
-.failed-where { color: var(--ink); font-size: 13px; font-weight: 600; }
-.failed-why { color: var(--muted); font-size: 12px; overflow-wrap: anywhere; }
-.failed-meta { color: var(--subtle); font-size: 11px; }
+.failed-where { color: var(--ink); font-size: var(--fs-md); font-weight: 600; }
+.failed-why { color: var(--muted); font-size: var(--fs-sm); overflow-wrap: anywhere; }
+.failed-meta { color: var(--subtle); font-size: var(--fs-xs); }
 .estimate-block { margin-top: 10px; padding: 12px 14px; border: 1px solid var(--line); border-radius: var(--radius-sm); background: var(--surface-raised); }
 .estimate-head { display: grid; gap: 3px; }
-.estimate-head strong { color: var(--ink); font-size: 12px; font-weight: 500; }
-.estimate-head span { color: var(--subtle); font-size: 11px; line-height: 1.55; }
+.estimate-head strong { color: var(--ink); font-size: var(--fs-sm); font-weight: 600; }
+.estimate-head span { color: var(--subtle); font-size: var(--fs-xs); line-height: 1.55; }
 .estimate-list { display: grid; gap: 3px; margin-top: 8px; }
-.estimate-row { display: grid; grid-template-columns: minmax(0, 88px) minmax(0, 1fr) auto; gap: 10px; align-items: baseline; color: var(--subtle); font-size: 11px; }
+.estimate-row { display: grid; grid-template-columns: minmax(0, 88px) minmax(0, 1fr) auto; gap: 10px; align-items: baseline; color: var(--subtle); font-size: var(--fs-xs); }
 .estimate-row > span:first-child { color: var(--ink); }
 .estimate-total { color: var(--muted); font-variant-numeric: tabular-nums; }
-.estimate-block .retain-note { margin: 8px 0 0; font-size: 11px; }
+.estimate-block .retain-note { margin: 8px 0 0; font-size: var(--fs-xs); }
 
 /* 与设置页共用的视觉基元。子组件拿不到父组件的 scoped 样式，
    所以这里按同一套 token 重述一遍，保证看起来是同一套东西。 */
-h2 { margin: 0 0 14px; font-size: 15px; font-weight: 700; color: var(--ink); }
+h2 { margin: 0 0 14px; font-size: var(--fs-xl); font-weight: 700; color: var(--ink); }
 .settings-card { padding: 18px 20px; border: 1px solid var(--line); border-radius: var(--radius-md); background: var(--surface); min-width: 0; }
-.section-description { margin: 0 0 var(--space-3); color: var(--muted); font-size: 12px; }
+.section-description { margin: 0 0 var(--space-3); color: var(--muted); font-size: var(--fs-sm); }
 .toggle-row { display: flex; align-items: center; gap: 10px; min-height: 52px; padding: 8px 0; }
 .toggle-copy { flex: 1; min-width: 0; display: grid; gap: 1px; }
-.toggle-copy strong { font-size: 12px; color: var(--ink); }
-.toggle-copy span { color: var(--subtle); font-size: 11px; line-height: 1.55; }
+.toggle-copy strong { font-size: var(--fs-sm); color: var(--ink); }
+.toggle-copy span { color: var(--subtle); font-size: var(--fs-xs); line-height: 1.55; }
 .switch { width: 42px; height: 24px; flex: 0 0 42px; padding: 2px; border: 1px solid var(--line-strong); border-radius: 999px; background: var(--surface-raised); cursor: pointer; }
 .switch span { display: block; width: 18px; height: 18px; border-radius: 50%; background: var(--muted); transition: transform 150ms ease, background-color 150ms ease; }
 .switch[aria-checked='true'] { border-color: var(--accent); background: var(--accent-soft); }
@@ -607,25 +607,25 @@ h2 { margin: 0 0 14px; font-size: 15px; font-weight: 700; color: var(--ink); }
   border-radius: 9px;
   background: var(--surface-raised);
   color: var(--ink);
-  font-size: 12px;
+  font-size: var(--fs-sm);
 }
 .field-row .select-menu { min-width: 220px; flex: 0 0 auto; }
-.kv-label { flex: 0 0 96px; color: var(--muted); font-size: 12px; }
-.retain-note { margin: 6px 0 8px; color: var(--muted); font-size: 12px; line-height: 1.6; }
+.kv-label { flex: 0 0 96px; color: var(--muted); font-size: var(--fs-sm); }
+.retain-note { margin: 6px 0 8px; color: var(--muted); font-size: var(--fs-sm); line-height: 1.6; }
 .inline-actions { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 12px; }
 /* 「自动跑完」放在按钮正上方：它改变的正是下面那个按钮的行为。 */
 .auto-continue { display: flex; gap: 8px; align-items: flex-start; margin-top: 14px; cursor: pointer; }
 .auto-continue input { margin-top: 3px; flex: none; }
 .auto-continue span { display: flex; flex-direction: column; gap: 2px; }
-.auto-continue em { font-style: normal; font-size: 12px; opacity: .72; line-height: 1.5; }
-.hint-line { display: inline-flex; align-items: center; gap: 6px; margin: 12px 0 0; color: var(--muted); font-size: 12px; }
+.auto-continue em { font-style: normal; font-size: var(--fs-sm); opacity: .72; line-height: 1.5; }
+.hint-line { display: inline-flex; align-items: center; gap: 6px; margin: 12px 0 0; color: var(--muted); font-size: var(--fs-sm); }
 .hint-line.ok { color: var(--accent); }
-.api-error { margin: 12px 0 0; color: var(--danger); font-size: 12px; line-height: 1.55; }
+.api-error { margin: 12px 0 0; color: var(--danger); font-size: var(--fs-sm); line-height: 1.55; }
 
 .archive-toggle { margin: 10px 0; border-bottom: 0; }
 .ledger-head { display: flex; flex-wrap: wrap; align-items: baseline; gap: 8px; margin-top: 14px; }
-.ledger-head strong { color: var(--ink); font-size: 12px; font-weight: 500; }
-.ledger-head span { color: var(--muted); font-size: 11px; }
+.ledger-head strong { color: var(--ink); font-size: var(--fs-sm); font-weight: 600; }
+.ledger-head span { color: var(--muted); font-size: var(--fs-xs); }
 .ledger-list { display: grid; gap: 8px; margin-top: 8px; }
 .ledger-row {
   display: grid;
@@ -635,7 +635,7 @@ h2 { margin: 0 0 14px; font-size: 15px; font-weight: 700; color: var(--ink); }
   border-radius: var(--radius-sm);
   background: var(--surface-raised);
 }
-.ledger-row strong { color: var(--ink); font-size: 12px; font-weight: 500; }
-.ledger-stats, .ledger-range { color: var(--subtle); font-size: 11px; }
+.ledger-row strong { color: var(--ink); font-size: var(--fs-sm); font-weight: 600; }
+.ledger-stats, .ledger-range { color: var(--subtle); font-size: var(--fs-xs); }
 .ledger-stats em { color: var(--danger); font-style: normal; }
 </style>

--- a/src/components/InsightCard.vue
+++ b/src/components/InsightCard.vue
@@ -361,30 +361,36 @@ const exclusionSummary = computed(() => {
   background: var(--surface);
 }
 .insight-card header { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
-.insight-card h2 { display: flex; align-items: center; gap: 6px; margin: 0; color: var(--ink); font-size: 14px; font-weight: 500; }
+.insight-card h2 { display: flex; align-items: center; gap: 6px; margin: 0; color: var(--ink); font-size: var(--fs-lg); font-weight: 600; }
 
-.insight-summary { margin: 0; color: var(--ink); font-size: 13px; line-height: 1.7; }
-.delta { margin-right: 10px; font-weight: 500; }
+.insight-summary { margin: 0; color: var(--ink); font-size: var(--fs-md); line-height: 1.7; }
+.delta { margin-right: 10px; font-weight: 600; }
 .delta.good, .fact-delta.good { color: var(--accent); }
 .delta.bad, .fact-delta.bad { color: var(--danger); }
 .delta.flat, .fact-delta.flat { color: var(--muted); }
 
+/* 好/坏不能只靠绿/红：红绿色觉障碍下这两个状态完全一样。
+   统一加一个前置符号，颜色只作为强化。 */
+.delta.good::before, .fact-delta.good::before { content: '✓\a0'; font-weight: 700; }
+.delta.bad::before, .fact-delta.bad::before { content: '!\a0'; font-weight: 700; }
+.delta.flat::before, .fact-delta.flat::before { content: '=\a0'; font-weight: 700; }
+
 .fact-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(130px, 1fr)); gap: 10px; }
 .fact { display: grid; gap: 2px; padding: 10px 12px; border-radius: 12px; background: var(--surface-raised); }
-.fact-label { color: var(--muted); font-size: 11px; }
-.fact strong { color: var(--ink); font-size: 16px; font-weight: 500; }
-.fact-delta { font-size: 11px; }
+.fact-label { color: var(--muted); font-size: var(--fs-xs); }
+.fact strong { color: var(--ink); font-size: var(--fs-2xl); font-weight: 600; }
+.fact-delta { font-size: var(--fs-xs); }
 .fact-delta.muted { color: var(--muted); }
 
-details summary { color: var(--subtle); font-size: 12px; cursor: pointer; }
+details summary { color: var(--subtle); font-size: var(--fs-sm); cursor: pointer; }
 .baseline-list { display: grid; gap: 2px; margin: 6px 0; padding-left: 18px; }
-.baseline-list a { color: var(--accent); font-size: 11px; }
+.baseline-list a { color: var(--accent); font-size: var(--fs-xs); }
 
-.insight-note { margin: 0; color: var(--subtle); font-size: 11px; line-height: 1.6; }
-.insight-error { margin: 0; color: var(--danger); font-size: 12px; }
+.insight-note { margin: 0; color: var(--subtle); font-size: var(--fs-xs); line-height: 1.6; }
+.insight-error { margin: 0; color: var(--danger); font-size: var(--fs-sm); }
 .drift { margin-top: 14px; padding-top: 13px; border-top: 1px solid var(--line); }
 .drift-head { display: flex; align-items: baseline; gap: 8px; margin: 0 0 4px; }
-.drift-head strong { color: var(--ink); font-size: 13px; }
+.drift-head strong { color: var(--ink); font-size: var(--fs-md); }
 .drift-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; margin: 10px 0 0; }
 .insight-note.subtle { color: var(--subtle); }
 </style>

--- a/src/components/MetricTrendCard.vue
+++ b/src/components/MetricTrendCard.vue
@@ -152,19 +152,19 @@ const option = computed(() => {
 }
 .trend-head { display: flex; align-items: flex-start; justify-content: space-between; gap: var(--space-3); }
 .trend-title { display: grid; gap: 2px; min-width: 0; }
-.trend-title strong { color: var(--ink); font-size: 13px; font-weight: 700; }
-.trend-title small { color: var(--subtle); font-size: 11px; }
+.trend-title strong { color: var(--ink); font-size: var(--fs-md); font-weight: 700; }
+.trend-title small { color: var(--subtle); font-size: var(--fs-xs); }
 .trend-latest { display: flex; align-items: baseline; gap: 4px; white-space: nowrap; }
-.trend-latest strong { font-family: var(--font-mono); font-size: 22px; font-variant-numeric: tabular-nums; }
-.trend-latest small { color: var(--subtle); font-size: 11px; }
-.trend-latest-tag { color: var(--subtle); font-size: 11px; font-style: normal; }
+.trend-latest strong { font-family: var(--font-mono); font-size: 24px; font-variant-numeric: tabular-nums; }
+.trend-latest small { color: var(--subtle); font-size: var(--fs-xs); }
+.trend-latest-tag { color: var(--subtle); font-size: var(--fs-xs); font-style: normal; }
 .trend-meta {
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-1) var(--space-3);
   margin: var(--space-2) 0 0;
   color: var(--subtle);
-  font-size: 11px;
+  font-size: var(--fs-xs);
 }
 .trend-date { font-family: var(--font-mono); }
 .trend-band { color: var(--muted); }
@@ -175,7 +175,7 @@ const option = computed(() => {
   min-height: 132px;
   margin: var(--space-2) 0 0;
   color: var(--subtle);
-  font-size: 12px;
+  font-size: var(--fs-sm);
 }
 .trend-stats {
   display: flex;
@@ -186,13 +186,13 @@ const option = computed(() => {
   border-top: 1px solid var(--line);
 }
 .trend-stats > div { display: flex; align-items: baseline; gap: var(--space-1); }
-.trend-stats dt { color: var(--subtle); font-size: 11px; }
+.trend-stats dt { color: var(--subtle); font-size: var(--fs-xs); }
 .trend-stats dd {
   margin: 0;
   color: var(--muted);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   font-variant-numeric: tabular-nums;
 }
-.trend-stats dd i { margin-left: 2px; font-size: 10px; font-style: normal; }
+.trend-stats dd i { margin-left: 2px; font-size: var(--fs-2xs); font-style: normal; }
 </style>

--- a/src/components/PageHeader.vue
+++ b/src/components/PageHeader.vue
@@ -52,7 +52,7 @@ defineProps<{
   justify-self: start;
   gap: 6px;
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   text-decoration: none;
 }
 .back-link:hover { color: var(--accent); }

--- a/src/components/RecordRow.vue
+++ b/src/components/RecordRow.vue
@@ -87,11 +87,11 @@ withDefaults(defineProps<{
 }
 .record-copy small, .record-fact small {
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--fs-sm);
 }
 .record-copy strong {
   overflow: hidden;
-  font-size: 14px;
+  font-size: var(--fs-lg);
   font-weight: 700;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -99,7 +99,7 @@ withDefaults(defineProps<{
 .record-mid {
   overflow: hidden;
   color: var(--muted);
-  font-size: 13px;
+  font-size: var(--fs-md);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -109,7 +109,7 @@ withDefaults(defineProps<{
 }
 .record-fact strong {
   font-family: 'Inter', var(--font-sans);
-  font-size: 14px;
+  font-size: var(--fs-lg);
   font-variant-numeric: tabular-nums;
   font-weight: 600;
 }
@@ -121,7 +121,7 @@ withDefaults(defineProps<{
   padding: 8px 14px;
 }
 .record-row.compact .record-copy strong {
-  font-size: 13px;
+  font-size: var(--fs-md);
   font-weight: 400;
 }
 .record-row.compact.tone-sleep .record-fact strong {
@@ -130,12 +130,12 @@ withDefaults(defineProps<{
   border-radius: 999px;
   background: var(--surface-raised);
   color: var(--sleep);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   text-align: center;
 }
 .record-row.compact.tone-activity .record-fact strong {
   color: var(--activity);
-  font-size: 13px;
+  font-size: var(--fs-md);
 }
 @media (max-width: 520px) {
   .record-row { grid-template-columns: auto minmax(0, 1fr) auto; }

--- a/src/components/SelectMenu.vue
+++ b/src/components/SelectMenu.vue
@@ -243,7 +243,7 @@ onBeforeUnmount(() => {
   border: 1px solid var(--line-strong, rgba(226, 234, 242, .16));
   border-radius: var(--radius-sm);
   /* 实心背景。半透明会让下面的内容透上来，选项就没法读了。 */
-  background: #24272F;
+  background: var(--surface-raised);
   box-shadow: 0 18px 44px rgba(4, 6, 8, .55);
   list-style: none;
 }
@@ -255,13 +255,13 @@ onBeforeUnmount(() => {
   padding: 8px 10px;
   border-radius: 7px;
   color: var(--muted);
-  font-size: 13px;
+  font-size: var(--fs-md);
   cursor: pointer;
 }
-.select-list .select-option.is-active { background: #2E323B; color: var(--ink); }
+.select-list .select-option.is-active { background: var(--surface-hover); color: var(--ink); }
 .select-list .select-option.is-selected { color: var(--ink); font-weight: 600; }
 .select-list .option-label { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.select-list .option-hint { grid-column: 1 / -1; color: var(--subtle); font-size: 11px; font-weight: 400; }
+.select-list .option-hint { grid-column: 1 / -1; color: var(--subtle); font-size: var(--fs-xs); font-weight: 400; }
 .select-list .option-tick { color: var(--accent); }
 </style>
 
@@ -276,17 +276,17 @@ onBeforeUnmount(() => {
   justify-content: space-between;
   gap: 8px;
   padding: 6px 10px;
-  border: 1px solid var(--line);
+  border: 1px solid var(--line-control);
   border-radius: var(--radius-sm);
   background: var(--surface-raised);
   color: var(--ink);
   font: inherit;
-  font-size: 13px;
+  font-size: var(--fs-md);
   text-align: left;
   cursor: pointer;
   transition: border-color 140ms ease, background 140ms ease;
 }
-.select-trigger:hover:not(:disabled) { border-color: rgba(221, 231, 239, .22); }
+.select-trigger:hover:not(:disabled) { border-color: var(--line-control); }
 .select-trigger:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
 .is-open .select-trigger { border-color: var(--accent); }
 .is-disabled .select-trigger, .select-trigger:disabled { opacity: .55; cursor: not-allowed; }

--- a/src/components/StageBar.vue
+++ b/src/components/StageBar.vue
@@ -174,7 +174,7 @@ const hypnogramOption = computed(() => {
       type: 'time',
       min: current.from,
       max: current.from + current.span,
-      axisLabel: { formatter: clock, hideOverlap: true, color: '#7E856D', fontSize: 11 },
+      axisLabel: { formatter: clock, hideOverlap: true, color: '#B4BBC3', fontSize: 14.5 },
       axisTick: { show: false },
       axisLine: { lineStyle: { color: 'rgba(226, 234, 242, .12)' } },
       splitLine: { show: false },
@@ -186,12 +186,12 @@ const hypnogramOption = computed(() => {
       interval: 1,
       axisLabel: {
         formatter: (value: number) => stageLabels.value[value] ?? '',
-        color: '#7E856D',
-        fontSize: 11,
+        color: '#B4BBC3',
+        fontSize: 14.5,
       },
       axisTick: { show: false },
       axisLine: { show: false },
-      splitLine: { lineStyle: { color: 'rgba(226, 234, 242, .08)', type: 'dashed' } },
+      splitLine: { lineStyle: { color: 'rgba(226, 234, 242, .12)', type: 'dashed' } },
     },
     visualMap: {
       show: false,
@@ -286,7 +286,7 @@ const hypnogramOption = computed(() => {
   gap: 12px;
   margin-top: 8px;
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   font-variant-numeric: tabular-nums;
 }
 .stage-list {
@@ -303,7 +303,7 @@ const hypnogramOption = computed(() => {
   background: var(--surface);
 }
 .stage-list span, .stage-list strong, .stage-list small { display: block; }
-.stage-list span { color: var(--muted); font-size: 12px; }
+.stage-list span { color: var(--muted); font-size: var(--fs-sm); }
 .stage-list i {
   display: inline-block;
   width: 7px;
@@ -314,11 +314,11 @@ const hypnogramOption = computed(() => {
 .stage-list strong {
   margin-top: 6px;
   color: var(--ink);
-  font-size: 15px;
+  font-size: var(--fs-xl);
   font-variant-numeric: tabular-nums;
   font-weight: 600;
 }
-.stage-list small { margin-top: 4px; color: var(--muted); font-size: 12px; }
+.stage-list small { margin-top: 4px; color: var(--muted); font-size: var(--fs-sm); }
 @media (max-width: 760px) {
   .stage-list { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 }

--- a/src/components/WeeklyReportCard.vue
+++ b/src/components/WeeklyReportCard.vue
@@ -254,35 +254,58 @@ function formatNumber(fact: InsightFact, value: number): string {
   background: var(--surface);
 }
 .weekly-card header { display: flex; flex-wrap: wrap; align-items: baseline; justify-content: space-between; gap: 8px; }
-.weekly-card h2 { display: flex; align-items: center; gap: 6px; margin: 0; color: var(--ink); font-size: 14px; font-weight: 500; }
-.weekly-window { color: var(--muted); font-size: 11px; }
-.weekly-legend { display: flex; flex-wrap: wrap; gap: 4px 14px; margin: 0; color: var(--muted); font-size: 11px; }
+.weekly-card h2 { display: flex; align-items: center; gap: 6px; margin: 0; color: var(--ink); font-size: var(--fs-lg); font-weight: 600; }
+.weekly-window { color: var(--muted); font-size: var(--fs-xs); }
+.weekly-legend { display: flex; flex-wrap: wrap; gap: 4px 14px; margin: 0; color: var(--muted); font-size: var(--fs-xs); }
 .weekly-legend span { display: inline-flex; align-items: center; gap: 5px; }
-.legend-dot { width: 7px; height: 7px; flex: 0 0 7px; border-radius: 2px; }
+
+/* 好/坏不能只靠绿/红：红绿色觉障碍下这两个状态完全一样。
+   统一加一个前置符号，颜色只作为强化。 */
+.legend-dot {
+  display: grid;
+  place-items: center;
+  width: 13px;
+  height: 13px;
+  flex: 0 0 13px;
+  border-radius: 3px;
+  color: var(--accent-ink);
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1;
+}
 .legend-dot.good { background: var(--accent); }
+.legend-dot.good::before { content: '✓'; }
 .legend-dot.bad { background: var(--danger); }
+.legend-dot.bad::before { content: '!'; }
 .legend-note { color: var(--subtle); }
 
-.weekly-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); gap: 10px; align-items: stretch; }
+/* 每格里现在有「上一个 28 天」这种长标签加进度条，210px 一行挤六个放不下，
+   标签会顶到进度条上。加宽下限，常见窗口宽度下自然落成五列。 */
+.weekly-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 10px; align-items: stretch; }
 .weekly-item { display: grid; gap: 2px; align-content: start; padding: 10px 12px; border-radius: 12px; background: var(--surface-raised); }
-.weekly-label { color: var(--muted); font-size: 11px; }
-.weekly-item strong { color: var(--ink); font-size: 16px; font-weight: 500; }
-.weekly-delta { font-size: 11px; line-height: 1.5; }
+.weekly-label { color: var(--muted); font-size: var(--fs-xs); }
+.weekly-item strong { color: var(--ink); font-size: var(--fs-2xl); font-weight: 600; }
+.weekly-delta { font-size: var(--fs-xs); line-height: 1.5; }
 .weekly-delta.good { color: var(--accent); }
+.weekly-delta.good::before { content: '✓\a0'; font-weight: 700; }
 .weekly-delta.bad { color: var(--danger); }
+.weekly-delta.bad::before { content: '!\a0'; font-weight: 700; }
 .weekly-delta.flat, .weekly-delta.muted { color: var(--muted); }
 
 .weekly-bars { display: grid; gap: 5px; margin: 6px 0 2px; }
-.bar-row { display: grid; grid-template-columns: 58px minmax(0, 1fr) auto; align-items: center; gap: 7px; }
-.bar-tag { color: var(--subtle); font-size: 10px; white-space: nowrap; }
+.bar-row { display: grid; grid-template-columns: 84px minmax(0, 1fr) auto; align-items: center; gap: 7px; }
+.bar-tag { color: var(--subtle); font-size: var(--fs-2xs); white-space: nowrap; }
 .bar-track { height: 6px; border-radius: 3px; background: rgba(232,238,244,.08); overflow: hidden; }
 .bar-fill { display: block; height: 100%; border-radius: 3px; background: var(--muted); transition: width .4s cubic-bezier(.16,1,.3,1); }
 .bar-fill.good { background: var(--accent); }
-.bar-fill.bad { background: var(--danger); }
+.bar-fill.bad {
+  background: repeating-linear-gradient(
+    -45deg, var(--danger) 0 4px, color-mix(in srgb, var(--danger) 62%, #000) 4px 8px);
+}
 .bar-fill.flat { background: var(--muted); }
 .bar-fill.baseline { background: rgba(232,238,244,.22); }
-.bar-value { color: var(--subtle); font-size: 10px; white-space: nowrap; }
+.bar-value { color: var(--subtle); font-size: var(--fs-2xs); white-space: nowrap; }
 
-.weekly-note { margin: 0; color: var(--subtle); font-size: 11px; line-height: 1.6; }
-.weekly-error { margin: 0; color: var(--danger); font-size: 12px; }
+.weekly-note { margin: 0; color: var(--subtle); font-size: var(--fs-xs); line-height: 1.6; }
+.weekly-error { margin: 0; color: var(--danger); font-size: var(--fs-sm); }
 </style>

--- a/src/composables/useUiScale.ts
+++ b/src/composables/useUiScale.ts
@@ -3,17 +3,21 @@ import { computed, readonly, ref } from 'vue';
 export const UI_SCALES = [80, 90, 100, 110, 125] as const;
 export type UiScale = (typeof UI_SCALES)[number];
 
+// 默认使用 100%：通过字号 token 放大 DOM 和图表文字，避免整体 zoom 影响图表指针坐标。
+// 界面缩放选项、快捷键和已保存的用户选择仍然有效，需要时可以调整整体大小。
+export const DEFAULT_UI_SCALE: UiScale = 100;
+
 const STORAGE_KEY = 'zeppbridge-ui-scale';
-const scale = ref<UiScale>(100);
+const scale = ref<UiScale>(DEFAULT_UI_SCALE);
 let initialized = false;
 
 const isUiScale = (value: number): value is UiScale =>
   (UI_SCALES as readonly number[]).includes(value);
 
 const readScale = (): UiScale => {
-  if (typeof window === 'undefined') return 100;
+  if (typeof window === 'undefined') return DEFAULT_UI_SCALE;
   const saved = Number(window.localStorage.getItem(STORAGE_KEY));
-  return isUiScale(saved) ? saved : 100;
+  return isUiScale(saved) ? saved : DEFAULT_UI_SCALE;
 };
 
 const applyScale = (value: UiScale) => {
@@ -35,7 +39,7 @@ const bumpScale = (direction: 1 | -1) => {
   setScale(next);
 };
 
-const resetScale = () => setScale(100);
+const resetScale = () => setScale(DEFAULT_UI_SCALE);
 
 const initializeScale = () => {
   if (initialized) return;

--- a/src/lib/echartsTheme.ts
+++ b/src/lib/echartsTheme.ts
@@ -20,7 +20,7 @@ export const zeppSemanticColors = {
   vo2: '#3DD84C',
   readiness: '#3DD84C',
   sleep: {
-    deep: '#4458B8',
+    deep: '#6477D7',
     light: '#7C8FF0',
     rem: '#8B5CF6',
     awake: '#E8833A',
@@ -43,27 +43,30 @@ const healthSeriesPalette = [
   zeppSemanticColors.sleep.awake,
 ];
 
+/* 坐标轴文字沿用 CSS 的 --muted：11px/#9AA1A9 在正常视距下读不出来。 */
+export const axisInk = '#B4BBC3';
+
 const darkAxis = {
   axisLine: { show: false },
   axisTick: { show: false },
-  axisLabel: { color: '#9AA1A9', fontSize: 11, fontFamily: fonts },
-  splitLine: { show: true, lineStyle: { color: 'rgba(226,234,242,0.07)', type: 'dashed' as const } },
+  axisLabel: { color: axisInk, fontSize: 14.5, fontWeight: 600 as const, fontFamily: fonts },
+  splitLine: { show: true, lineStyle: { color: 'rgba(226,234,242,0.12)', type: 'dashed' as const } },
 };
 
 export const zeppThemeDark = {
   color: healthSeriesPalette,
   backgroundColor: 'transparent',
-  textStyle: { fontFamily: fonts, color: '#9AA1A9' },
+  textStyle: { fontFamily: fonts, color: axisInk },
   categoryAxis: { ...darkAxis },
   valueAxis: { ...darkAxis },
   timeAxis: { ...darkAxis },
   logAxis: { ...darkAxis },
   tooltip: {
-    backgroundColor: '#24272F',
-    borderColor: 'rgba(226,234,242,0.14)',
+    backgroundColor: '#1F232A',
+    borderColor: 'rgba(226,234,242,0.22)',
     borderWidth: 1,
     padding: [8, 12],
-    textStyle: { color: '#F2F4EE', fontSize: 12, fontFamily: fonts },
+    textStyle: { color: '#F2F4EE', fontSize: 15.5, fontFamily: fonts },
     extraCssText: 'border-radius:8px;box-shadow:none;',
   },
   line: {

--- a/src/lib/metricSeries.ts
+++ b/src/lib/metricSeries.ts
@@ -189,10 +189,10 @@ export const buildSeriesOption = (
         const unit = options.unit ? ` ${options.unit}` : '';
         const spread =
           typeof point.min === 'number' && typeof point.max === 'number'
-            ? `<br><span style="color:#9AA1A9">${copy().dayRange(format(point.min), format(point.max), unit)}</span>`
+            ? `<br><span style="color:#B4BBC3">${copy().dayRange(format(point.min), format(point.max), unit)}</span>`
             : '';
         const samples = point.samples
-          ? `<br><span style="color:#6E757D">${copy().samples(point.samples)}</span>`
+          ? `<br><span style="color:#949CA5">${copy().samples(point.samples)}</span>`
           : '';
         return `${point.date}<br><b>${format(point.value)}</b>${unit}${spread}${samples}`;
       },
@@ -201,14 +201,14 @@ export const buildSeriesOption = (
       type: 'category',
       data: dates,
       boundaryGap: bar,
-      axisLabel: { formatter: shortDate, hideOverlap: true, fontSize: 10 },
+      axisLabel: { formatter: shortDate, hideOverlap: true, fontSize: 11 },
       splitLine: { show: false },
     },
     yAxis: {
       type: 'value',
       scale: true,
       splitNumber: 3,
-      axisLabel: { fontSize: 10, formatter: (value: number) => format(value) },
+      axisLabel: { fontSize: 11, formatter: (value: number) => format(value) },
     },
     series: [
       ...(hasSpread

--- a/src/views/ActivityDetail.vue
+++ b/src/views/ActivityDetail.vue
@@ -209,11 +209,11 @@ watch(dataRevision, () => { void load(); });
 <style scoped>
 .metric-page.page { display: grid; gap: var(--space-4); align-content: start; }
 .range-switch { display: flex; gap: var(--space-1); padding: 4px; border-radius: var(--radius-sm); background: var(--surface-raised); }
-.range-pill { min-height: 30px; padding: 5px 12px; border: 1px solid transparent; border-radius: var(--radius-sm); background: transparent; color: var(--muted); font-size: 12px; cursor: pointer; }
+.range-pill { min-height: 30px; padding: 5px 12px; border: 1px solid transparent; border-radius: var(--radius-sm); background: transparent; color: var(--muted); font-size: var(--fs-sm); cursor: pointer; }
 .range-pill:hover { color: var(--ink); }
 .range-pill.is-on { background: var(--accent); color: var(--accent-ink); font-weight: 600; }
 .card-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: var(--space-4); }
-.inline-alert { display: flex; align-items: center; gap: var(--space-2); margin: 0; padding: 9px 13px; border: 1px solid var(--line); border-radius: var(--radius-md); background: var(--surface); color: var(--muted); font-size: 12px; }
+.inline-alert { display: flex; align-items: center; gap: var(--space-2); margin: 0; padding: 9px 13px; border: 1px solid var(--line); border-radius: var(--radius-md); background: var(--surface); color: var(--muted); font-size: var(--fs-sm); }
 .inline-alert[role='alert'] { color: var(--danger); }
 .retry { margin-left: auto; }
 @media (max-width: 720px) {

--- a/src/views/BodyStatus.vue
+++ b/src/views/BodyStatus.vue
@@ -624,11 +624,11 @@ const curveChartOption = computed(() => {
     grid: { left: 40, right: 18, top: 16, bottom: 28 },
     tooltip: {
       trigger: 'axis',
-      backgroundColor: '#22261A',
+      backgroundColor: '#1E221F',
       borderColor: 'rgba(228, 235, 208, 0.16)',
       borderWidth: 1,
       padding: [8, 12],
-      textStyle: { color: '#F3F4EC', fontSize: 12 },
+      textStyle: { color: '#F3F4EC', fontSize: 15.5 },
       extraCssText: 'border-radius:8px;box-shadow:none;',
       formatter: (params: Array<{ value: [number, number | null] }>) => {
         const point = Array.isArray(params) ? params[0] : params;
@@ -641,7 +641,7 @@ const curveChartOption = computed(() => {
       type: 'time',
       min: curve.value[0]?.ts,
       max: curve.value[curve.value.length - 1]?.ts,
-      axisLabel: { formatter: clock, hideOverlap: true, color: '#78818C', fontSize: 10 },
+      axisLabel: { formatter: clock, hideOverlap: true, color: '#B4BBC3', fontSize: 14.5 },
       axisLine: { lineStyle: { color: 'rgba(232,238,244,.12)' } },
       axisTick: { show: false },
       splitLine: { show: false },
@@ -650,7 +650,7 @@ const curveChartOption = computed(() => {
     // 把一个安稳的下午画成剧烈起伏的锯齿。
     yAxis: {
       type: 'value', min: 0, max: 100, splitNumber: 4,
-      axisLabel: { color: '#78818C', fontSize: 10 },
+      axisLabel: { color: '#B4BBC3', fontSize: 14.5 },
       axisLine: { show: false }, axisTick: { show: false },
       splitLine: { lineStyle: { color: 'rgba(232,238,244,.08)', type: 'dashed' } },
     },
@@ -859,24 +859,24 @@ watch(dataRevision, () => { void load(); });
   border-radius: var(--radius-sm);
   background: transparent;
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   cursor: pointer;
 }
 .range-pill:hover { color: var(--ink); }
 .range-pill.is-on { background: var(--accent); color: var(--accent-ink); font-weight: 600; }
 .day-card { padding: 18px 20px; border: 1px solid var(--line); border-radius: var(--radius-md); background: var(--surface); }
 .day-head { display: flex; flex-wrap: wrap; align-items: flex-start; justify-content: space-between; gap: 14px; margin-bottom: 12px; }
-.day-head h2 { margin: 0 0 2px; font-size: 15px; font-weight: 700; color: var(--ink); }
-.day-head p { margin: 0; color: var(--muted); font-size: 12px; }
+.day-head h2 { margin: 0 0 2px; font-size: var(--fs-xl); font-weight: 700; color: var(--ink); }
+.day-head p { margin: 0; color: var(--muted); font-size: var(--fs-sm); }
 .day-stats { display: flex; gap: 18px; margin: 0; }
 .day-stats div { display: grid; gap: 2px; }
-.day-stats dt { color: var(--subtle); font-size: 11px; }
-.day-stats dd { margin: 0; color: var(--ink); font-size: 18px; font-weight: 700; font-family: var(--font-mono); }
+.day-stats dt { color: var(--subtle); font-size: var(--fs-xs); }
+.day-stats dd { margin: 0; color: var(--ink); font-size: var(--fs-3xl); font-weight: 700; font-family: var(--font-mono); }
 .day-chart { width: 100%; height: 240px; }
 /* 区间边界是手表给的，不是我们算的。不写清楚，它就会被当成又一套自选算法。 */
-.curve-note { margin: 10px 0 0; color: var(--subtle); font-size: 11px; line-height: 1.6; }
+.curve-note { margin: 10px 0 0; color: var(--subtle); font-size: var(--fs-xs); line-height: 1.6; }
 .card-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: var(--space-4); }
-.group-title { margin: var(--space-5) 0 0; font-size: 15px; font-weight: 700; color: var(--ink); }
+.group-title { margin: var(--space-5) 0 0; font-size: var(--fs-xl); font-weight: 700; color: var(--ink); }
 .macro-chart { height: 200px; }
 .inline-alert {
   display: flex;
@@ -888,7 +888,7 @@ watch(dataRevision, () => { void load(); });
   border-radius: var(--radius-md);
   background: var(--surface);
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--fs-sm);
 }
 .inline-alert[role='alert'] { color: var(--danger); }
 .retry { margin-left: auto; }

--- a/src/views/DeviceDetail.vue
+++ b/src/views/DeviceDetail.vue
@@ -207,7 +207,7 @@ onMounted(() => {
 .device-page { width: 100%; display: grid; gap: 16px; align-content: start; }
 .detail-loading { display: grid; gap: 12px; }
 .page-toolbar { display: flex; align-items: center; justify-content: space-between; gap: 12px; min-height: 38px; }
-.back-link { display: inline-flex; align-items: center; gap: 6px; color: var(--muted); font-size: 12px; text-decoration: none; }
+.back-link { display: inline-flex; align-items: center; gap: 6px; color: var(--muted); font-size: var(--fs-sm); text-decoration: none; }
 .back-link:hover { color: var(--accent); }
 
 /* 设备主图比列表里的缩略图大一号，上下留够，别把表带切了。 */
@@ -217,26 +217,26 @@ onMounted(() => {
   border: 1px solid var(--line); border-radius: var(--radius-md); background: var(--surface-raised);
 }
 .hero-copy { display: grid; gap: 4px; min-width: 0; }
-.hero-eyebrow { margin: 0; color: var(--subtle); font-size: 11px; letter-spacing: .12em; }
-.hero-copy h1 { margin: 0; font-size: 22px; font-weight: 700; color: var(--ink); }
-.hero-sub { margin: 0; color: var(--muted); font-size: 13px; }
-.hero-state { display: inline-flex; align-items: center; gap: 6px; margin-top: 6px; color: var(--muted); font-size: 12px; }
+.hero-eyebrow { margin: 0; color: var(--subtle); font-size: var(--fs-xs); letter-spacing: .12em; }
+.hero-copy h1 { margin: 0; font-size: 24px; font-weight: 700; color: var(--ink); }
+.hero-sub { margin: 0; color: var(--muted); font-size: var(--fs-md); }
+.hero-state { display: inline-flex; align-items: center; gap: 6px; margin-top: 6px; color: var(--muted); font-size: var(--fs-sm); }
 .hero-state i { width: 7px; height: 7px; border-radius: 50%; background: var(--subtle); }
 .hero-state.on i { background: #7da33e; }
 
 .facts-card, .assign-card { padding: 18px 20px; border: 1px solid var(--line); border-radius: var(--radius-md); background: var(--surface); }
 .facts-card dl { display: grid; gap: 10px; margin: 0; }
 .facts-card dl > div { display: flex; align-items: baseline; justify-content: space-between; gap: 16px; }
-.facts-card dt { color: var(--muted); font-size: 12px; }
-.facts-card dd { margin: 0; color: var(--ink); font-size: 13px; text-align: right; }
-.facts-note { display: flex; align-items: center; gap: 8px; margin: 14px 0 0; color: var(--subtle); font-size: 11px; }
+.facts-card dt { color: var(--muted); font-size: var(--fs-sm); }
+.facts-card dd { margin: 0; color: var(--ink); font-size: var(--fs-md); text-align: right; }
+.facts-note { display: flex; align-items: center; gap: 8px; margin: 14px 0 0; color: var(--subtle); font-size: var(--fs-xs); }
 
-.assign-card h2 { margin: 0 0 6px; font-size: 15px; font-weight: 700; color: var(--ink); }
-.assign-sub { margin: 0 0 14px; color: var(--muted); font-size: 12px; line-height: 1.65; }
+.assign-card h2 { margin: 0 0 6px; font-size: var(--fs-xl); font-weight: 700; color: var(--ink); }
+.assign-sub { margin: 0 0 14px; color: var(--muted); font-size: var(--fs-sm); line-height: 1.65; }
 .inline-actions { display: flex; flex-wrap: wrap; gap: 8px; }
-.hint-line { margin: 10px 0 0; color: var(--muted); font-size: 12px; }
+.hint-line { margin: 10px 0 0; color: var(--muted); font-size: var(--fs-sm); }
 .hint-line.ok { color: #b9da77; }
-.api-error { margin: 10px 0 0; color: #e2856f; font-size: 12px; }
+.api-error { margin: 10px 0 0; color: #e2856f; font-size: var(--fs-sm); }
 
 @media (max-width: 640px) {
   .device-hero { flex-direction: column; align-items: flex-start; }

--- a/src/views/Explore.vue
+++ b/src/views/Explore.vue
@@ -921,10 +921,10 @@ onBeforeUnmount(() => window.clearTimeout(previewTimer));
   box-shadow: 0 18px 44px rgba(4, 6, 8, .55);
 }
 .calendar-popover .cal-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px; }
-.calendar-popover .cal-title { font-size: 12px; font-weight: 600; color: var(--ink); }
+.calendar-popover .cal-title { font-size: var(--fs-sm); font-weight: 600; color: var(--ink); }
 .calendar-popover .cal-nav-btn { display: grid; place-items: center; width: 22px; height: 22px; border: 0; border-radius: 4px; background: var(--surface-raised); color: var(--muted); cursor: pointer; }
 .calendar-popover .cal-nav-btn:hover { color: var(--accent); }
-.calendar-popover .cal-weekdays { display: grid; grid-template-columns: repeat(7, 1fr); text-align: center; font-size: 10px; color: var(--subtle); margin-bottom: 4px; }
+.calendar-popover .cal-weekdays { display: grid; grid-template-columns: repeat(7, 1fr); text-align: center; font-size: var(--fs-2xs); color: var(--subtle); margin-bottom: 4px; }
 .calendar-popover .cal-grid { display: grid; grid-template-columns: repeat(7, 1fr); gap: 2px; }
 .calendar-popover .cal-day {
   display: grid;
@@ -934,7 +934,7 @@ onBeforeUnmount(() => window.clearTimeout(previewTimer));
   border-radius: 4px;
   background: transparent;
   color: var(--ink);
-  font-size: 11px;
+  font-size: var(--fs-xs);
   font-family: var(--font-mono);
   cursor: pointer;
 }
@@ -956,7 +956,7 @@ onBeforeUnmount(() => window.clearTimeout(previewTimer));
   border: 0;
   background: transparent;
   color: var(--subtle);
-  font-size: 11px;
+  font-size: var(--fs-xs);
   cursor: pointer;
 }
 .stream-group-head:hover em { color: var(--accent); }
@@ -971,16 +971,16 @@ onBeforeUnmount(() => window.clearTimeout(previewTimer));
   border: 1px solid transparent;
   border-radius: 8px;
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   cursor: pointer;
 }
 .stream-row:hover { background: var(--surface-raised); }
 .stream-row.is-on { border-color: var(--line-strong); background: var(--surface-raised); color: var(--ink); }
 .stream-row input { width: 13px; height: 13px; margin: 0; accent-color: var(--accent); cursor: pointer; }
-.page-head h1 { margin-bottom: 6px; font-size: 24px; font-weight: 700; color: var(--ink); }
+.page-head h1 { margin-bottom: 6px; font-size: 26.5px; font-weight: 700; color: var(--ink); }
 
-.workout-scope-banner { display: flex; align-items: center; gap: 8px; margin-bottom: 12px; padding: 10px 12px; border: 1px solid var(--line); border-radius: 12px; background: var(--surface-raised); color: var(--subtle); font-size: 12px; }
-.workout-scope-banner code { color: var(--ink); font-family: var(--font-mono); font-size: 11px; }
+.workout-scope-banner { display: flex; align-items: center; gap: 8px; margin-bottom: 12px; padding: 10px 12px; border: 1px solid var(--line); border-radius: 12px; background: var(--surface-raised); color: var(--subtle); font-size: var(--fs-sm); }
+.workout-scope-banner code { color: var(--ink); font-family: var(--font-mono); font-size: var(--fs-xs); }
 .workout-scope-banner .button { margin-left: auto; }
 /* 三栏底部对齐。
  *
@@ -1009,9 +1009,9 @@ onBeforeUnmount(() => window.clearTimeout(previewTimer));
 .col-templates > :last-child { display: flex; flex-direction: column; min-height: 0; }
 .col-templates > :last-child .template-list { overflow-y: auto; min-height: 0; }
 .pad { padding: 16px; }
-.col-title { margin: 0 0 10px; color: var(--ink); font-size: 13px; font-weight: 700; }
-.col-title.big { font-size: 15px; margin-bottom: 4px; }
-.col-sub { margin: 0 0 14px; color: var(--muted); font-size: 12px; }
+.col-title { margin: 0 0 10px; color: var(--ink); font-size: var(--fs-md); font-weight: 700; }
+.col-title.big { font-size: var(--fs-xl); margin-bottom: 4px; }
+.col-sub { margin: 0 0 14px; color: var(--muted); font-size: var(--fs-sm); }
 
 /* 模板分类 */
 .category-list { display: grid; gap: 4px; }
@@ -1025,7 +1025,7 @@ onBeforeUnmount(() => window.clearTimeout(previewTimer));
   border-radius: 9px;
   background: transparent;
   color: var(--muted);
-  font-size: 13px;
+  font-size: var(--fs-md);
   text-align: left;
   cursor: pointer;
   transition: all 140ms ease;
@@ -1033,7 +1033,7 @@ onBeforeUnmount(() => window.clearTimeout(previewTimer));
 .category-item:hover { background: var(--surface-hover); color: var(--ink); }
 .category-item.is-on { background: var(--accent-soft); border-color: rgba(205, 220, 124, .2); color: var(--accent); font-weight: 600; }
 .category-item span { flex: 1; }
-.category-item em { font-style: normal; font-size: 11px; color: var(--subtle); font-family: var(--font-mono); }
+.category-item em { font-style: normal; font-size: var(--fs-xs); color: var(--subtle); font-family: var(--font-mono); }
 .category-item.is-on em { color: var(--accent); }
 
 /* 模板列表 */
@@ -1043,12 +1043,12 @@ onBeforeUnmount(() => window.clearTimeout(previewTimer));
   gap: 7px;
   margin-bottom: 10px;
   padding: 7px 10px;
-  border: 1px solid var(--line);
+  border: 1px solid var(--line-control);
   border-radius: 9px;
   background: var(--surface-raised);
   color: var(--subtle);
 }
-.template-search input { flex: 1; min-width: 0; border: 0; outline: 0; background: transparent; color: var(--ink); font-size: 12px; }
+.template-search input { flex: 1; min-width: 0; border: 0; outline: 0; background: transparent; color: var(--ink); font-size: var(--fs-sm); }
 .template-list { display: grid; gap: 6px; }
 .template-item {
   display: flex;
@@ -1056,14 +1056,14 @@ onBeforeUnmount(() => window.clearTimeout(previewTimer));
   gap: 10px;
   min-width: 0;
   padding: 10px;
-  border: 1px solid var(--line);
+  border: 1px solid var(--line-control);
   border-radius: 11px;
   background: var(--surface-raised);
   text-align: left;
   cursor: pointer;
   transition: border-color 140ms ease, background 140ms ease;
 }
-.template-item:hover { border-color: var(--line-strong); }
+.template-item:hover { border-color: var(--line-control); }
 .template-item.is-on { border-color: rgba(205, 220, 124, .4); background: var(--accent-soft); }
 .tpl-icon {
   display: grid;
@@ -1078,28 +1078,28 @@ onBeforeUnmount(() => window.clearTimeout(previewTimer));
 }
 .template-item.is-on .tpl-icon { color: var(--accent); }
 .tpl-copy { display: grid; gap: 1px; min-width: 0; flex: 1; }
-.tpl-copy strong { font-size: 12px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--ink); }
-.tpl-copy span { color: var(--subtle); font-size: 11px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.tpl-copy strong { font-size: var(--fs-sm); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--ink); }
+.tpl-copy span { color: var(--subtle); font-size: var(--fs-xs); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .tpl-star { color: var(--accent); }
-.empty-note { margin: 4px 0; color: var(--subtle); font-size: 12px; }
+.empty-note { margin: 4px 0; color: var(--subtle); font-size: var(--fs-sm); }
 
 /* 当前模板与编辑器 */
 .current-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; margin-bottom: 14px; }
-.current-head .col-title { margin-bottom: 2px; color: var(--muted); font-weight: 400; font-size: 12px; }
-.tpl-name { display: inline-flex; align-items: center; gap: 8px; margin: 0 0 4px; color: var(--accent); font-size: 20px; font-weight: 700; }
+.current-head .col-title { margin-bottom: 2px; color: var(--muted); font-weight: 400; font-size: var(--fs-sm); }
+.tpl-name { display: inline-flex; align-items: center; gap: 8px; margin: 0 0 4px; color: var(--accent); font-size: 22px; font-weight: 700; }
 .tpl-name svg { color: var(--subtle); }
-.tpl-desc { margin: 0; color: var(--muted); font-size: 12px; }
+.tpl-desc { margin: 0; color: var(--muted); font-size: var(--fs-sm); }
 .mini-btn {
   display: inline-flex;
   align-items: center;
   gap: 6px;
   flex: 0 0 auto;
   padding: 6px 12px;
-  border: 1px solid var(--line);
+  border: 1px solid var(--line-control);
   border-radius: 8px;
   background: var(--surface-raised);
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   cursor: pointer;
   transition: all 140ms ease;
 }
@@ -1110,7 +1110,7 @@ onBeforeUnmount(() => window.clearTimeout(previewTimer));
    让提示词编辑框吃掉：多出来的空间变成更大的编辑区，是有用的。 */
 .col-editor > .current-template { display: flex; flex-direction: column; min-height: 0; }
 .col-editor > .current-template .summary-block { flex: 0 0 auto; }
-.prompt-editor { display: flex; flex: 1 1 auto; flex-direction: column; min-height: 190px; border: 1px solid var(--line); border-radius: var(--radius-sm); background: var(--surface-raised); overflow: hidden; margin-bottom: 14px; }
+.prompt-editor { display: flex; flex: 1 1 auto; flex-direction: column; min-height: 190px; border: 1px solid var(--line-control); border-radius: var(--radius-sm); background: var(--surface-raised); overflow: hidden; margin-bottom: 14px; }
 .editor-head {
   display: flex;
   align-items: center;
@@ -1119,11 +1119,11 @@ onBeforeUnmount(() => window.clearTimeout(previewTimer));
   padding: 9px 12px;
   border-bottom: 1px solid var(--line);
   color: var(--ink);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   font-weight: 600;
 }
 .editor-head em { color: var(--subtle); font-weight: 400; font-style: normal; }
-.injected { display: inline-flex; align-items: center; gap: 5px; color: var(--accent); font-weight: 400; font-size: 11px; }
+.injected { display: inline-flex; align-items: center; gap: 5px; color: var(--accent); font-weight: 400; font-size: var(--fs-xs); }
 .prompt-editor textarea {
   display: block;
   width: 100%;
@@ -1136,33 +1136,33 @@ onBeforeUnmount(() => window.clearTimeout(previewTimer));
   background: transparent;
   color: var(--ink);
   font-family: var(--font-sans);
-  font-size: 12.5px;
+  font-size: var(--fs-sm);
   line-height: 1.8;
 }
 
 /* 数据感知摘要（四格卡片） */
 .summary-block { border: 1px solid var(--line); border-radius: var(--radius-sm); padding: 12px 14px; margin-bottom: 0; background: var(--surface-raised); position: relative; }
-.summary-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 10px; font-size: 12px; font-weight: 600; color: var(--ink); }
+.summary-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 10px; font-size: var(--fs-sm); font-weight: 600; color: var(--ink); }
 .summary-head span:first-child { display: inline-flex; align-items: center; gap: 5px; }
-.see-more { color: var(--subtle); font-size: 11px; font-weight: 400; }
+.see-more { color: var(--subtle); font-size: var(--fs-xs); font-weight: 400; }
 .summary-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 1px; border: 1px solid var(--line); border-radius: 9px; overflow: hidden; background: var(--line); }
 .summary-cell { display: grid; gap: 3px; padding: 10px 12px; background: var(--surface); min-width: 0; }
-.cell-label { display: inline-flex; align-items: center; gap: 5px; color: var(--subtle); font-size: 11px; }
-.cell-value { color: var(--ink); font-size: 15px; font-weight: 600; }
-.cell-value.small { font-size: 12px; }
-.cell-sub { color: var(--subtle); font-size: 11px; }
+.cell-label { display: inline-flex; align-items: center; gap: 5px; color: var(--subtle); font-size: var(--fs-xs); }
+.cell-value { color: var(--ink); font-size: var(--fs-xl); font-weight: 600; }
+.cell-value.small { font-size: var(--fs-sm); }
+.cell-sub { color: var(--subtle); font-size: var(--fs-xs); }
 .font-mono { font-family: var(--font-mono); }
 
 /* 快捷范围与深色日期选择器 */
-.range-row { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin-top: 10px; color: var(--subtle); font-size: 12px; position: relative; }
-.range-label { color: var(--subtle); font-size: 11px; }
+.range-row { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin-top: 10px; color: var(--subtle); font-size: var(--fs-sm); position: relative; }
+.range-label { color: var(--subtle); font-size: var(--fs-xs); }
 .range-pill {
   padding: 3px 10px;
-  border: 1px solid var(--line);
+  border: 1px solid var(--line-control);
   border-radius: 999px;
   background: transparent;
   color: var(--muted);
-  font-size: 11px;
+  font-size: var(--fs-xs);
   cursor: pointer;
 }
 .range-pill.is-on { border-color: var(--accent); background: var(--accent-soft); color: var(--accent); }
@@ -1173,16 +1173,16 @@ onBeforeUnmount(() => window.clearTimeout(previewTimer));
   align-items: center;
   gap: 6px;
   padding: 4px 10px;
-  border: 1px solid var(--line);
+  border: 1px solid var(--line-control);
   border-radius: 7px;
   background: var(--surface);
   color: var(--ink);
-  font-size: 11px;
+  font-size: var(--fs-xs);
   font-family: var(--font-mono);
   cursor: pointer;
 }
 .date-trigger-btn.is-open { border-color: var(--accent); }
-.date-trigger-btn:hover { border-color: var(--line-strong); }
+.date-trigger-btn:hover { border-color: var(--line-control); }
 
 /* 底部操作条 */
 .editor-footer {
@@ -1193,22 +1193,22 @@ onBeforeUnmount(() => window.clearTimeout(previewTimer));
   padding: 12px 16px;
   flex-wrap: wrap;
 }
-.secure-note { display: inline-flex; align-items: center; gap: 7px; margin: 0; color: var(--muted); font-size: 12px; flex-wrap: wrap; }
+.secure-note { display: inline-flex; align-items: center; gap: 7px; margin: 0; color: var(--muted); font-size: var(--fs-sm); flex-wrap: wrap; }
 .secure-note > svg { color: var(--accent); }
 .secure-ok { display: inline-flex; align-items: center; gap: 4px; color: var(--accent); }
 .footer-actions { display: flex; gap: 8px; flex-wrap: wrap; }
 .send-btn { min-width: 128px; }
-.action-note { display: inline-flex; align-items: center; gap: 6px; margin: 0; font-size: 12px; }
+.action-note { display: inline-flex; align-items: center; gap: 6px; margin: 0; font-size: var(--fs-sm); }
 .action-note.ok { color: var(--accent); }
 .action-note.bad { color: var(--danger); }
 
 /* 右列 */
-.group-label { margin: 0 0 8px; color: var(--ink); font-size: 12px; font-weight: 700; }
+.group-label { margin: 0 0 8px; color: var(--ink); font-size: var(--fs-sm); font-weight: 700; }
 /* 折叠而不是常驻：大多数人不需要读它，但需要读的时候必须在按下导出**之前**
    就能找到（issue #28）。 */
 .pack-contents { margin: 0 0 14px; }
-.pack-contents summary { color: var(--accent); cursor: pointer; font-size: 12px; font-weight: 600; }
-.pack-contents p { margin: 8px 0 0; color: var(--subtle); font-size: 11px; line-height: 1.65; }
+.pack-contents summary { color: var(--accent); cursor: pointer; font-size: var(--fs-sm); font-weight: 600; }
+.pack-contents p { margin: 8px 0 0; color: var(--subtle); font-size: var(--fs-xs); line-height: 1.65; }
 .group-row { display: flex; align-items: center; justify-content: space-between; margin-top: 16px; }
 .group-row .group-label { margin: 0; }
 .format-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 8px; margin-bottom: 4px; }
@@ -1218,16 +1218,16 @@ onBeforeUnmount(() => window.clearTimeout(previewTimer));
   justify-items: center;
   gap: 4px;
   padding: 12px 6px 10px;
-  border: 1px solid var(--line);
+  border: 1px solid var(--line-control);
   border-radius: 11px;
   background: var(--surface-raised);
   color: var(--muted);
-  font-size: 11px;
+  font-size: var(--fs-xs);
   cursor: pointer;
   transition: all 140ms ease;
 }
-.format-card strong { color: var(--ink); font-size: 12px; }
-.format-card span { color: var(--subtle); font-size: 10px; }
+.format-card strong { color: var(--ink); font-size: var(--fs-sm); }
+.format-card span { color: var(--subtle); font-size: var(--fs-2xs); }
 .format-card.is-on { border-color: var(--accent); background: var(--accent-soft); }
 .format-card.is-on svg, .format-card.is-on strong { color: var(--accent); }
 .format-check { position: absolute; top: 6px; right: 6px; }
@@ -1244,7 +1244,7 @@ onBeforeUnmount(() => window.clearTimeout(previewTimer));
   border-radius: 9px;
   background: var(--surface-raised);
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--fs-sm);
 }
 .size-row strong { color: var(--accent); font-variant-numeric: tabular-nums; }
 
@@ -1256,11 +1256,11 @@ onBeforeUnmount(() => window.clearTimeout(previewTimer));
   gap: 8px;
   min-height: 42px;
   padding: 8px 10px;
-  border: 1px solid var(--line);
+  border: 1px solid var(--line-control);
   border-radius: 10px;
   background: var(--surface-raised);
   color: var(--ink);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   cursor: pointer;
   transition: border-color 140ms ease;
 }
@@ -1277,11 +1277,11 @@ onBeforeUnmount(() => window.clearTimeout(previewTimer));
   color: var(--muted);
 }
 .tool-logo img { width: 16px; height: 16px; object-fit: contain; }
-.tool-fallback { color: var(--muted); font-size: 12px; font-weight: 700; line-height: 1; }
+.tool-fallback { color: var(--muted); font-size: var(--fs-sm); font-weight: 700; line-height: 1; }
 .tool-card.is-on .tool-logo { color: var(--accent); }
 .tool-check { position: absolute; top: 5px; right: 6px; color: var(--accent); }
 
-.send-hint { display: flex; align-items: flex-start; gap: 6px; margin: 14px 0 0; color: var(--subtle); font-size: 11px; line-height: 1.45; }
+.send-hint { display: flex; align-items: flex-start; gap: 6px; margin: 14px 0 0; color: var(--subtle); font-size: var(--fs-xs); line-height: 1.45; }
 .retry-open { width: fit-content; margin-top: 2px; }
 
 /* 响应式 */

--- a/src/views/HealthCheck.vue
+++ b/src/views/HealthCheck.vue
@@ -600,21 +600,21 @@ onMounted(() => void load());
   border-radius: 16px;
   background: var(--surface);
 }
-.health-card h2 { margin: 0; color: var(--ink); font-size: 14px; font-weight: 500; }
-.health-note { margin: 0; color: var(--subtle); font-size: 11px; line-height: 1.6; }
+.health-card h2 { margin: 0; color: var(--ink); font-size: var(--fs-lg); font-weight: 600; }
+.health-note { margin: 0; color: var(--subtle); font-size: var(--fs-xs); line-height: 1.6; }
 .health-note.ok { color: var(--accent); }
 
 .timing-grid, .fact-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 12px; }
 .timing-grid > div { display: grid; gap: 2px; }
-.timing-label { color: var(--muted); font-size: 11px; }
-.timing-grid strong { color: var(--ink); font-size: 13px; font-weight: 500; }
-.timing-note { color: var(--subtle); font-size: 11px; line-height: 1.5; }
+.timing-label { color: var(--muted); font-size: var(--fs-xs); }
+.timing-grid strong { color: var(--ink); font-size: var(--fs-md); font-weight: 600; }
+.timing-note { color: var(--subtle); font-size: var(--fs-xs); line-height: 1.5; }
 
 .fact-grid > div { display: grid; gap: 2px; }
-.fact-grid span { color: var(--muted); font-size: 11px; }
-.fact-grid strong { color: var(--ink); font-size: 15px; font-weight: 500; }
+.fact-grid span { color: var(--muted); font-size: var(--fs-xs); }
+.fact-grid strong { color: var(--ink); font-size: var(--fs-xl); font-weight: 600; }
 .fact-grid strong.warn { color: var(--warning, var(--accent)); }
-.fact-grid strong.mono { font-family: var(--font-mono); font-size: 11px; word-break: break-all; }
+.fact-grid strong.mono { font-family: var(--font-mono); font-size: var(--fs-xs); word-break: break-all; }
 
 .stream-list, .occasional-list, .action-list { display: grid; gap: 10px; }
 .stream-row {
@@ -626,33 +626,33 @@ onMounted(() => void load());
   background: var(--surface-raised);
 }
 .stream-row header { display: flex; align-items: baseline; gap: 8px; }
-.stream-row header strong { color: var(--ink); font-size: 13px; font-weight: 500; }
-.cadence { color: var(--muted); font-size: 11px; }
+.stream-row header strong { color: var(--ink); font-size: var(--fs-md); font-weight: 600; }
+.cadence { color: var(--muted); font-size: var(--fs-xs); }
 
 .stages { display: flex; flex-wrap: wrap; gap: 8px; }
-.stage { display: inline-flex; align-items: center; gap: 6px; color: var(--muted); font-size: 11px; }
+.stage { display: inline-flex; align-items: center; gap: 6px; color: var(--muted); font-size: var(--fs-xs); }
 .stage i { width: 6px; height: 6px; border-radius: 50%; background: currentColor; }
 .stage.ok { color: var(--accent); }
 .stage.failed { color: var(--danger); }
 
-.stream-message { margin: 0; color: var(--danger); font-size: 11px; line-height: 1.5; }
+.stream-message { margin: 0; color: var(--danger); font-size: var(--fs-xs); line-height: 1.5; }
 .stream-facts { display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 8px; margin: 0; }
 .stream-facts div { display: grid; gap: 1px; }
-.stream-facts dt { color: var(--muted); font-size: 11px; }
-.stream-facts dd { margin: 0; color: var(--ink); font-size: 12px; }
-.coverage-note { margin: 0; color: var(--subtle); font-size: 11px; line-height: 1.6; }
+.stream-facts dt { color: var(--muted); font-size: var(--fs-xs); }
+.stream-facts dd { margin: 0; color: var(--ink); font-size: var(--fs-sm); }
+.coverage-note { margin: 0; color: var(--subtle); font-size: var(--fs-xs); line-height: 1.6; }
 
 .occasional-row { display: grid; grid-template-columns: minmax(0, 1fr) auto auto; gap: 10px; align-items: baseline; padding: 8px 0; border-bottom: 1px solid var(--line); }
 .occasional-row:last-child { border-bottom: 0; }
-.occasional-row strong { color: var(--ink); font-size: 12px; font-weight: 500; }
-.occasional-row span { color: var(--subtle); font-size: 11px; }
+.occasional-row strong { color: var(--ink); font-size: var(--fs-sm); font-weight: 600; }
+.occasional-row span { color: var(--subtle); font-size: var(--fs-xs); }
 .occasional-row .muted { color: var(--muted); }
 
 .action-row { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 12px; align-items: center; padding: 10px 0; border-bottom: 1px solid var(--line); }
 .action-row:last-child { border-bottom: 0; }
 .action-row div { display: grid; gap: 2px; }
-.action-row strong { color: var(--ink); font-size: 12px; font-weight: 500; }
-.action-row span { color: var(--subtle); font-size: 11px; line-height: 1.5; }
+.action-row strong { color: var(--ink); font-size: var(--fs-sm); font-weight: 600; }
+.action-row span { color: var(--subtle); font-size: var(--fs-xs); line-height: 1.5; }
 
 .inline-alert.neutral { color: var(--muted); }
 </style>

--- a/src/views/HeartRateDetail.vue
+++ b/src/views/HeartRateDetail.vue
@@ -152,11 +152,11 @@ const dayChartOption = computed(() => {
     grid: { left: 40, right: 18, top: 16, bottom: 28 },
     tooltip: {
       trigger: 'axis',
-      backgroundColor: '#22261A',
+      backgroundColor: '#1E221F',
       borderColor: 'rgba(228, 235, 208, 0.16)',
       borderWidth: 1,
       padding: [8, 12],
-      textStyle: { color: '#F3F4EC', fontSize: 12 },
+      textStyle: { color: '#F3F4EC', fontSize: 15.5 },
       extraCssText: 'border-radius:8px;box-shadow:none;',
       formatter: (params: Array<{ value: [number, number] }>) => {
         const point = Array.isArray(params) ? params[0] : params;
@@ -168,14 +168,14 @@ const dayChartOption = computed(() => {
       type: 'time',
       min: data[0]?.[0],
       max: data[data.length - 1]?.[0],
-      axisLabel: { formatter: clock, hideOverlap: true, color: '#78818C', fontSize: 10 },
+      axisLabel: { formatter: clock, hideOverlap: true, color: '#B4BBC3', fontSize: 14.5 },
       axisLine: { lineStyle: { color: 'rgba(232,238,244,.12)' } },
       axisTick: { show: false },
       splitLine: { show: false },
     },
     yAxis: {
       type: 'value', scale: true, splitNumber: 4,
-      axisLabel: { color: '#78818C', fontSize: 10 },
+      axisLabel: { color: '#B4BBC3', fontSize: 14.5 },
       axisLine: { show: false }, axisTick: { show: false },
       splitLine: { lineStyle: { color: 'rgba(232,238,244,.08)', type: 'dashed' } },
     },
@@ -253,7 +253,7 @@ const dailyMaxChartOption = computed(() => {
     legend: {
       data: [t.value.dailyMaxLegendMax, t.value.dailyMaxLegendAvg],
       top: 0,
-      textStyle: { color: '#7E856D', fontSize: 11 },
+      textStyle: { color: '#B4BBC3', fontSize: 14.5 },
     },
     tooltip: {
       trigger: 'axis',
@@ -266,17 +266,17 @@ const dailyMaxChartOption = computed(() => {
     xAxis: {
       type: 'category',
       data: rows.map((row) => row.date.slice(5)),
-      axisLabel: { color: '#7E856D', fontSize: 11, hideOverlap: true },
+      axisLabel: { color: '#B4BBC3', fontSize: 14.5, hideOverlap: true },
       axisTick: { show: false },
       axisLine: { lineStyle: { color: 'rgba(226, 234, 242, .12)' } },
     },
     yAxis: {
       type: 'value',
       scale: true,
-      axisLabel: { color: '#7E856D', fontSize: 11 },
+      axisLabel: { color: '#B4BBC3', fontSize: 14.5 },
       axisLine: { show: false },
       axisTick: { show: false },
-      splitLine: { lineStyle: { color: 'rgba(226, 234, 242, .08)', type: 'dashed' } },
+      splitLine: { lineStyle: { color: 'rgba(226, 234, 242, .12)', type: 'dashed' } },
     },
     series: [
       {
@@ -415,22 +415,22 @@ watch(dataRevision, () => { void load(); });
 .metric-page.page { display: grid; gap: var(--space-4); align-content: start; }
 .stack { display: grid; gap: var(--space-4); }
 .range-switch { display: flex; gap: var(--space-1); padding: 4px; border-radius: var(--radius-sm); background: var(--surface-raised); }
-.range-pill { min-height: 30px; padding: 5px 12px; border: 1px solid transparent; border-radius: var(--radius-sm); background: transparent; color: var(--muted); font-size: 12px; cursor: pointer; }
+.range-pill { min-height: 30px; padding: 5px 12px; border: 1px solid transparent; border-radius: var(--radius-sm); background: transparent; color: var(--muted); font-size: var(--fs-sm); cursor: pointer; }
 .range-pill:hover { color: var(--ink); }
 .range-pill.is-on { background: var(--accent); color: var(--accent-ink); font-weight: 600; }
 .day-card { padding: 18px 20px; border: 1px solid var(--line); border-radius: var(--radius-md); background: var(--surface); }
 .day-head { display: flex; flex-wrap: wrap; align-items: flex-start; justify-content: space-between; gap: 14px; margin-bottom: 12px; }
-.day-head h2 { margin: 0 0 2px; font-size: 15px; font-weight: 700; color: var(--ink); }
-.day-head p { margin: 0; color: var(--muted); font-size: 12px; }
+.day-head h2 { margin: 0 0 2px; font-size: var(--fs-xl); font-weight: 700; color: var(--ink); }
+.day-head p { margin: 0; color: var(--muted); font-size: var(--fs-sm); }
 .day-stats { display: flex; gap: 18px; margin: 0; }
 .day-stats div { display: grid; gap: 2px; }
-.day-stats dt { color: var(--subtle); font-size: 11px; }
-.day-stats dd { margin: 0; color: var(--ink); font-size: 18px; font-weight: 700; font-family: var(--font-mono); }
+.day-stats dt { color: var(--subtle); font-size: var(--fs-xs); }
+.day-stats dd { margin: 0; color: var(--ink); font-size: var(--fs-3xl); font-weight: 700; font-family: var(--font-mono); }
 .day-chart { width: 100%; height: 240px; }
 /* 说明为什么这个数字和 Zepp App 里的不一样。少了它，用户只会以为其中一边坏了。 */
-.daily-max-note { margin: 10px 0 0; color: var(--subtle); font-size: 11px; line-height: 1.6; }
+.daily-max-note { margin: 10px 0 0; color: var(--subtle); font-size: var(--fs-xs); line-height: 1.6; }
 .card-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: var(--space-4); }
-.inline-alert { display: flex; align-items: center; gap: var(--space-2); margin: 0; padding: 9px 13px; border: 1px solid var(--line); border-radius: var(--radius-md); background: var(--surface); color: var(--muted); font-size: 12px; }
+.inline-alert { display: flex; align-items: center; gap: var(--space-2); margin: 0; padding: 9px 13px; border: 1px solid var(--line); border-radius: var(--radius-md); background: var(--surface); color: var(--muted); font-size: var(--fs-sm); }
 .inline-alert[role='alert'] { color: var(--danger); }
 .retry { margin-left: auto; }
 @media (max-width: 720px) {

--- a/src/views/LandingPage.vue
+++ b/src/views/LandingPage.vue
@@ -530,34 +530,34 @@ const revealStarNudge = () => {
 .landing-nav { position: relative; z-index: 10; display: flex; align-items: center; justify-content: space-between; width: min(1240px, calc(100% - 48px)); min-height: 74px; margin: 0 auto; border-bottom: 1px solid var(--site-line); }
 .landing-brand { display: inline-flex; align-items: center; gap: 10px; text-decoration: none; }
 .landing-brand > span { display: grid; flex: 0 0 auto; place-items: center; width: 42px; height: 42px; border-radius: 13px; background: rgba(203,229,132,.05); }
-.landing-brand strong { font-size: 18px; letter-spacing: -.02em; }
+.landing-brand strong { font-size: var(--fs-3xl); letter-spacing: -.02em; }
 .landing-nav nav { display: flex; gap: 30px; }
-.landing-nav nav a { color: #9ca892; font-size: 12px; text-decoration: none; }
+.landing-nav nav a { color: #9ca892; font-size: var(--fs-sm); text-decoration: none; }
 .landing-nav nav a:hover { color: #d6e99e; }
 .nav-actions { display: inline-flex; align-items: center; gap: 10px; }
-.lang-toggle { display: inline-flex; align-items: center; gap: 6px; padding: 7px 12px 7px 8px; border: 1px solid var(--site-line); border-radius: 11px; background: rgba(255,255,255,.02); color: #9ca892; font: inherit; font-size: 12px; font-weight: 700; white-space: nowrap; cursor: pointer; }
+.lang-toggle { display: inline-flex; align-items: center; gap: 6px; padding: 7px 12px 7px 8px; border: 1px solid var(--site-line); border-radius: 11px; background: rgba(255,255,255,.02); color: #9ca892; font: inherit; font-size: var(--fs-sm); font-weight: 700; white-space: nowrap; cursor: pointer; }
 .lang-toggle:hover { color: #d6e99e; border-color: rgba(185,220,112,.5); }
-.nav-github { display: inline-flex; align-items: center; gap: 7px; padding: 8px 12px 8px 10px; border: 1px solid rgba(185,220,112,.28); border-radius: 11px; background: rgba(185,220,112,.07); color: #dce7cb; font-size: 12px; font-weight: 700; text-decoration: none; white-space: nowrap; }
+.nav-github { display: inline-flex; align-items: center; gap: 7px; padding: 8px 12px 8px 10px; border: 1px solid rgba(185,220,112,.28); border-radius: 11px; background: rgba(185,220,112,.07); color: #dce7cb; font-size: var(--fs-sm); font-weight: 700; text-decoration: none; white-space: nowrap; }
 .nav-github svg { width: 17px; height: 17px; fill: none; stroke: #b9dc70; stroke-width: 1.65; stroke-linejoin: round; }
 main, footer { position: relative; z-index: 1; }
 .hero-section { display: grid; grid-template-columns: minmax(0,.9fr) minmax(520px,1.1fr); align-items: center; gap: 42px; width: min(1240px, calc(100% - 48px)); min-height: 690px; margin: 0 auto; padding: 72px 0 82px; }
-.overline, .section-heading > p, .connect-intro > p, .privacy-copy > p { display: flex; align-items: center; gap: 8px; margin: 0 0 20px; color: #91b44e; font-family: var(--font-mono); font-size: 10px; font-weight: 700; letter-spacing: .17em; }
+.overline, .section-heading > p, .connect-intro > p, .privacy-copy > p { display: flex; align-items: center; gap: 8px; margin: 0 0 20px; color: #91b44e; font-family: var(--font-mono); font-size: var(--fs-2xs); font-weight: 700; letter-spacing: .17em; }
 .overline span { width: 24px; height: 1px; background: #91b44e; }
 .hero-copy h1 { max-width: 660px; margin: 0; font-size: clamp(48px, 5.5vw, 78px); line-height: 1.03; letter-spacing: -.065em; }
 .hero-copy h1 em { color: #b9dc70; font-style: normal; }
-.hero-lead { max-width: 620px; margin: 26px 0 0; color: #9da79a; font-size: 16px; line-height: 1.8; }
+.hero-lead { max-width: 620px; margin: 26px 0 0; color: #9da79a; font-size: var(--fs-2xl); line-height: 1.8; }
 .hero-actions { display: flex; flex-wrap: wrap; align-items: flex-start; gap: 12px; margin-top: 32px; }
 .download-choice { display: grid; gap: 7px; }
 .primary-cta { display: inline-flex; align-items: center; text-decoration: none; }
 .primary-cta { gap: 10px; min-width: 244px; white-space: nowrap; padding: 8px 10px 8px 8px; border: 1px solid rgba(185,220,112,.45); border-radius: 14px; background: linear-gradient(135deg, #789f39, #58772c); color: #f8faef; box-shadow: 0 14px 32px rgba(80,111,38,.2); }
 .primary-cta > span { display: grid; margin-right: auto; }
-.primary-cta b { font-size: 13px; } .primary-cta small { color: rgba(247,250,238,.68); font-size: 10px; }
+.primary-cta b { font-size: var(--fs-md); } .primary-cta small { color: rgba(247,250,238,.68); font-size: var(--fs-2xs); }
 .alt-cta { display: inline-flex; gap: 9px; align-items: center; white-space: nowrap; padding: 8px 14px 8px 9px; border: 1px solid var(--site-line); border-radius: 14px; background: #151915; color: #dce6cd; text-decoration: none; }
 .alt-cta > span { display: grid; }
-.alt-cta b { font-size: 12px; font-weight: 700; } .alt-cta small { color: rgba(220,230,205,.6); font-size: 10px; }
+.alt-cta b { font-size: var(--fs-sm); font-weight: 700; } .alt-cta small { color: rgba(220,230,205,.6); font-size: var(--fs-2xs); }
 .alt-cta:hover { transform: translateY(-2px); border-color: rgba(185,220,112,.5); }
 .alt-cta { transition: transform .2s ease, border-color .2s ease; }
-.format-link { justify-self: center; color: #788474; font-size: 9px; text-underline-offset: 3px; }
+.format-link { justify-self: center; color: #788474; font-size: var(--fs-2xs); text-underline-offset: 3px; }
 .format-link:hover { color: #b9ce9c; }
 .primary-cta, .nav-github, .lang-toggle { transition: transform .2s ease, border-color .2s ease, color .2s ease; }
 .primary-cta:hover, .nav-github:hover { transform: translateY(-2px); border-color: rgba(185,220,112,.5); }
@@ -565,14 +565,14 @@ main, footer { position: relative; z-index: 1; }
 /* Linux 一行，四个包并排。刻意不做成第三个大按钮：它还没有经过实机验证，
    和 Windows / macOS 并列会暗示同等成熟度。 */
 .linux-row { margin-top: 16px; }
-.linux-head { display: flex; align-items: center; gap: 8px; margin: 0 0 6px; font-size: 12px; color: #9aa79a; }
-.linux-head strong { color: #cfd8cd; font-size: 13px; }
+.linux-head { display: flex; align-items: center; gap: 8px; margin: 0 0 6px; font-size: var(--fs-sm); color: #9aa79a; }
+.linux-head strong { color: #cfd8cd; font-size: var(--fs-md); }
 .linux-head em {
   padding: 1px 7px;
   border: 1px solid rgba(226, 234, 242, .22);
   border-radius: 999px;
   color: #c9a86a;
-  font-size: 10px;
+  font-size: var(--fs-2xs);
   font-style: normal;
   letter-spacing: .04em;
   text-transform: uppercase;
@@ -583,12 +583,12 @@ main, footer { position: relative; z-index: 1; }
   border: 1px solid rgba(226, 234, 242, .18);
   border-radius: 8px;
   color: #cfd8cd;
-  font-size: 12px;
+  font-size: var(--fs-sm);
   text-decoration: none;
 }
 .linux-links a:hover { border-color: rgba(226, 234, 242, .4); }
-.linux-note { max-width: 52ch; margin: 8px 0 0; color: #778274; font-size: 11px; line-height: 1.6; }
-.release-status { display: flex; align-items: center; gap: 7px; min-height: 18px; margin: 14px 0 0; color: #778274; font-size: 10px; }
+.linux-note { max-width: 52ch; margin: 8px 0 0; color: #778274; font-size: var(--fs-xs); line-height: 1.6; }
+.release-status { display: flex; align-items: center; gap: 7px; min-height: 18px; margin: 14px 0 0; color: #778274; font-size: var(--fs-2xs); }
 .release-status i { width: 6px; height: 6px; border-radius: 50%; background: #697365; }
 .release-status.is-loading i { background: #8faa58; animation: release-pulse 1.4s ease-in-out infinite; }
 .release-status.is-ready { color: #96aa86; }
@@ -598,15 +598,15 @@ main, footer { position: relative; z-index: 1; }
 .star-nudge { display: grid; grid-template-columns: auto minmax(0,1fr) auto auto; align-items: center; gap: 12px; max-width: 620px; margin-top: 16px; padding: 13px 14px; border: 1px solid rgba(185,220,112,.2); border-radius: 15px; background: rgba(24,30,22,.92); box-shadow: inset 0 1px 0 rgba(255,255,255,.035); }
 .star-nudge > svg { width: 25px; height: 25px; fill: rgba(185,220,112,.08); stroke: #b9dc70; stroke-width: 1.55; stroke-linejoin: round; }
 .star-nudge > div { display: grid; gap: 3px; }
-.star-nudge strong { color: #e3ead9; font-size: 11px; }
-.star-nudge p { margin: 0; color: #889582; font-size: 9px; line-height: 1.55; }
-.star-nudge a { padding: 8px 10px; border: 1px solid rgba(185,220,112,.25); border-radius: 10px; background: rgba(185,220,112,.08); color: #cce39b; font-size: 10px; font-weight: 700; text-decoration: none; white-space: nowrap; }
-.star-nudge button { padding: 7px 5px; border: 0; background: transparent; color: #6f7b6b; font: inherit; font-size: 9px; cursor: pointer; white-space: nowrap; }
+.star-nudge strong { color: #e3ead9; font-size: var(--fs-xs); }
+.star-nudge p { margin: 0; color: #889582; font-size: var(--fs-2xs); line-height: 1.55; }
+.star-nudge a { padding: 8px 10px; border: 1px solid rgba(185,220,112,.25); border-radius: 10px; background: rgba(185,220,112,.08); color: #cce39b; font-size: var(--fs-2xs); font-weight: 700; text-decoration: none; white-space: nowrap; }
+.star-nudge button { padding: 7px 5px; border: 0; background: transparent; color: #7a8775; font: inherit; font-size: var(--fs-2xs); cursor: pointer; white-space: nowrap; }
 .star-nudge button:hover { color: #aebba7; }
 .star-nudge-enter-active, .star-nudge-leave-active { transition: opacity .24s ease, transform .24s cubic-bezier(.16,1,.3,1); }
 .star-nudge-enter-from, .star-nudge-leave-to { opacity: 0; transform: translateY(-5px); }
 @keyframes release-pulse { 0%,100% { opacity: .35; transform: scale(.78); } 50% { opacity: 1; transform: scale(1); } }
-.trust-row { display: flex; gap: 20px; margin-top: 26px; color: #7e8a79; font-size: 10px; }
+.trust-row { display: flex; gap: 20px; margin-top: 26px; color: #7e8a79; font-size: var(--fs-2xs); }
 .trust-row span { display: inline-flex; align-items: center; gap: 5px; }
 .hero-stage { position: relative; display: grid; align-content: start; gap: 18px; min-height: 510px; padding: 28px 22px 18px; overflow: hidden; border: 1px solid var(--site-line); border-radius: 28px; background: linear-gradient(145deg, rgba(26,32,25,.9), rgba(13,16,14,.94)); box-shadow: inset 0 1px 0 rgba(255,255,255,.025), 0 35px 90px rgba(0,0,0,.24); }
 .stage-glow { position: absolute; inset: 13% 24%; border-radius: 50%; background: rgba(130,175,61,.13); filter: blur(70px); pointer-events: none; }
@@ -614,16 +614,16 @@ main, footer { position: relative; z-index: 1; }
 .mini-flow i { position: relative; display: block; height: 1px; background: linear-gradient(90deg, rgba(145,180,78,.15), #8fb34a); }
 .mini-flow i::after { position: absolute; top: -3px; right: -1px; width: 7px; height: 7px; border-top: 1px solid #8fb34a; border-right: 1px solid #8fb34a; content: ''; transform: rotate(45deg); }
 .bridge-core { position: relative; z-index: 2; display: grid; justify-items: center; justify-self: center; gap: 8px; width: 168px; padding: 14px 12px; border: 1px solid rgba(185,220,112,.25); border-radius: 23px; background: linear-gradient(145deg, rgba(56,72,38,.85), rgba(26,33,24,.95)); box-shadow: 0 20px 55px rgba(0,0,0,.3); }
-.bridge-core div { display: grid; justify-items: center; } .bridge-core span { color: #8fa968; font-family: var(--font-mono); font-size: 8px; letter-spacing: .14em; } .bridge-core strong { font-size: 16px; } .bridge-core small { color: #7e8a76; font-size: 9px; }
+.bridge-core div { display: grid; justify-items: center; } .bridge-core span { color: #8fa968; font-family: var(--font-mono); font-size: var(--fs-2xs); letter-spacing: .14em; } .bridge-core strong { font-size: var(--fs-2xl); } .bridge-core small { color: #7e8a76; font-size: var(--fs-2xs); }
 .output-stack { position: relative; z-index: 1; display: grid; grid-template-columns: 1fr 1fr; gap: 13px; }
 .output-stack article { display: flex; align-items: center; gap: 8px; padding: 9px; border: 1px solid var(--site-line); border-radius: 14px; background: rgba(20,25,21,.92); }
-.output-stack span { display: grid; } .output-stack b { font-size: 11px; } .output-stack small { color: #737e70; font-size: 8px; }
+.output-stack span { display: grid; } .output-stack b { font-size: var(--fs-xs); } .output-stack small { color: #778374; font-size: var(--fs-2xs); }
 .stage-status { position: relative; z-index: 1; display: flex; align-items: center; gap: 8px; padding: 9px 0 0; border-top: 1px solid var(--site-line); color: #9aaa8e; }
-.stage-status span { display: grid; } .stage-status b { color: #b8d27e; font-size: 10px; } .stage-status small { font-size: 9px; }
+.stage-status span { display: grid; } .stage-status b { color: #b8d27e; font-size: var(--fs-2xs); } .stage-status small { font-size: var(--fs-2xs); }
 .principle-strip { display: grid; grid-template-columns: repeat(4,1fr); width: min(1240px, calc(100% - 48px)); margin: 0 auto; border-top: 1px solid var(--site-line); border-bottom: 1px solid var(--site-line); }
 .principle-strip > div { display: flex; align-items: center; justify-content: center; gap: 9px; min-height: 92px; border-right: 1px solid var(--site-line); }
 .principle-strip > div:last-child { border-right: 0; }
-.principle-strip span { display: grid; } .principle-strip b { font-size: 11px; } .principle-strip small { color: #717c6d; font-size: 9px; }
+.principle-strip span { display: grid; } .principle-strip b { font-size: var(--fs-xs); } .principle-strip small { color: #727e6e; font-size: var(--fs-2xs); }
 .content-section { width: min(1240px, calc(100% - 48px)); margin: 0 auto; padding: 116px 0; }
 .section-heading { max-width: 780px; }
 .section-heading > p, .connect-intro > p, .privacy-copy > p { margin-bottom: 12px; }
@@ -632,7 +632,7 @@ main, footer { position: relative; z-index: 1; }
 .capability-grid { display: grid; grid-template-columns: repeat(4,1fr); gap: 14px; margin-top: 48px; }
 .capability-card { position: relative; overflow: hidden; display: grid; min-height: 260px; padding: 22px; border: 1px solid var(--site-line); border-radius: 21px; background: var(--site-card); }
 .capability-card::before { position: absolute; right: -40px; bottom: -60px; width: 160px; height: 160px; border-radius: 50%; content: ''; background: rgba(125,163,62,.08); filter: blur(12px); }
-.capability-card > span { display: grid; align-self: end; gap: 5px; } .capability-card b { font-size: 18px; } .capability-card small { color: #7e897a; line-height: 1.65; }
+.capability-card > span { display: grid; align-self: end; gap: 5px; } .capability-card b { font-size: var(--fs-3xl); } .capability-card small { color: #7e897a; line-height: 1.65; }
 .capability-card > .design-icon:last-child { position: absolute; top: 22px; right: 20px; opacity: .5; }
 .capability-card.tone-red::before { background: rgba(240,97,106,.12); } .capability-card.tone-purple::before { background: rgba(139,92,246,.14); } .capability-card.tone-blue::before { background: rgba(74,168,232,.13); }
 .connect-section { display: grid; grid-template-columns: .82fr 1.18fr; gap: 70px; align-items: center; }
@@ -640,14 +640,14 @@ main, footer { position: relative; z-index: 1; }
 .mini-flow { display: grid; gap: 12px; width: 90px; }
 .auth-grid { display: grid; grid-template-columns: repeat(3,1fr); gap: 12px; }
 .auth-grid article { position: relative; min-height: 315px; padding: 19px; border: 1px solid var(--site-line); border-radius: 21px; background: linear-gradient(160deg, #181d18, #111411); }
-.auth-title { display: flex; align-items: flex-start; justify-content: space-between; } .auth-title > span { padding: 3px 7px; border-radius: 6px; background: rgba(145,180,78,.1); color: #9fbd63; font-size: 9px; }
-.auth-grid h3 { margin: 56px 0 8px; font-size: 18px; } .auth-grid p { margin: 0; color: #7c8778; font-size: 11px; line-height: 1.7; }
+.auth-title { display: flex; align-items: flex-start; justify-content: space-between; } .auth-title > span { padding: 3px 7px; border-radius: 6px; background: rgba(145,180,78,.1); color: #9fbd63; font-size: var(--fs-2xs); }
+.auth-grid h3 { margin: 56px 0 8px; font-size: var(--fs-3xl); } .auth-grid p { margin: 0; color: #7c8778; font-size: var(--fs-xs); line-height: 1.7; }
 .auth-grid article > .design-icon:last-child { position: absolute; right: 18px; bottom: 18px; opacity: .5; }
 .privacy-section { display: grid; grid-template-columns: 1fr .75fr; gap: 80px; align-items: center; padding: 100px max(24px, calc((100% - 1240px)/2)); background: linear-gradient(135deg, #171d15, #0d110e); border-top: 1px solid var(--site-line); border-bottom: 1px solid var(--site-line); }
-.privacy-points { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 30px; }.privacy-points span { display: inline-flex; align-items: center; gap: 6px; padding: 6px 10px 6px 6px; border: 1px solid var(--site-line); border-radius: 10px; color: #9faa99; font-size: 10px; }
+.privacy-points { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 30px; }.privacy-points span { display: inline-flex; align-items: center; gap: 6px; padding: 6px 10px 6px 6px; border: 1px solid var(--site-line); border-radius: 10px; color: #9faa99; font-size: var(--fs-2xs); }
 .privacy-vault { display: flex; align-items: center; gap: 18px; min-height: 210px; padding: 28px; border: 1px solid rgba(185,220,112,.22); border-radius: 28px; background: radial-gradient(circle at 28% 50%, rgba(126,167,58,.16), transparent 40%), rgba(11,14,11,.65); }
-.privacy-vault div { display: grid; gap: 6px; }.privacy-vault b { color: #b9d87a; font-family: var(--font-mono); font-size: 13px; letter-spacing: .12em; }.privacy-vault span { color: #7e8979; font-size: 11px; line-height: 1.6; }
-footer { display: flex; align-items: center; flex-wrap: wrap; gap: 18px; width: min(1240px, calc(100% - 48px)); min-height: 120px; margin: 0 auto; } footer p { margin-right: auto; color: #697365; font-size: 10px; } footer .footer-disclaimer { flex-basis: 100%; margin-right: 0; max-width: 62ch; line-height: 1.6; } footer > div { display: flex; gap: 20px; } footer > div a { color: #909b8c; font-size: 11px; text-decoration: none; }
+.privacy-vault div { display: grid; gap: 6px; }.privacy-vault b { color: #b9d87a; font-family: var(--font-mono); font-size: var(--fs-md); letter-spacing: .12em; }.privacy-vault span { color: #7e8979; font-size: var(--fs-xs); line-height: 1.6; }
+footer { display: flex; align-items: center; flex-wrap: wrap; gap: 18px; width: min(1240px, calc(100% - 48px)); min-height: 120px; margin: 0 auto; } footer p { margin-right: auto; color: #737e6f; font-size: var(--fs-2xs); } footer .footer-disclaimer { flex-basis: 100%; margin-right: 0; max-width: 62ch; line-height: 1.6; } footer > div { display: flex; gap: 20px; } footer > div a { color: #909b8c; font-size: var(--fs-xs); text-decoration: none; }
 @media (max-width: 1080px) { .hero-section { grid-template-columns: 1fr; padding-top: 56px; } .hero-stage { min-height: 500px; } .capability-grid { grid-template-columns: repeat(2,1fr); } .connect-section { grid-template-columns: 1fr; } .privacy-section { grid-template-columns: 1fr; } }
 @media (max-width: 720px) { .landing-nav { width: min(100% - 28px,1240px); }.landing-nav nav { display: none; }.nav-github { padding-right: 9px; }.hero-section, .content-section, .principle-strip, footer { width: min(100% - 28px,1240px); }.hero-section { min-height: auto; padding: 48px 0 64px; }.hero-copy h1 { font-size: 44px; }.hero-actions { align-items: stretch; flex-direction: column; }.download-choice, .primary-cta, .alt-cta { width: 100%; }.primary-cta { min-width: 0; }.star-nudge { grid-template-columns: auto minmax(0,1fr); }.star-nudge a, .star-nudge button { grid-column: 2; justify-self: start; }.trust-row { flex-wrap: wrap; }.hero-stage { min-height: auto; }.output-stack { grid-template-columns: 1fr 1fr; }.principle-strip { grid-template-columns: repeat(2,1fr); }.principle-strip > div:nth-child(2) { border-right: 0; }.principle-strip > div:nth-child(-n+2) { border-bottom: 1px solid var(--site-line); }.content-section { padding: 84px 0; }.capability-grid, .auth-grid { grid-template-columns: 1fr; }.capability-card { min-height: 210px; }.auth-grid article { min-height: 245px; }.privacy-section { padding: 80px 20px; }.privacy-vault { align-items: flex-start; flex-direction: column; }.privacy-vault > .design-icon { width: 78px !important; height: 78px !important; } footer { align-items: flex-start; flex-wrap: wrap; padding: 28px 0; } footer p { width: 100%; order: 3; } }
 @media (max-width: 480px) { .landing-nav > .landing-brand strong { display: none; }.nav-actions { gap: 6px; } }

--- a/src/views/Overview.vue
+++ b/src/views/Overview.vue
@@ -295,11 +295,11 @@ const hrChartOption = computed(() => {
     grid: { left: 36, right: 16, top: 14, bottom: 24 },
     tooltip: {
       trigger: 'axis',
-      backgroundColor: '#22261A',
+      backgroundColor: '#1E221F',
       borderColor: 'rgba(228, 235, 208, 0.16)',
       borderWidth: 1,
       padding: [8, 12],
-      textStyle: { color: '#F3F4EC', fontSize: 12 },
+      textStyle: { color: '#F3F4EC', fontSize: 15.5 },
       extraCssText: 'border-radius:8px;box-shadow:none;',
       formatter: (params: Array<{ value: [number, number] }>) => {
         const point = Array.isArray(params) ? params[0] : params;
@@ -309,12 +309,12 @@ const hrChartOption = computed(() => {
     },
     xAxis: {
       type: 'time', min: data[0]?.[0], max: last?.[0],
-      axisLabel: { formatter: clock, hideOverlap: true, color: '#78818C', fontSize: 10 },
+      axisLabel: { formatter: clock, hideOverlap: true, color: '#B4BBC3', fontSize: 14.5 },
       axisLine: { lineStyle: { color: 'rgba(232,238,244,.12)' } }, axisTick: { show: false }, splitLine: { show: false },
     },
     yAxis: {
       type: 'value', scale: true, splitNumber: 3, min: 40,
-      axisLabel: { color: '#78818C', fontSize: 10 }, axisLine: { show: false }, axisTick: { show: false },
+      axisLabel: { color: '#B4BBC3', fontSize: 14.5 }, axisLine: { show: false }, axisTick: { show: false },
       splitLine: { lineStyle: { color: 'rgba(232,238,244,.08)', type: 'dashed' } },
     },
     series: [{
@@ -656,42 +656,42 @@ watch(dataRevision, () => { void loadOverview(); void loadDevices(); });
 
 <style scoped>
 .overview-page { display: grid; gap: 18px; align-content: start; max-width: 1540px; margin: 0 auto; }
-.hero-card { position: relative; display: grid; grid-template-columns: minmax(0, 1.08fr) minmax(440px, .92fr); min-height: 292px; overflow: hidden; border: 1px solid rgba(220,232,239,.1); border-radius: 26px; background: radial-gradient(700px 320px at 92% 20%, rgba(136,164,73,.13), transparent 68%), linear-gradient(135deg, #1C2026, #181C20 68%); box-shadow: inset 0 1px 0 rgba(255,255,255,.045), 0 20px 48px rgba(5,8,10,.15); }
+.hero-card { position: relative; display: grid; grid-template-columns: minmax(0, 1.08fr) minmax(440px, .92fr); min-height: 292px; overflow: hidden; border: 1px solid rgba(220,232,239,.1); border-radius: 26px; background: radial-gradient(700px 320px at 92% 20%, rgba(136,164,73,.13), transparent 68%), linear-gradient(135deg, #1A1E24, #15191E 68%); box-shadow: inset 0 1px 0 rgba(255,255,255,.045), 0 20px 48px rgba(5,8,10,.15); }
 .hero-card::before { position: absolute; inset: 0; pointer-events: none; content: ''; background-image: linear-gradient(rgba(255,255,255,.018) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,.018) 1px, transparent 1px); background-size: 34px 34px; mask-image: linear-gradient(90deg, transparent 35%, black); }
 .hero-copy { position: relative; padding: 34px 10px 30px 34px; align-self: center; }
-.hero-kicker { display: flex; align-items: center; gap: 8px; margin: 0 0 12px; color: #A3BD69; font-family: var(--font-mono); font-size: 10px; letter-spacing: .12em; }.hero-kicker span { width: 26px; height: 1px; background: #9DBB58; }
+.hero-kicker { display: flex; align-items: center; gap: 8px; margin: 0 0 12px; color: #A3BD69; font-family: var(--font-mono); font-size: var(--fs-2xs); letter-spacing: .12em; }.hero-kicker span { width: 26px; height: 1px; background: #9DBB58; }
 .hero-copy h1 { margin: 0; color: #F5F7F0; font-size: clamp(27px, 2.3vw, 39px); font-weight: 700; letter-spacing: -.04em; line-height: 1.18; }.hero-copy h1 em { color: #C7DC80; font-style: normal; }
-.hero-intro { max-width: 640px; margin: 13px 0 22px; color: #9AA3AD; font-size: 13px; line-height: 1.75; }
-.hero-values { display: flex; flex-wrap: wrap; gap: 10px; margin: 0; padding: 0; list-style: none; }.hero-values li { display: flex; min-width: 148px; align-items: center; gap: 8px; padding: 6px 12px 6px 5px; border: 1px solid rgba(222,232,239,.09); border-radius: 15px; background: rgba(38,43,49,.72); box-shadow: inset 0 1px 0 rgba(255,255,255,.04); }.hero-values li > span { display: grid; gap: 1px; }.hero-values strong { color: #EEF2E7; font-size: 12px; }.hero-values small { color: #78818B; font-size: 10px; }
+.hero-intro { max-width: 640px; margin: 13px 0 22px; color: #9AA3AD; font-size: var(--fs-md); line-height: 1.75; }
+.hero-values { display: flex; flex-wrap: wrap; gap: 10px; margin: 0; padding: 0; list-style: none; }.hero-values li { display: flex; min-width: 148px; align-items: center; gap: 8px; padding: 6px 12px 6px 5px; border: 1px solid rgba(222,232,239,.09); border-radius: 15px; background: rgba(34,39,45,.72); box-shadow: inset 0 1px 0 rgba(255,255,255,.04); }.hero-values li > span { display: grid; gap: 1px; }.hero-values strong { color: #EEF2E7; font-size: var(--fs-sm); }.hero-values small { color: var(--subtle); font-size: var(--fs-2xs); }
 .hero-visual { position: relative; display: grid; grid-template-columns: auto minmax(64px, 1fr) auto; align-items: center; min-width: 0; padding: 26px 28px 26px 8px; gap: 14px; }
 .device-stack { display: flex; align-items: flex-end; gap: 14px; min-width: 0; }
 .hero-device { display: grid; justify-items: center; gap: 7px; margin: 0; flex: 0 0 auto; width: 104px; }
-.device-plinth { display: grid; width: 104px; height: 90px; place-items: center; border: 1px solid rgba(221,232,240,.09); border-radius: 20px; background: linear-gradient(145deg, rgba(45,50,58,.9), rgba(26,30,35,.78)); box-shadow: inset 0 1px 0 rgba(255,255,255,.055), 0 14px 30px rgba(3,5,7,.28); }
+.device-plinth { display: grid; width: 104px; height: 90px; place-items: center; border: 1px solid rgba(221,232,240,.09); border-radius: 20px; background: linear-gradient(145deg, rgba(40,45,53,.9), rgba(22,26,31,.78)); box-shadow: inset 0 1px 0 rgba(255,255,255,.055), 0 14px 30px rgba(3,5,7,.28); }
 .device-stack.solo .hero-device { width: 124px; }
 .device-stack.solo .device-plinth { width: 124px; height: 106px; }
 .hero-device :deep(.device-visual) { width: 92px; height: 80px; flex-basis: 80px; border: 0; background: transparent; }
 .device-stack.solo .hero-device :deep(.device-visual) { width: 112px; height: 94px; flex-basis: 94px; }
 .hero-device :deep(.device-visual img) { padding: 1px; filter: drop-shadow(0 9px 12px rgba(0,0,0,.28)); }
-.hero-device figcaption { width: 100%; color: #818A94; font-size: 11px; line-height: 1.3; text-align: center; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.device-more { align-self: center; padding: 4px 8px; border: 1px solid rgba(221,232,240,.12); border-radius: 999px; color: #9CB965; font-family: var(--font-mono); font-size: 11px; }
+.hero-device figcaption { width: 100%; color: var(--subtle); font-size: var(--fs-xs); line-height: 1.3; text-align: center; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.device-more { align-self: center; padding: 4px 8px; border: 1px solid rgba(221,232,240,.12); border-radius: 999px; color: #9CB965; font-family: var(--font-mono); font-size: var(--fs-xs); }
 .data-flow { width: 100%; min-width: 56px; max-width: 140px; height: 72px; justify-self: stretch; color: #8FB348; overflow: visible; }.data-flow path:not(.arrow) { stroke: currentColor; stroke-width: 2; stroke-dasharray: 6 8; animation: flow 1.7s linear infinite; }.data-flow .arrow { fill: currentColor; }@keyframes flow { to { stroke-dashoffset: -28; } }
-.ai-node { display: grid; justify-items: center; gap: 8px; flex: 0 0 auto; min-width: 96px; color: #9CB965; font-family: var(--font-mono); font-size: 9px; letter-spacing: .15em; }
+.ai-node { display: grid; justify-items: center; gap: 8px; flex: 0 0 auto; min-width: 96px; color: #9CB965; font-family: var(--font-mono); font-size: var(--fs-2xs); letter-spacing: .15em; }
 .ai-logos { display: flex; align-items: center; }
-.ai-logos img { width: 32px; height: 32px; margin-left: -8px; border: 2px solid #1C2026; border-radius: 50%; background: #161a14; object-fit: cover; }
+.ai-logos img { width: 32px; height: 32px; margin-left: -8px; border: 2px solid #1A1E24; border-radius: 50%; background: #141812; object-fit: cover; }
 .ai-logos img:first-child { margin-left: 0; }
-.inline-alert { display: flex; align-items: center; gap: 8px; padding: 9px 13px; border: 1px solid var(--line); border-radius: 12px; background: var(--surface); color: var(--muted); font-size: 12px; }.inline-alert.warning { color: var(--warning); }
-.overview-skeleton { display: grid; gap: 16px; }.skeleton-grid { display: grid; grid-template-columns: repeat(3, minmax(0,1fr)); gap: 16px; }.empty-wrap { display: grid; min-height: 300px; place-items: center; }.empty-state { display: grid; max-width: 360px; justify-items: center; gap: 9px; padding: 32px; color: var(--muted); text-align: center; }.empty-state strong { color: var(--ink); font-size: 16px; }
-.dashboard-grid { display: grid; grid-template-columns: repeat(12, minmax(0, 1fr)); gap: 16px; }.metric-panel { position: relative; min-width: 0; overflow: hidden; border: 1px solid rgba(221,231,239,.09); border-radius: 22px; background: linear-gradient(145deg, rgba(31,35,41,.98), rgba(27,31,36,.98)); box-shadow: inset 0 1px 0 rgba(255,255,255,.035); transition: transform .28s cubic-bezier(.16,1,.3,1), border-color .28s ease; }.metric-panel:hover { transform: translateY(-2px); border-color: rgba(221,231,239,.15); }
+.inline-alert { display: flex; align-items: center; gap: 8px; padding: 9px 13px; border: 1px solid var(--line); border-radius: 12px; background: var(--surface); color: var(--muted); font-size: var(--fs-sm); }.inline-alert.warning { color: var(--warning); }
+.overview-skeleton { display: grid; gap: 16px; }.skeleton-grid { display: grid; grid-template-columns: repeat(3, minmax(0,1fr)); gap: 16px; }.empty-wrap { display: grid; min-height: 300px; place-items: center; }.empty-state { display: grid; max-width: 360px; justify-items: center; gap: 9px; padding: 32px; color: var(--muted); text-align: center; }.empty-state strong { color: var(--ink); font-size: var(--fs-2xl); }
+.dashboard-grid { display: grid; grid-template-columns: repeat(12, minmax(0, 1fr)); gap: 16px; }.metric-panel { position: relative; min-width: 0; overflow: hidden; border: 1px solid rgba(221,231,239,.09); border-radius: 22px; background: linear-gradient(145deg, rgba(27,31,37,.98), rgba(23,27,32,.98)); box-shadow: inset 0 1px 0 rgba(255,255,255,.035); transition: transform .28s cubic-bezier(.16,1,.3,1), border-color .28s ease; }.metric-panel:hover { transform: translateY(-2px); border-color: rgba(221,231,239,.15); }
 .hr-panel { grid-column: span 6; min-height: 286px; padding: 20px 20px 12px; }.steps-panel, .sleep-panel { grid-column: span 3; min-height: 286px; padding: 18px; }.mini-panel { grid-column: span 4; min-height: 166px; padding: 18px; }.recent-panel { grid-column: 1 / -1; padding: 18px; }
-.panel-head { display: flex; min-width: 0; align-items: center; justify-content: space-between; gap: 12px; }.panel-title { display: flex; min-width: 0; align-items: center; gap: 8px; }.panel-title > span { display: grid; gap: 1px; }.panel-title strong { color: #EEF1EC; font-size: 13px; font-weight: 600; }.panel-title small { color: #737C86; font-size: 11px; }.chart-icon { display: grid; width: 38px; height: 38px; flex: 0 0 38px; place-items: center; overflow: hidden; border-radius: 11px; background: rgba(255,255,255,.025); }.latest-value { display: flex; align-items: baseline; gap: 5px; color: #8A929B; font-size: 12px; white-space: nowrap; }.latest-value strong { color: #F1F5EC; font-family: var(--font-mono); font-size: 20px; font-weight: 600; }.latest-value small { font-size: 11px; }
-.hr-chart { width: 100%; height: 198px; }.hr-zones { display: flex; flex-wrap: wrap; gap: 8px 12px; margin: 4px 0 0; padding: 0; list-style: none; color: #747D87; font-size: 11px; }.panel-empty { display: flex; min-height: 190px; align-items: center; justify-content: center; gap: 12px; color: #717A84; font-size: 11px; text-align: center; }.panel-empty.compact { min-height: 170px; flex-direction: column; }.panel-empty .design-icon { opacity: .7; filter: saturate(.8); }
+.panel-head { display: flex; min-width: 0; align-items: center; justify-content: space-between; gap: 12px; }.panel-title { display: flex; min-width: 0; align-items: center; gap: 8px; }.panel-title > span { display: grid; gap: 1px; }.panel-title strong { color: #EEF1EC; font-size: var(--fs-md); font-weight: 600; }.panel-title small { color: var(--subtle); font-size: var(--fs-xs); }.chart-icon { display: grid; width: 38px; height: 38px; flex: 0 0 38px; place-items: center; overflow: hidden; border-radius: 11px; background: rgba(255,255,255,.025); }.latest-value { display: flex; align-items: baseline; gap: 5px; color: var(--muted); font-size: var(--fs-sm); white-space: nowrap; }.latest-value strong { color: #F1F5EC; font-family: var(--font-mono); font-size: 20px; font-weight: 600; }.latest-value small { font-size: var(--fs-xs); }
+.hr-chart { width: 100%; height: 198px; }.hr-zones { display: flex; flex-wrap: wrap; gap: 8px 12px; margin: 4px 0 0; padding: 0; list-style: none; color: var(--subtle); font-size: var(--fs-xs); }.panel-empty { display: flex; min-height: 190px; align-items: center; justify-content: center; gap: 12px; color: var(--subtle); font-size: var(--fs-xs); text-align: center; }.panel-empty.compact { min-height: 170px; flex-direction: column; }.panel-empty .design-icon { opacity: .7; filter: saturate(.8); }
 .steps-content { display: grid; min-height: 220px; place-items: center; align-content: center; gap: 14px; }
 .steps-inring { display: grid; justify-items: center; gap: 2px; }
-.steps-inring strong { color: #F4F6EF; font-family: var(--font-mono); font-size: 22px; font-weight: 600; font-variant-numeric: tabular-nums; line-height: 1; }
-.steps-inring span { color: #8AA894; font-size: 11px; }
-.steps-goal { margin: 0; color: #8A929B; font-size: 12px; font-variant-numeric: tabular-nums; }
-.sleep-panel { background: radial-gradient(380px 240px at 90% 0, rgba(104,87,217,.12), transparent 70%), linear-gradient(145deg, #20222C, #1C1F27); }.sleep-score { padding: 4px 10px; border-radius: 999px; background: rgba(131,109,235,.14); color: #A895FF; font-family: var(--font-mono); font-size: 12px; }.sleep-total { margin: 16px 0 10px; color: #F4F3FC; font-family: var(--font-mono); font-size: 20px; font-weight: 600; }.sleep-bar { display: flex; gap: 3px; height: 7px; overflow: hidden; border-radius: 999px; }.sleep-bar span { min-width: 3px; border-radius: 999px; }.sleep-stages { display: grid; grid-template-columns: minmax(0,1fr); gap: 9px; margin: 14px 0 0; padding: 0; list-style: none; }.sleep-stages li { display: grid; grid-template-columns: 8px minmax(0,1fr) auto; align-items: center; gap: 8px; min-width: 0; color: #9299A4; font-size: 12px; }.sleep-stages i { width: 6px; height: 6px; border-radius: 50%; }.sleep-stages strong { color: #C4C8D0; font-family: var(--font-mono); font-size: 12px; font-weight: 500; white-space: nowrap; }
-.mini-panel { display: grid; grid-template-columns: auto minmax(0,1fr); align-items: center; gap: 14px; }.mini-icon { display: grid; width: 68px; height: 68px; place-items: center; overflow: hidden; border-radius: 18px; }.mini-label { margin: 0; color: #B4BAC1; font-size: 13px; font-weight: 500; }.mini-value { display: flex; align-items: baseline; gap: 6px; margin: 5px 0; }.mini-value strong { color: #F5F6F2; font-family: var(--font-mono); font-size: 22px; font-weight: 600; line-height: 1; }.mini-value span { color: #8A929B; font-size: 12px; }.mini-note { margin: 0; color: #7B838C; font-size: 11px; line-height: 1.4; }.resting-panel { background: radial-gradient(300px 180px at 0 100%, rgba(225,75,88,.1), transparent 72%), linear-gradient(145deg, #221E23, #1D2025); }
+.steps-inring strong { color: #F4F6EF; font-family: var(--font-mono); font-size: 24px; font-weight: 600; font-variant-numeric: tabular-nums; line-height: 1; }
+.steps-inring span { color: #8AA894; font-size: var(--fs-xs); }
+.steps-goal { margin: 0; color: var(--muted); font-size: var(--fs-sm); font-variant-numeric: tabular-nums; }
+.sleep-panel { background: radial-gradient(380px 240px at 90% 0, rgba(104,87,217,.12), transparent 70%), linear-gradient(145deg, #1D1F29, #191C25); }.sleep-score { padding: 4px 10px; border-radius: 999px; background: rgba(131,109,235,.14); color: #A895FF; font-family: var(--font-mono); font-size: var(--fs-sm); }.sleep-total { margin: 16px 0 10px; color: #F4F3FC; font-family: var(--font-mono); font-size: 20px; font-weight: 600; }.sleep-bar { display: flex; gap: 3px; height: 7px; overflow: hidden; border-radius: 999px; }.sleep-bar span { min-width: 3px; border-radius: 999px; }.sleep-stages { display: grid; grid-template-columns: minmax(0,1fr); gap: 9px; margin: 14px 0 0; padding: 0; list-style: none; }.sleep-stages li { display: grid; grid-template-columns: 8px minmax(0,1fr) auto; align-items: center; gap: 8px; min-width: 0; color: var(--subtle); font-size: var(--fs-sm); }.sleep-stages i { width: 6px; height: 6px; border-radius: 50%; }.sleep-stages strong { color: #C4C8D0; font-family: var(--font-mono); font-size: var(--fs-sm); font-weight: 600; white-space: nowrap; }
+.mini-panel { display: grid; grid-template-columns: auto minmax(0,1fr); align-items: center; gap: 14px; }.mini-icon { display: grid; width: 68px; height: 68px; place-items: center; overflow: hidden; border-radius: 18px; }.mini-label { margin: 0; color: var(--muted); font-size: var(--fs-md); font-weight: 600; }.mini-value { display: flex; align-items: baseline; gap: 6px; margin: 5px 0; }.mini-value strong { color: #F5F6F2; font-family: var(--font-mono); font-size: 22px; font-weight: 600; line-height: 1; }.mini-value span { color: var(--muted); font-size: var(--fs-sm); }.mini-note { margin: 0; color: var(--subtle); font-size: var(--fs-xs); line-height: 1.4; }.resting-panel { background: radial-gradient(300px 180px at 0 100%, rgba(225,75,88,.1), transparent 72%), linear-gradient(145deg, #1F1B20, #1A1D22); }
 /* 四张指标卡现在是链接，得把 <a> 的默认样式收掉，并给出一致的「看更多」提示。 */
 .unrecognized-banner {
   display: flex;
@@ -702,7 +702,7 @@ watch(dataRevision, () => { void loadOverview(); void loadDevices(); });
   border-radius: 14px;
   background: rgba(245, 195, 59, .08);
   color: #e8cf86;
-  font-size: 12px;
+  font-size: var(--fs-sm);
   text-decoration: none;
 }
 .unrecognized-banner strong { color: #f4e2ae; font-weight: 600; }
@@ -711,20 +711,20 @@ watch(dataRevision, () => { void loadOverview(); void loadDevices(); });
 
 a.metric-panel { display: block; color: inherit; text-decoration: none; }
 a.metric-panel.mini-panel { display: flex; align-items: center; gap: 14px; }
-.panel-more { display: inline-flex; align-items: center; gap: 4px; margin-top: 6px; color: #737C86; font-size: 11px; }
+.panel-more { display: inline-flex; align-items: center; gap: 4px; margin-top: 6px; color: var(--subtle); font-size: var(--fs-xs); }
 .mini-chevron { margin-left: auto; opacity: .55; }
 /* 静息心率卡撤掉之后，这一行由身体状态和训练状态平分。 */
 .entry-panel { display: grid; grid-template-columns: auto minmax(0,1fr); grid-column: span 6; align-items: start; gap: 12px; min-height: 166px; padding: 18px; color: inherit; text-decoration: none; }
 .entry-panel:hover { border-color: rgba(221,231,239,.18); }
 .entry-icon { display: grid; width: 52px; height: 52px; place-items: center; overflow: hidden; border-radius: 15px; }
 .entry-copy { display: grid; align-content: start; gap: 7px; min-width: 0; }
-.entry-label { display: flex; align-items: center; gap: 3px; margin: 0; color: #B4BAC1; font-size: 13px; font-weight: 500; }
-.entry-facts { display: flex; flex-wrap: wrap; gap: 4px 14px; margin: 0; color: #7B838C; font-size: 11px; }
-.entry-facts strong { color: #F5F6F2; font-family: var(--font-mono); font-size: 15px; font-weight: 600; font-variant-numeric: tabular-nums; }
-.entry-note { margin: 0; color: #7B838C; font-size: 11px; line-height: 1.5; }
-.body-entry { background: radial-gradient(300px 180px at 0 100%, rgba(61,216,76,.09), transparent 72%), linear-gradient(145deg, #1C2320, #1D2025); }
-.training-entry { background: radial-gradient(300px 180px at 0 100%, rgba(136,164,73,.1), transparent 72%), linear-gradient(145deg, #1E2218, #1C2018); }
-.text-link { display: inline-flex; align-items: center; gap: 3px; color: #9DBA5D; font-size: 11px; text-decoration: none; }.text-link:hover { color: #C7DC80; }.recent-list { display: grid; grid-template-columns: repeat(2, minmax(0,1fr)); margin-top: 12px; overflow: hidden; border: 1px solid rgba(226,234,242,.07); border-radius: 16px; }.recent-list :deep(.record-row:nth-child(odd)) { border-right: 1px solid var(--line); }.recent-list :deep(.record-row) { min-height: 72px; transition: background .2s ease, transform .2s ease; }.recent-list :deep(.record-row:hover) { transform: translateX(2px); }.recent-empty { min-height: 120px; }
+.entry-label { display: flex; align-items: center; gap: 3px; margin: 0; color: var(--muted); font-size: var(--fs-md); font-weight: 600; }
+.entry-facts { display: flex; flex-wrap: wrap; gap: 4px 14px; margin: 0; color: var(--subtle); font-size: var(--fs-xs); }
+.entry-facts strong { color: #F5F6F2; font-family: var(--font-mono); font-size: var(--fs-xl); font-weight: 600; font-variant-numeric: tabular-nums; }
+.entry-note { margin: 0; color: var(--subtle); font-size: var(--fs-xs); line-height: 1.5; }
+.body-entry { background: radial-gradient(300px 180px at 0 100%, rgba(61,216,76,.09), transparent 72%), linear-gradient(145deg, #19221C, #1A1D22); }
+.training-entry { background: radial-gradient(300px 180px at 0 100%, rgba(136,164,73,.1), transparent 72%), linear-gradient(145deg, #1B1F16, #191D16); }
+.text-link { display: inline-flex; align-items: center; gap: 3px; color: #9DBA5D; font-size: var(--fs-xs); text-decoration: none; }.text-link:hover { color: #C7DC80; }.recent-list { display: grid; grid-template-columns: repeat(2, minmax(0,1fr)); margin-top: 12px; overflow: hidden; border: 1px solid rgba(226,234,242,.07); border-radius: 16px; }.recent-list :deep(.record-row:nth-child(odd)) { border-right: 1px solid var(--line); }.recent-list :deep(.record-row) { min-height: 72px; transition: background .2s ease, transform .2s ease; }.recent-list :deep(.record-row:hover) { transform: translateX(2px); }.recent-empty { min-height: 120px; }
 @media (max-width: 1180px) { .hero-card { grid-template-columns: minmax(0,1fr); }.hero-visual { min-height: 210px; padding: 0 34px 24px; }.hero-copy { padding-right: 34px; }.hr-panel { grid-column: span 8; }.steps-panel { grid-column: span 4; }.sleep-panel { grid-column: span 6; }.mini-panel, .entry-panel { grid-column: span 6; } }
 @media (max-width: 820px) { .overview-page { padding-inline: 16px; }.hero-card { border-radius: 20px; }.hero-copy { padding: 26px 22px 18px; }.hero-visual { grid-template-columns: auto auto; padding: 0 20px 24px; }.data-flow { display: none; }.hero-values li { min-width: calc(50% - 5px); }.dashboard-grid { grid-template-columns: minmax(0,1fr); }.hr-panel,.steps-panel,.sleep-panel,.mini-panel,.entry-panel,.recent-panel { grid-column: 1; }.recent-list { grid-template-columns: minmax(0,1fr); }.recent-list :deep(.record-row:nth-child(odd)) { border-right: 0; }.skeleton-grid { grid-template-columns: minmax(0,1fr); } }
 @media (max-width: 520px) { .hero-visual { grid-template-columns: minmax(0,1fr); }.hero-values { display: grid; }.hero-values li { min-width: 0; } }

--- a/src/views/RecentRecords.vue
+++ b/src/views/RecentRecords.vue
@@ -317,7 +317,7 @@ function formatDateHint(value: string): string {
   align-items: center;
   gap: 7px;
   margin: 0;
-  font-size: 13px;
+  font-size: var(--fs-md);
   font-weight: 700;
   color: var(--ink);
 }
@@ -329,7 +329,7 @@ function formatDateHint(value: string): string {
   background: var(--surface);
   border: 1px solid var(--line);
   color: var(--muted);
-  font-size: 11px;
+  font-size: var(--fs-xs);
   font-style: normal;
   font-weight: 400;
   font-family: var(--font-mono);
@@ -339,7 +339,7 @@ function formatDateHint(value: string): string {
   align-items: center;
   gap: 4px;
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   text-decoration: none;
 }
 .see-all:hover { color: var(--accent); }
@@ -361,12 +361,12 @@ function formatDateHint(value: string): string {
   border-radius: var(--radius-sm);
   background: var(--surface-raised);
   color: var(--subtle);
-  font-size: 11px;
+  font-size: var(--fs-xs);
 }
 .empty-row {
   padding: 18px 16px;
   color: var(--muted);
-  font-size: 13px;
+  font-size: var(--fs-md);
 }
 .partial-warning {
   display: flex;
@@ -378,7 +378,7 @@ function formatDateHint(value: string): string {
   border-radius: var(--radius-md);
   background: var(--surface);
   color: var(--warning);
-  font-size: 12px;
+  font-size: var(--fs-sm);
 }
 .partial-warning svg { color: var(--warning); }
 .filter-tabs {
@@ -398,7 +398,7 @@ function formatDateHint(value: string): string {
   border-radius: var(--radius-sm);
   background: transparent;
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   cursor: pointer;
   transition: all 0.2s;
 }

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -1731,7 +1731,7 @@ const runCapabilityProbe = async () => {
 </template>
 
 <style scoped>
-.build-stamp { color: var(--subtle); font-size: 11px; font-family: var(--font-mono); }
+.build-stamp { color: var(--subtle); font-size: var(--fs-xs); font-family: var(--font-mono); }
 .page { width: 100%; min-width: 0; margin: 0; display: grid; gap: 14px; }
 .page-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; flex-wrap: wrap; margin-bottom: 0; min-width: 0; }
 .locale-switch { flex: 0 0 auto; text-align: right; }
@@ -1739,64 +1739,64 @@ const runCapabilityProbe = async () => {
 .locale-switch .scale-options { justify-content: flex-end; }
 .locale-switch .scale-options button { min-width: 62px; }
 h1, h2, h3, p { margin-top: 0; }
-h1 { font-size: 24px; font-weight: 700; color: var(--ink); }
-h2 { margin-bottom: 14px; font-size: 15px; font-weight: 700; color: var(--ink); }
-h3 { margin-bottom: 4px; font-size: 13px; font-weight: 700; color: var(--ink); }
-.page-intro, .section-description { margin-bottom: 0; color: var(--muted); font-size: 12px; }
+h1 { font-size: 26.5px; font-weight: 700; color: var(--ink); }
+h2 { margin-bottom: 14px; font-size: var(--fs-xl); font-weight: 700; color: var(--ink); }
+h3 { margin-bottom: 4px; font-size: var(--fs-md); font-weight: 700; color: var(--ink); }
+.page-intro, .section-description { margin-bottom: 0; color: var(--muted); font-size: var(--fs-sm); }
 .section-description { margin: 0 0 var(--space-3); }
 .settings-card { padding: 18px 20px; border: 1px solid var(--line); border-radius: var(--radius-md); background: var(--surface); min-width: 0; }
 .api-head { display: grid; grid-template-columns: auto minmax(0, 1fr) auto; align-items: center; gap: 12px; }
 .api-head h2 { margin-bottom: 4px; }
-.api-head p, .api-note, .api-error { margin: 0; color: var(--subtle); font-size: 11px; line-height: 1.5; }
+.api-head p, .api-note, .api-error { margin: 0; color: var(--subtle); font-size: var(--fs-xs); line-height: 1.5; }
 .api-icon { display: grid; width: 38px; height: 38px; place-items: center; border-radius: 10px; background: var(--accent-soft); color: var(--accent); }
-.api-state { display: inline-flex; align-items: center; gap: 6px; color: var(--muted); font-size: 12px; white-space: nowrap; }
+.api-state { display: inline-flex; align-items: center; gap: 6px; color: var(--muted); font-size: var(--fs-sm); white-space: nowrap; }
 .api-state.on { color: var(--accent); }
 .api-state i { width: 6px; height: 6px; border-radius: 50%; background: currentColor; }
 .api-endpoint { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: 10px; margin-top: 14px; padding: 10px 12px; border: 1px solid var(--line); border-radius: var(--radius-sm); background: var(--surface-raised); }
-.api-endpoint code { overflow: hidden; color: var(--ink); font-family: var(--font-mono); font-size: 11px; text-overflow: ellipsis; white-space: nowrap; }
+.api-endpoint code { overflow: hidden; color: var(--ink); font-family: var(--font-mono); font-size: var(--fs-xs); text-overflow: ellipsis; white-space: nowrap; }
 .api-note, .api-error { margin-top: 9px; }
-.api-note code { padding: 1px 5px; border-radius: 4px; background: var(--surface-raised); font-family: var(--font-mono); font-size: 10px; }
+.api-note code { padding: 1px 5px; border-radius: 4px; background: var(--surface-raised); font-family: var(--font-mono); font-size: var(--fs-2xs); }
 .api-toggle { margin-top: 12px; border-bottom: 0; }
 .api-token { display: grid; grid-template-columns: auto minmax(0, 1fr); align-items: center; gap: 10px 12px; margin-top: 10px; padding: 10px 12px; border: 1px solid var(--line); border-radius: var(--radius-sm); background: var(--surface-raised); }
-.api-token code { overflow: hidden; color: var(--ink); font-family: var(--font-mono); font-size: 11px; text-overflow: ellipsis; white-space: nowrap; }
+.api-token code { overflow: hidden; color: var(--ink); font-family: var(--font-mono); font-size: var(--fs-xs); text-overflow: ellipsis; white-space: nowrap; }
 .api-token .inline-actions { grid-column: 1 / -1; }
 .fact-list { display: grid; gap: 12px; margin: 0; padding: 0; list-style: none; }
 .fact-list li { display: grid; grid-template-columns: auto minmax(0, 1fr); gap: 10px; align-items: start; }
-.fact-list strong { display: block; margin-bottom: 3px; color: var(--ink); font-size: 12px; font-weight: 500; }
-.fact-list span { color: var(--subtle); font-size: 11px; line-height: 1.55; }
+.fact-list strong { display: block; margin-bottom: 3px; color: var(--ink); font-size: var(--fs-sm); font-weight: 600; }
+.fact-list span { color: var(--subtle); font-size: var(--fs-xs); line-height: 1.55; }
 .code-list { display: grid; gap: 10px; margin-top: 12px; }
 .code-row { display: grid; gap: 10px; padding: 12px; border: 1px solid var(--line); border-radius: 12px; background: var(--surface-raised); }
 .code-head { display: grid; grid-template-columns: auto minmax(0, 1fr) auto; align-items: center; gap: 10px; }
-.code-badge { display: grid; place-items: center; width: 34px; height: 34px; border: 1px solid var(--line); border-radius: 10px; color: var(--muted); font-family: var(--font-mono); font-size: 11px; }
+.code-badge { display: grid; place-items: center; width: 34px; height: 34px; border: 1px solid var(--line); border-radius: 10px; color: var(--muted); font-family: var(--font-mono); font-size: var(--fs-xs); }
 .code-meta { display: grid; gap: 2px; }
-.code-meta strong { color: var(--ink); font-size: 12px; font-weight: 500; }
-.code-meta span { color: var(--subtle); font-size: 11px; }
-.code-preview { color: var(--accent); font-size: 11px; text-align: right; }
+.code-meta strong { color: var(--ink); font-size: var(--fs-sm); font-weight: 600; }
+.code-meta span { color: var(--subtle); font-size: var(--fs-xs); }
+.code-preview { color: var(--accent); font-size: var(--fs-xs); text-align: right; }
 .code-preview.muted { color: var(--muted); }
 .code-input-row { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 8px; }
 .code-suggestions { display: flex; flex-wrap: wrap; gap: 6px; }
-.code-suggestions .filter-chip { padding: 3px 10px; border: 1px solid var(--line); border-radius: 999px; background: transparent; color: var(--muted); font-size: 11px; cursor: pointer; }
+.code-suggestions .filter-chip { padding: 3px 10px; border: 1px solid var(--line-control); border-radius: 999px; background: transparent; color: var(--muted); font-size: var(--fs-xs); cursor: pointer; }
 .code-suggestions .filter-chip:hover { border-color: var(--accent); color: var(--accent); }
 .assign-trigger { justify-self: end; }
 .api-error { color: var(--danger); }
 .update-head, .update-release { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: 14px; }
 .update-head h2 { margin-bottom: 4px; }
-.update-head p, .update-state p, .update-release p { margin: 0; color: var(--subtle); font-size: 11px; line-height: 1.5; }
+.update-head p, .update-state p, .update-release p { margin: 0; color: var(--subtle); font-size: var(--fs-xs); line-height: 1.5; }
 .update-state { display: grid; grid-template-columns: 7px minmax(0, 1fr); align-items: center; gap: 11px; margin-top: 14px; padding: 11px 12px; border: 1px solid var(--line); border-radius: var(--radius-sm); background: var(--surface-raised); }
 .update-state i { width: 7px; height: 7px; border-radius: 50%; background: var(--muted); }
 .update-state.is-available i, .update-state.is-upToDate i { background: var(--accent); }
 .update-state.is-checking i, .update-state.is-downloading i, .update-state.is-installing i { background: var(--warning); }
 .update-state.is-failed i { background: var(--danger); }
-.update-state strong, .update-release strong { color: var(--ink); font-size: 12px; }
+.update-state strong, .update-release strong { color: var(--ink); font-size: var(--fs-sm); }
 .update-card progress { width: 100%; height: 6px; margin-top: 10px; accent-color: var(--accent); }
 .update-release { margin-top: 10px; padding: 11px 12px; border: 1px solid var(--line); border-radius: var(--radius-sm); background: var(--surface-raised); }
-.diagnostic-note { display: grid; gap: 6px; margin: 10px 0; font-size: 12px; color: var(--muted); }
+.diagnostic-note { display: grid; gap: 6px; margin: 10px 0; font-size: var(--fs-sm); color: var(--muted); }
 .diagnostic-note em { font-style: normal; color: var(--subtle); }
-.diagnostic-note textarea { width: 100%; min-height: 68px; padding: 8px 10px; border: 1px solid var(--line); border-radius: 10px; background: var(--surface); color: var(--ink); font: inherit; resize: vertical; }
-.diagnostic-note small { color: var(--subtle); font-size: 11px; }
-.diagnostic-done { display: grid; gap: 4px; margin-top: 10px; padding: 10px 12px; border: 1px solid rgba(125,163,62,.34); border-radius: 10px; background: rgba(125,163,62,.1); color: var(--ink); font-size: 12px; }
+.diagnostic-note textarea { width: 100%; min-height: 68px; padding: 8px 10px; border: 1px solid var(--line-control); border-radius: 10px; background: var(--surface); color: var(--ink); font: inherit; resize: vertical; }
+.diagnostic-note small { color: var(--subtle); font-size: var(--fs-xs); }
+.diagnostic-done { display: grid; gap: 4px; margin-top: 10px; padding: 10px 12px; border: 1px solid rgba(125,163,62,.34); border-radius: 10px; background: rgba(125,163,62,.1); color: var(--ink); font-size: var(--fs-sm); }
 .diagnostic-done strong { display: inline-flex; align-items: center; gap: 6px; color: #b9da77; }
-.diagnostic-done code { font-family: var(--font-mono); font-size: 11px; }
+.diagnostic-done code { font-family: var(--font-mono); font-size: var(--fs-xs); }
 .diagnostic-done-note { color: var(--muted); }
 .section-heading-row { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
 .section-heading-row h2 { margin-bottom: 14px; }
@@ -1820,18 +1820,18 @@ h3 { margin-bottom: 4px; font-size: 13px; font-weight: 700; color: var(--ink); }
   border: 0;
   background: none;
   color: var(--accent);
-  font-size: 13px;
+  font-size: var(--fs-md);
   font-weight: 600;
   cursor: pointer;
 }
 .account-logout .link-button:hover { text-decoration: underline; }
-.account-logout-hint { margin: 4px 0 0; color: var(--subtle); font-size: 11px; line-height: 1.55; }
+.account-logout-hint { margin: 4px 0 0; color: var(--subtle); font-size: var(--fs-xs); line-height: 1.55; }
 .account-logout-hint.warn { color: var(--muted); }
-.account-avatar { display: grid; width: 36px; height: 36px; flex: 0 0 36px; place-items: center; border-radius: 9px; background: var(--accent-soft); color: var(--accent); font-family: var(--font-mono); font-size: 15px; font-weight: 700; }
+.account-avatar { display: grid; width: 36px; height: 36px; flex: 0 0 36px; place-items: center; border-radius: 9px; background: var(--accent-soft); color: var(--accent); font-family: var(--font-mono); font-size: var(--fs-xl); font-weight: 700; }
 .account-meta { display: grid; min-width: 0; gap: 1px; flex: 1; }
-.account-meta strong { overflow: hidden; color: var(--ink); font-family: var(--font-mono); font-size: 13px; text-overflow: ellipsis; white-space: nowrap; }
-.account-meta span { overflow: hidden; color: var(--subtle); font-size: 11px; text-overflow: ellipsis; white-space: nowrap; }
-.account-state { display: inline-flex; align-items: center; gap: 6px; color: var(--muted); font-size: 12px; white-space: nowrap; }
+.account-meta strong { overflow: hidden; color: var(--ink); font-family: var(--font-mono); font-size: var(--fs-md); text-overflow: ellipsis; white-space: nowrap; }
+.account-meta span { overflow: hidden; color: var(--subtle); font-size: var(--fs-xs); text-overflow: ellipsis; white-space: nowrap; }
+.account-state { display: inline-flex; align-items: center; gap: 6px; color: var(--muted); font-size: var(--fs-sm); white-space: nowrap; }
 .account-state.on { color: var(--accent); }
 .account-state .dot { width: 6px; height: 6px; border-radius: 50%; background: currentColor; }
 /* Deliberately the same surface, radius, gap and type scale as `.source-row`
@@ -1839,7 +1839,7 @@ h3 { margin-bottom: 4px; font-size: 13px; font-weight: 700; color: var(--ink); }
    devices, so they have to read as one system rather than two. */
 .release-teaser { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .update-progress { display: grid; gap: 7px; margin-top: 14px; }
-.progress-head { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; color: var(--ink); font-size: 13px; }
+.progress-head { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; color: var(--ink); font-size: var(--fs-md); }
 .progress-head span { color: var(--accent); font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
 .progress-track { height: 6px; overflow: hidden; border-radius: 3px; background: rgba(232, 238, 244, .1); }
 .progress-track i { display: block; height: 100%; border-radius: 3px; background: var(--accent); transition: width 220ms ease; }
@@ -1852,9 +1852,9 @@ h3 { margin-bottom: 4px; font-size: 13px; font-weight: 700; color: var(--ink); }
 @media (prefers-reduced-motion: reduce) {
   .progress-track i.indeterminate { animation: none; width: 100%; opacity: .5; }
 }
-.progress-note { margin: 10px 0 0; color: var(--muted); font-size: 12px; line-height: 1.7; }
+.progress-note { margin: 10px 0 0; color: var(--muted); font-size: var(--fs-sm); line-height: 1.7; }
 .progress-note.bad { color: var(--danger); }
-.modal-sub { margin: 0 0 10px; color: var(--muted); font-size: 12px; }
+.modal-sub { margin: 0 0 10px; color: var(--muted); font-size: var(--fs-sm); }
 .release-notes {
   margin: 0;
   padding: 14px 16px;
@@ -1865,24 +1865,24 @@ h3 { margin-bottom: 4px; font-size: 13px; font-weight: 700; color: var(--ink); }
   background: var(--surface-raised);
   color: var(--ink);
   font-family: var(--font-sans);
-  font-size: 12.5px;
+  font-size: var(--fs-sm);
   line-height: 1.85;
   white-space: pre-wrap;
   word-break: break-word;
 }
 
 .mcp-handoff { margin-bottom: var(--space-4); }
-.mcp-handoff .mcp-config { max-height: 200px; overflow: auto; white-space: pre-wrap; font-size: 11.5px; line-height: 1.75; }
+.mcp-handoff .mcp-config { max-height: 200px; overflow: auto; white-space: pre-wrap; font-size: var(--fs-xs); line-height: 1.75; }
 .mcp-handoff .inline-actions { margin-top: 10px; }
 .mcp-tools { display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: var(--space-2); margin-bottom: var(--space-3); }
 .mcp-tool { display: grid; gap: 2px; padding: 9px 11px; border: 1px solid var(--line); border-radius: var(--radius-sm); background: var(--surface-raised); min-width: 0; }
-.mcp-tool code { color: var(--ink); font-family: var(--font-mono); font-size: 12px; }
-.mcp-tool span { color: var(--muted); font-size: 11px; }
-.mcp-sub { margin: 0 0 6px; color: var(--muted); font-size: 12px; }
-.mcp-config { margin: 0; padding: 12px 14px; overflow-x: auto; border: 1px solid var(--line); border-radius: var(--radius-sm); background: var(--surface-raised); color: var(--ink); font-family: var(--font-mono); font-size: 12px; line-height: 1.6; }
+.mcp-tool code { color: var(--ink); font-family: var(--font-mono); font-size: var(--fs-sm); }
+.mcp-tool span { color: var(--muted); font-size: var(--fs-xs); }
+.mcp-sub { margin: 0 0 6px; color: var(--muted); font-size: var(--fs-sm); }
+.mcp-config { margin: 0; padding: 12px 14px; overflow-x: auto; border: 1px solid var(--line); border-radius: var(--radius-sm); background: var(--surface-raised); color: var(--ink); font-family: var(--font-mono); font-size: var(--fs-sm); line-height: 1.6; }
 
 .capability-board { display: grid; gap: var(--space-3); }
-.capability-legend { display: flex; flex-wrap: wrap; gap: 6px 18px; margin: 0; color: var(--muted); font-size: 12px; }
+.capability-legend { display: flex; flex-wrap: wrap; gap: 6px 18px; margin: 0; color: var(--muted); font-size: var(--fs-sm); }
 .legend-item { display: inline-flex; align-items: center; gap: 6px; }
 .lamp { width: 8px; height: 8px; flex: 0 0 8px; border-radius: 50%; background: var(--subtle); }
 .lamp.on { background: #7da33e; box-shadow: 0 0 0 3px rgba(125,163,62,.16); }
@@ -1909,9 +1909,9 @@ h3 { margin-bottom: 4px; font-size: 13px; font-weight: 700; color: var(--ink); }
 }
 .capability-cell.off { opacity: .62; }
 .cell-head { display: flex; align-items: center; gap: 7px; min-width: 0; }
-.cell-head strong { overflow: hidden; color: var(--ink); font-size: 13px; text-overflow: ellipsis; white-space: nowrap; }
-.cell-detail { color: var(--muted); font-size: 11px; }
-.cell-note { color: var(--subtle); font-size: 11px; line-height: 1.5; }
+.cell-head strong { overflow: hidden; color: var(--ink); font-size: var(--fs-md); text-overflow: ellipsis; white-space: nowrap; }
+.cell-detail { color: var(--muted); font-size: var(--fs-xs); }
+.cell-note { color: var(--subtle); font-size: var(--fs-xs); line-height: 1.5; }
 @media (max-width: 720px) { .capability-grid { grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); } }
 .capability-heading {
   display: flex;
@@ -1919,7 +1919,7 @@ h3 { margin-bottom: 4px; font-size: 13px; font-weight: 700; color: var(--ink); }
   gap: var(--space-2);
   margin: 0 0 var(--space-2);
   color: var(--ink);
-  font-size: 13px;
+  font-size: var(--fs-md);
   font-weight: 700;
 }
 .capability-heading em {
@@ -1929,7 +1929,7 @@ h3 { margin-bottom: 4px; font-size: 13px; font-weight: 700; color: var(--ink); }
   background: var(--surface-raised);
   color: var(--muted);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--fs-xs);
   font-style: normal;
   font-weight: 400;
 }
@@ -1945,26 +1945,26 @@ h3 { margin-bottom: 4px; font-size: 13px; font-weight: 700; color: var(--ink); }
   background: var(--surface-raised);
 }
 .capability-copy { display: grid; gap: 1px; min-width: 0; flex: 1; }
-.capability-copy strong { color: var(--ink); font-size: 13px; font-weight: 400; }
-.capability-copy span { color: var(--subtle); font-size: 11px; overflow-wrap: anywhere; }
+.capability-copy strong { color: var(--ink); font-size: var(--fs-md); font-weight: 400; }
+.capability-copy span { color: var(--subtle); font-size: var(--fs-xs); overflow-wrap: anywhere; }
 .capability-empty {
   padding: 8px 10px;
   border: 1px dashed var(--line-strong);
   border-radius: var(--radius-sm);
   color: var(--subtle);
-  font-size: 12px;
+  font-size: var(--fs-sm);
 }
-.capability-checked { color: var(--muted); font-size: 12px; white-space: nowrap; }
+.capability-checked { color: var(--muted); font-size: var(--fs-sm); white-space: nowrap; }
 .capability-yes { color: var(--accent); flex: 0 0 auto; }
 .capability-no { color: var(--faint); flex: 0 0 auto; }
 .capability-pending { color: var(--warning); flex: 0 0 auto; }
-.capability-why { color: var(--subtle); font-size: 10px; line-height: 1.5; }
+.capability-why { color: var(--subtle); font-size: var(--fs-2xs); line-height: 1.5; }
 .probe-diagnostics { margin-top: 16px; }
-.probe-diagnostics > summary { color: var(--muted); font-size: 12px; cursor: pointer; }
+.probe-diagnostics > summary { color: var(--muted); font-size: var(--fs-sm); cursor: pointer; }
 .probe-diagnostics ul { margin: 8px 0 0; padding-left: 18px; }
 .probe-diagnostics li,
-.probe-selfcheck { color: var(--muted); font-size: 11px; line-height: 1.7; overflow-wrap: anywhere; }
-.device-empty { display: flex; align-items: center; gap: 7px; min-height: 60px; padding: 10px; border: 1px dashed var(--line-strong); border-radius: var(--radius-sm); color: var(--muted); font-size: 12px; }
+.probe-selfcheck { color: var(--muted); font-size: var(--fs-xs); line-height: 1.7; overflow-wrap: anywhere; }
+.device-empty { display: flex; align-items: center; gap: 7px; min-height: 60px; padding: 10px; border: 1px dashed var(--line-strong); border-radius: var(--radius-sm); color: var(--muted); font-size: var(--fs-sm); }
 .two-col { display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1.1fr); gap: 14px; align-items: start; }
 /* 成对的两块卡片等高对齐；高度由内容较多的一块决定，而不是被第三块撑开。 */
 .two-col.paired { grid-template-columns: repeat(2, minmax(0, 1fr)); align-items: stretch; }
@@ -1999,26 +1999,26 @@ h3 { margin-bottom: 4px; font-size: 13px; font-weight: 700; color: var(--ink); }
   color: var(--warning);
 }
 .auth-card.current .auth-icon { color: var(--accent); }
-.auth-head strong { display: block; font-size: 13px; margin-bottom: 3px; color: var(--ink); }
-.auth-head p { margin: 0; color: var(--subtle); font-size: 11px; line-height: 1.5; }
+.auth-head strong { display: block; font-size: var(--fs-md); margin-bottom: 3px; color: var(--ink); }
+.auth-head p { margin: 0; color: var(--subtle); font-size: var(--fs-xs); line-height: 1.5; }
 .auth-action {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 6px;
   min-height: 34px;
-  border: 1px solid var(--line);
+  border: 1px solid var(--line-control);
   border-radius: 9px;
   background: var(--surface);
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   cursor: pointer;
   transition: all 140ms ease;
 }
 .auth-action:hover:not(:disabled) { color: var(--accent); border-color: var(--accent); }
 .auth-action:disabled { opacity: .5; cursor: not-allowed; }
 .auth-action.is-current { border-color: rgba(205, 220, 124, .35); background: var(--accent-soft); color: var(--accent); font-weight: 600; }
-.hint-line { display: inline-flex; align-items: center; gap: 6px; margin: 12px 0 0; color: var(--muted); font-size: 12px; }
+.hint-line { display: inline-flex; align-items: center; gap: 6px; margin: 12px 0 0; color: var(--muted); font-size: var(--fs-sm); }
 .hint-line.ok { color: var(--accent); }
 .hint-line.ok svg { color: var(--accent); }
 
@@ -2033,16 +2033,16 @@ h3 { margin-bottom: 4px; font-size: 13px; font-weight: 700; color: var(--ink); }
   border-bottom: 1px solid var(--line);
 }
 .kv-row:last-child { border-bottom: 0; }
-.kv-label { flex: 0 0 96px; color: var(--muted); font-size: 12px; }
-.kv-value { flex: 1; min-width: 0; color: var(--ink); font-size: 13px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.kv-value.mono { font-family: var(--font-mono); font-size: 12px; }
+.kv-label { flex: 0 0 96px; color: var(--muted); font-size: var(--fs-sm); }
+.kv-value { flex: 1; min-width: 0; color: var(--ink); font-size: var(--fs-md); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.kv-value.mono { font-family: var(--font-mono); font-size: var(--fs-sm); }
 .kv-btn {
   padding: 5px 14px;
-  border: 1px solid var(--line);
+  border: 1px solid var(--line-control);
   border-radius: 8px;
   background: var(--surface-raised);
   color: var(--accent);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   cursor: pointer;
 }
 .kv-btn:hover:not(:disabled) { border-color: var(--accent); }
@@ -2073,10 +2073,10 @@ h3 { margin-bottom: 4px; font-size: 13px; font-weight: 700; color: var(--ink); }
 .source-icon :deep(.device-visual) { width: 36px; max-width: 100%; height: 36px; max-height: 100%; min-width: 0; min-height: 0; flex: 0 0 36px; border: 0; border-radius: 9px; background: transparent; }
 .source-icon :deep(.device-visual img) { padding: 3px; }
 .source-copy { flex: 1; min-width: 0; display: grid; gap: 1px; }
-.source-copy strong { font-size: 13px; color: var(--ink); }
-.source-copy span { color: var(--subtle); font-size: 11px; }
-.source-copy span + span { font-family: var(--font-mono); font-size: 10px; }
-.source-state { display: inline-flex; align-items: center; gap: 5px; color: var(--subtle); font-size: 12px; }
+.source-copy strong { font-size: var(--fs-md); color: var(--ink); }
+.source-copy span { color: var(--subtle); font-size: var(--fs-xs); }
+.source-copy span + span { font-family: var(--font-mono); font-size: var(--fs-2xs); }
+.source-state { display: inline-flex; align-items: center; gap: 5px; color: var(--subtle); font-size: var(--fs-sm); }
 .source-state .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--subtle); }
 .source-state.on { color: var(--accent); }
 .source-state.on .dot { background: var(--accent); }
@@ -2107,8 +2107,8 @@ h3 { margin-bottom: 4px; font-size: 13px; font-weight: 700; color: var(--ink); }
   color: var(--accent);
 }
 .toggle-copy { flex: 1; min-width: 0; display: grid; gap: 1px; }
-.toggle-copy strong { font-size: 12px; color: var(--ink); }
-.toggle-copy span { color: var(--subtle); font-size: 11px; }
+.toggle-copy strong { font-size: var(--fs-sm); color: var(--ink); }
+.toggle-copy span { color: var(--subtle); font-size: var(--fs-xs); }
 .switch { width: 42px; height: 24px; flex: 0 0 42px; padding: 2px; border: 1px solid var(--line-strong); border-radius: 999px; background: var(--surface-raised); cursor: pointer; }
 .switch span { display: block; width: 18px; height: 18px; border-radius: 50%; background: var(--muted); transition: transform 150ms ease, background-color 150ms ease; }
 .switch[aria-checked='true'] { border-color: var(--accent); background: var(--accent-soft); }
@@ -2123,14 +2123,14 @@ h3 { margin-bottom: 4px; font-size: 13px; font-weight: 700; color: var(--ink); }
   border: 0;
   background: transparent;
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   cursor: pointer;
   transition: color 140ms ease;
 }
 .privacy-link-btn:hover { color: var(--accent); }
 .diagnostic-panel { display: grid; gap: 7px; margin-top: 12px; padding: 12px; border: 1px solid var(--line); border-radius: 12px; background: rgba(255,255,255,.025); }
-.diagnostic-panel strong { color: var(--ink); font-size: 12px; }
-.diagnostic-panel p { margin: 0; color: var(--subtle); font-size: 11px; line-height: 1.55; }
+.diagnostic-panel strong { color: var(--ink); font-size: var(--fs-sm); }
+.diagnostic-panel p { margin: 0; color: var(--subtle); font-size: var(--fs-xs); line-height: 1.55; }
 .diagnostic-panel .button { justify-self: start; }
 
 .field-row {
@@ -2143,12 +2143,12 @@ h3 { margin-bottom: 4px; font-size: 13px; font-weight: 700; color: var(--ink); }
 }
 /* 这些下拉现在是 SelectMenu，不是原生 select；宽度在这里定，其余样式在组件里。 */
 .field-row .select-menu { min-width: 180px; flex: 0 0 auto; }
-.retain-note { margin: 6px 0 8px; color: var(--muted); font-size: 12px; line-height: 1.6; }
+.retain-note { margin: 6px 0 8px; color: var(--muted); font-size: var(--fs-sm); line-height: 1.6; }
 .inline-actions { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 12px; }
-.button { display: inline-flex; min-height: 32px; align-items: center; justify-content: center; gap: 6px; padding: 5px 14px; border: 1px solid transparent; border-radius: 9px; background: transparent; font-size: 12px; cursor: pointer; }
+.button { display: inline-flex; min-height: 32px; align-items: center; justify-content: center; gap: 6px; padding: 5px 14px; border: 1px solid transparent; border-radius: 9px; background: transparent; font-size: var(--fs-sm); cursor: pointer; }
 .button:disabled { opacity: .5; cursor: not-allowed; }
 .button.primary { background: var(--accent); color: var(--accent-ink); font-weight: 600; }
-.button.secondary { border-color: var(--line-strong); color: var(--muted); background: var(--surface-raised); }
+.button.secondary { border-color: var(--line-control); color: var(--muted); background: var(--surface-raised); }
 .button.secondary:hover:not(:disabled) { border-color: var(--accent); color: var(--accent); }
 .danger-button { border-color: rgba(240, 97, 106, .35); color: var(--danger); }
 
@@ -2167,12 +2167,12 @@ h3 { margin-bottom: 4px; font-size: 13px; font-weight: 700; color: var(--ink); }
   background: var(--surface-raised);
   color: var(--accent);
 }
-.sync-desc { margin: 0; color: var(--muted); font-size: 12px; line-height: 1.6; }
+.sync-desc { margin: 0; color: var(--muted); font-size: var(--fs-sm); line-height: 1.6; }
 .sync-controls { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
-.sync-toggle-label { color: var(--muted); font-size: 12px; }
+.sync-toggle-label { color: var(--muted); font-size: var(--fs-sm); }
 .sync-now { min-height: 36px; border-radius: 10px; }
 .interval-options { display: flex; flex-wrap: wrap; gap: 6px; }
-.interval-options button { min-width: 58px; min-height: 28px; padding: 3px 10px; border: 1px solid var(--line); border-radius: 8px; background: transparent; color: var(--ink); font-size: 12px; cursor: pointer; }
+.interval-options button { min-width: 58px; min-height: 28px; padding: 3px 10px; border: 1px solid var(--line-control); border-radius: 8px; background: transparent; color: var(--ink); font-size: var(--fs-sm); cursor: pointer; }
 .interval-options button[aria-checked='true'] { border-color: var(--accent); color: var(--accent); background: var(--accent-soft); }
 .interval-options.is-disabled { opacity: .5; }
 .interval-options.is-disabled button { cursor: not-allowed; }
@@ -2181,35 +2181,35 @@ h3 { margin-bottom: 4px; font-size: 13px; font-weight: 700; color: var(--ink); }
 .advanced > summary { display: flex; align-items: center; justify-content: space-between; gap: 12px; cursor: pointer; list-style: none; }
 .advanced > summary::-webkit-details-marker { display: none; }
 .advanced > summary span { display: grid; gap: 2px; min-width: 0; }
-.advanced > summary strong { font-size: 14px; font-weight: 700; color: var(--ink); }
-.advanced > summary em { color: var(--muted); font-size: 12px; font-style: normal; }
+.advanced > summary strong { font-size: var(--fs-lg); font-weight: 700; color: var(--ink); }
+.advanced > summary em { color: var(--muted); font-size: var(--fs-sm); font-style: normal; }
 .advanced[open] > summary > svg { transform: rotate(180deg); }
 .advanced-content { display: grid; gap: 16px; margin-top: 12px; border-top: 1px solid var(--line); padding-top: 12px; }
 .advanced-block { display: grid; gap: 6px; }
-.advanced-label { margin: 0; color: var(--ink); font-size: 13px; font-weight: 600; }
+.advanced-label { margin: 0; color: var(--ink); font-size: var(--fs-md); font-weight: 600; }
 .diag-fold { border-top: 1px solid var(--line); padding-top: 8px; }
-.diag-fold > summary { cursor: pointer; color: var(--muted); font-size: 12px; list-style: none; }
+.diag-fold > summary { cursor: pointer; color: var(--muted); font-size: var(--fs-sm); list-style: none; }
 .diag-fold > summary::-webkit-details-marker { display: none; }
 .diag-fold[open] > summary { color: var(--ink); }
 .scale-options { display: flex; flex-wrap: wrap; gap: 6px; }
-.scale-options button { min-width: 48px; min-height: 30px; padding: 4px 8px; border: 1px solid var(--line); border-radius: 8px; background: transparent; color: var(--ink); font-variant-numeric: tabular-nums; font-family: 'Inter', var(--font-sans); font-size: 12px; cursor: pointer; }
+.scale-options button { min-width: 48px; min-height: 30px; padding: 4px 8px; border: 1px solid var(--line-control); border-radius: 8px; background: transparent; color: var(--ink); font-variant-numeric: tabular-nums; font-family: 'Inter', var(--font-sans); font-size: var(--fs-sm); cursor: pointer; }
 .scale-options button[aria-checked='true'] { border-color: var(--accent); color: var(--accent); background: var(--accent-soft); }
 .stream-list { display: grid; gap: 2px; margin-top: 6px; }
-.stream-row { display: grid; grid-template-columns: 110px minmax(0, 1fr) auto; gap: 12px; padding: 7px 0; border-bottom: 1px solid var(--line); color: var(--muted); font-size: 12px; }
+.stream-row { display: grid; grid-template-columns: 110px minmax(0, 1fr) auto; gap: 12px; padding: 7px 0; border-bottom: 1px solid var(--line); color: var(--muted); font-size: var(--fs-sm); }
 .stream-row strong { font-weight: 600; color: var(--ink); }
-.alert { display: flex; align-items: flex-start; gap: 7px; padding: 9px 12px; border: 1px solid var(--line); border-radius: var(--radius-sm); background: var(--surface); color: var(--muted); font-size: 12px; }
+.alert { display: flex; align-items: flex-start; gap: 7px; padding: 9px 12px; border: 1px solid var(--line); border-radius: var(--radius-sm); background: var(--surface); color: var(--muted); font-size: var(--fs-sm); }
 .alert.success { color: var(--accent); }
 .alert.danger { color: var(--danger); }
 .alert.warning { color: var(--warning); }
-.alert button { margin-left: auto; border: 0; background: transparent; color: inherit; cursor: pointer; font-size: 12px; }
-code { color: var(--muted); font-family: var(--font-mono); font-size: 12px; }
+.alert button { margin-left: auto; border: 0; background: transparent; color: inherit; cursor: pointer; font-size: var(--fs-sm); }
+code { color: var(--muted); font-family: var(--font-mono); font-size: var(--fs-sm); }
 .manual-auth-form { margin-top: 16px; padding: 16px; border: 1px solid var(--line); border-radius: var(--radius-md); background: var(--surface-raised); }
-.manual-auth-form h3 { margin: 0 0 8px; font-size: 14px; font-weight: 700; color: var(--ink); }
-.manual-auth-form .form-hint { margin: 0 0 12px; color: var(--muted); font-size: 12px; }
+.manual-auth-form h3 { margin: 0 0 8px; font-size: var(--fs-lg); font-weight: 700; color: var(--ink); }
+.manual-auth-form .form-hint { margin: 0 0 12px; color: var(--muted); font-size: var(--fs-sm); }
 .manual-auth-form .form-group { margin-bottom: 12px; }
 .manual-auth-form .form-group:last-of-type { margin-bottom: 16px; }
-.manual-auth-form label { display: block; margin-bottom: 4px; color: var(--ink); font-size: 12px; font-weight: 500; }
-.manual-auth-form input { width: 100%; padding: 8px 10px; border: 1px solid var(--line); border-radius: 9px; background: var(--surface); color: var(--ink); font-family: var(--font-mono); font-size: 12px; }
+.manual-auth-form label { display: block; margin-bottom: 4px; color: var(--ink); font-size: var(--fs-sm); font-weight: 600; }
+.manual-auth-form input { width: 100%; padding: 8px 10px; border: 1px solid var(--line-control); border-radius: 9px; background: var(--surface); color: var(--ink); font-family: var(--font-mono); font-size: var(--fs-sm); }
 .manual-auth-form input:focus { outline: none; border-color: var(--accent); }
 .manual-auth-form input:disabled { opacity: 0.5; cursor: not-allowed; }
 .manual-auth-form .form-actions { display: flex; gap: 8px; }
@@ -2222,7 +2222,7 @@ code { color: var(--muted); font-family: var(--font-mono); font-size: 12px; }
 .shield-ic { color: var(--accent); }
 .close-btn { display: grid; place-items: center; width: 28px; height: 28px; border: 0; border-radius: 6px; background: transparent; color: var(--muted); cursor: pointer; }
 .close-btn:hover { background: var(--surface-hover); color: var(--ink); }
-.modal-body { display: grid; gap: 10px; color: var(--muted); font-size: 12px; line-height: 1.6; }
+.modal-body { display: grid; gap: 10px; color: var(--muted); font-size: var(--fs-sm); line-height: 1.6; }
 .modal-body strong { color: var(--ink); }
 .modal-foot { display: flex; justify-content: flex-end; margin-top: 16px; padding-top: 12px; border-top: 1px solid var(--line); }
 

--- a/src/views/SleepDetail.vue
+++ b/src/views/SleepDetail.vue
@@ -170,17 +170,17 @@ const weeklyChartOption = computed(() => {
       data: sleepStageLabels(),
       top: 0,
       right: 0,
-      textStyle: { color: '#7E856D', fontSize: 11 },
+      textStyle: { color: '#B4BBC3', fontSize: 14.5 },
       itemWidth: 8,
       itemHeight: 8,
       icon: 'circle',
     },
     tooltip: {
       trigger: 'axis',
-      backgroundColor: '#22261A',
+      backgroundColor: '#1E221F',
       borderColor: 'rgba(228, 235, 208, 0.16)',
       borderWidth: 1,
-      textStyle: { color: '#F3F4EC', fontSize: 12 },
+      textStyle: { color: '#F3F4EC', fontSize: 15.5 },
       formatter: (params: Array<{ seriesName: string; value: number; name: string }>) => {
         if (!params || !params.length) return '';
         const name = params[0].name;
@@ -198,18 +198,18 @@ const weeklyChartOption = computed(() => {
       axisLine: { lineStyle: { color: 'rgba(228, 235, 208, 0.1)' } },
       axisTick: { show: false },
       axisLabel: {
-        color: (_val: string, index: number) => index === currentIndex ? '#7DA33E' : '#7E856D',
-        fontSize: 11,
+        color: (_val: string, index: number) => index === currentIndex ? '#93B952' : '#B4BBC3',
+        fontSize: 14.5,
         fontWeight: (_val: string, index: number) => index === currentIndex ? 'bold' : 'normal',
       },
     },
     yAxis: {
       type: 'value',
       name: t.value.hoursAxis,
-      nameTextStyle: { color: '#7E856D', fontSize: 10, align: 'right' },
+      nameTextStyle: { color: '#B4BBC3', fontSize: 14.5, align: 'right' },
       axisLine: { show: false },
       axisTick: { show: false },
-      axisLabel: { color: '#7E856D', fontSize: 10 },
+      axisLabel: { color: '#B4BBC3', fontSize: 14.5 },
       splitLine: { show: true, lineStyle: { color: 'rgba(228, 235, 208, 0.08)', type: 'dashed' } },
     },
     series: [
@@ -407,7 +407,7 @@ watch([dataRevision, sleepId], () => void loadDetail());
   align-items: center;
   gap: 6px;
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   text-decoration: none;
 }
 .back-link:hover { color: var(--accent); }
@@ -415,14 +415,14 @@ watch([dataRevision, sleepId], () => void loadDetail());
 .page-heading h1 {
   margin: 0;
   color: var(--ink);
-  font-size: 22px;
+  font-size: 24px;
   font-weight: 700;
   letter-spacing: -0.02em;
 }
 .page-heading p {
   margin: 4px 0 0;
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--fs-sm);
 }
 .muted-line { color: var(--muted); }
 .sleep-hero {
@@ -447,19 +447,19 @@ watch([dataRevision, sleepId], () => void loadDetail());
 .score-num {
   margin: 0;
   color: var(--ink);
-  font-size: 22px;
+  font-size: 24px;
   font-weight: 700;
   font-variant-numeric: tabular-nums;
 }
-.score-num small { color: var(--muted); font-size: 13px; font-weight: 500; }
-.score-note { margin: 2px 0 0; color: var(--muted); font-size: 11px; line-height: 1.45; }
+.score-num small { color: var(--muted); font-size: var(--fs-md); font-weight: 600; }
+.score-note { margin: 2px 0 0; color: var(--muted); font-size: var(--fs-xs); line-height: 1.45; }
 .kicker {
   display: flex;
   align-items: center;
   gap: 8px;
   margin: 0;
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--fs-sm);
 }
 .mark {
   display: grid;
@@ -482,11 +482,11 @@ watch([dataRevision, sleepId], () => void loadDetail());
 .meta {
   margin: 8px 0 0;
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--fs-sm);
 }
 .score-empty {
   color: var(--ink);
-  font-size: 28px;
+  font-size: 31px;
   font-weight: 600;
 }
 .stage-card, .chart-card { margin: 0; padding: 16px 18px; background: var(--surface); border: 1px solid var(--line); border-radius: var(--radius-md); }
@@ -498,19 +498,19 @@ watch([dataRevision, sleepId], () => void loadDetail());
   gap: 12px;
   margin-bottom: 12px;
 }
-.stage-head h2 { margin: 0; color: var(--ink); font-size: 15px; font-weight: 700; }
-.stage-head p { margin: 0; color: var(--muted); font-size: 12px; }
+.stage-head h2 { margin: 0; color: var(--ink); font-size: var(--fs-xl); font-weight: 700; }
+.stage-head p { margin: 0; color: var(--muted); font-size: var(--fs-sm); }
 .stage-actions { display: flex; align-items: center; gap: 10px; }
 .stage-help-button {
   border: 1px solid var(--line);
   border-radius: 999px;
   background: transparent;
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   padding: 4px 10px;
   cursor: pointer;
 }
-.stage-help { margin: 0 0 12px; color: var(--muted); font-size: 12px; line-height: 1.55; }
+.stage-help { margin: 0 0 12px; color: var(--muted); font-size: var(--fs-sm); line-height: 1.55; }
 .meta-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -524,19 +524,19 @@ watch([dataRevision, sleepId], () => void loadDetail());
   gap: 8px;
   margin: 0 0 10px;
   color: var(--ink);
-  font-size: 13px;
+  font-size: var(--fs-md);
   font-weight: 700;
 }
 .meta-title svg { color: var(--sleep); }
 .meta-card dl { display: grid; gap: 8px; margin: 0; }
-.meta-card dt { color: var(--muted); font-size: 12px; }
+.meta-card dt { color: var(--muted); font-size: var(--fs-sm); }
 .meta-card dd {
   margin: 3px 0 0;
   color: var(--ink);
   overflow-wrap: anywhere;
-  font-size: 13px;
+  font-size: var(--fs-md);
 }
-.note { margin: 0; color: var(--muted); font-size: 12px; }
+.note { margin: 0; color: var(--muted); font-size: var(--fs-sm); }
 @media (max-width: 760px) {
   .sleep-hero, .meta-grid { grid-template-columns: 1fr; }
   .hero-score { justify-content: flex-start; }

--- a/src/views/SleepList.vue
+++ b/src/views/SleepList.vue
@@ -158,14 +158,14 @@ watch(dataRevision, () => void loadList());
   gap: 6px;
   margin-bottom: 8px;
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   text-decoration: none;
 }
 .back-link:hover { color: var(--accent); }
 .footnote {
   margin: 12px 0 0;
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--fs-sm);
 }
 .load-more { display: flex; justify-content: center; margin-top: 12px; }
 </style>

--- a/src/views/TrainingStatus.vue
+++ b/src/views/TrainingStatus.vue
@@ -147,13 +147,15 @@ const thresholdOption = computed(() => {
     source?.points.find((point) => point.date === date)?.value ?? null;
   return {
     animationDuration: 600,
-    grid: { left: 46, right: 52, top: 24, bottom: 28 },
+    // 左边距要放得下 `165 bpm` 这种带单位的刻度：这里不开 containLabel，
+    // 标签是贴着固定的左边距右对齐画的，放不下就直接被画到画布外面去了。
+    grid: { left: 68, right: 52, top: 24, bottom: 28 },
     legend: {
       data: [t.value.thresholdHr, t.value.thresholdPace],
       top: 0,
       itemWidth: 14,
       itemHeight: 8,
-      textStyle: { fontSize: 11 },
+      textStyle: { fontSize: 14.5 },
     },
     tooltip: {
       trigger: 'axis',
@@ -169,9 +171,9 @@ const thresholdOption = computed(() => {
         return [params[0].axisValue, ...lines].join('<br>');
       },
     },
-    xAxis: { type: 'category', data: dates, boundaryGap: false, axisLabel: { fontSize: 10, hideOverlap: true } },
+    xAxis: { type: 'category', data: dates, boundaryGap: false, axisLabel: { fontSize: 14.5, hideOverlap: true } },
     yAxis: [
-      { type: 'value', scale: true, splitNumber: 3, axisLabel: { fontSize: 10, formatter: '{value} bpm' } },
+      { type: 'value', scale: true, splitNumber: 3, axisLabel: { fontSize: 14.5, formatter: '{value} bpm' } },
       {
         type: 'value',
         scale: true,
@@ -180,7 +182,7 @@ const thresholdOption = computed(() => {
         // keep "better" pointing up like every other chart here.
         inverse: true,
         splitLine: { show: false },
-        axisLabel: { fontSize: 10, formatter: (value: number) => formatPaceSeconds(value) },
+        axisLabel: { fontSize: 14.5, formatter: (value: number) => formatPaceSeconds(value) },
       },
     ],
     series: [
@@ -220,7 +222,7 @@ const balanceOption = computed(() => {
       top: 0,
       itemWidth: 14,
       itemHeight: 8,
-      textStyle: { fontSize: 11 },
+      textStyle: { fontSize: 14.5 },
     },
     tooltip: {
       trigger: 'axis',
@@ -239,10 +241,10 @@ const balanceOption = computed(() => {
         ].join('<br>');
       },
     },
-    xAxis: { type: 'category', data: dates, boundaryGap: false, axisLabel: { fontSize: 10, hideOverlap: true } },
+    xAxis: { type: 'category', data: dates, boundaryGap: false, axisLabel: { fontSize: 14.5, hideOverlap: true } },
     yAxis: [
-      { type: 'value', scale: true, splitNumber: 3, axisLabel: { fontSize: 10 } },
-      { type: 'value', scale: true, splitNumber: 3, splitLine: { show: false }, axisLabel: { fontSize: 10 } },
+      { type: 'value', scale: true, splitNumber: 3, axisLabel: { fontSize: 14.5 } },
+      { type: 'value', scale: true, splitNumber: 3, splitLine: { show: false }, axisLabel: { fontSize: 14.5 } },
     ],
     series: [
       {
@@ -445,7 +447,7 @@ watch(dataRevision, () => { void load(); });
   border-radius: var(--radius-sm);
   background: transparent;
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   cursor: pointer;
 }
 .range-pill:hover { color: var(--ink); }
@@ -464,11 +466,11 @@ watch(dataRevision, () => { void load(); });
 .chart-card.wide { padding: var(--space-4) var(--space-6); }
 .chart-head { display: flex; align-items: flex-start; justify-content: space-between; gap: var(--space-3); }
 .chart-title { display: grid; gap: 2px; min-width: 0; }
-.chart-title strong { color: var(--ink); font-size: 13px; font-weight: 700; }
-.chart-title small { color: var(--subtle); font-size: 11px; }
+.chart-title strong { color: var(--ink); font-size: var(--fs-md); font-weight: 700; }
+.chart-title small { color: var(--subtle); font-size: var(--fs-xs); }
 .chart-latest { display: flex; align-items: baseline; gap: 4px; white-space: nowrap; }
-.chart-latest b { color: var(--ink); font-family: var(--font-mono); font-size: 18px; font-variant-numeric: tabular-nums; }
-.chart-latest i { margin-right: 6px; color: var(--subtle); font-size: 10px; font-style: normal; }
+.chart-latest b { color: var(--ink); font-family: var(--font-mono); font-size: var(--fs-3xl); font-variant-numeric: tabular-nums; }
+.chart-latest i { margin-right: 6px; color: var(--subtle); font-size: var(--fs-2xs); font-style: normal; }
 .chart-body { width: 100%; height: 172px; margin-top: var(--space-2); }
 .chart-body.tall { height: 236px; }
 .chart-empty {
@@ -477,9 +479,9 @@ watch(dataRevision, () => { void load(); });
   min-height: 172px;
   margin: var(--space-2) 0 0;
   color: var(--subtle);
-  font-size: 12px;
+  font-size: var(--fs-sm);
 }
-.chart-note { margin: var(--space-2) 0 0; color: var(--subtle); font-size: 11px; line-height: 1.7; }
+.chart-note { margin: var(--space-2) 0 0; color: var(--subtle); font-size: var(--fs-xs); line-height: 1.7; }
 .inline-alert {
   display: flex;
   align-items: center;
@@ -490,7 +492,7 @@ watch(dataRevision, () => { void load(); });
   border-radius: var(--radius-md);
   background: var(--surface);
   color: var(--danger);
-  font-size: 12px;
+  font-size: var(--fs-sm);
 }
 .retry { margin-left: auto; }
 @media (max-width: 720px) {

--- a/src/views/WorkoutDetail.vue
+++ b/src/views/WorkoutDetail.vue
@@ -763,7 +763,7 @@ const lineOption = (points: { t: number; v: number }[], color: string, unit: str
       type: 'time',
       axisLine: { show: false },
       axisTick: { show: false },
-      axisLabel: { color: '#7E856D', fontSize: 10 },
+      axisLabel: { color: '#B4BBC3', fontSize: 14.5 },
       splitLine: { show: false },
     },
     yAxis: {
@@ -771,15 +771,15 @@ const lineOption = (points: { t: number; v: number }[], color: string, unit: str
       scale: true,
       axisLine: { show: false },
       axisTick: { show: false },
-      axisLabel: { color: '#7E856D', fontSize: 10 },
+      axisLabel: { color: '#B4BBC3', fontSize: 14.5 },
       splitLine: { show: true, lineStyle: { color: 'rgba(228, 235, 208, 0.08)', type: 'dashed' } },
     },
     tooltip: {
       trigger: 'axis',
-      backgroundColor: '#22261A',
+      backgroundColor: '#1E221F',
       borderColor: 'rgba(228, 235, 208, 0.16)',
       borderWidth: 1,
-      textStyle: { color: '#F3F4EC', fontSize: 12 },
+      textStyle: { color: '#F3F4EC', fontSize: 15.5 },
       formatter: (params: Array<{ value: [number, number] }>) => {
         const point = Array.isArray(params) ? params[0] : params;
         if (!point) return '';
@@ -1168,25 +1168,25 @@ watch([dataRevision, workoutId], () => void loadDetail());
 .workout-page { width: 100%; display: grid; gap: 16px; align-content: start; }
 .detail-loading { display: grid; gap: 12px; }
 .page-toolbar { display: flex; align-items: center; justify-content: space-between; gap: 12px; min-height: 38px; }
-.back-link { display: inline-flex; align-items: center; gap: 6px; justify-self: start; color: var(--muted); font-size: 12px; text-decoration: none; }
+.back-link { display: inline-flex; align-items: center; gap: 6px; justify-self: start; color: var(--muted); font-size: var(--fs-sm); text-decoration: none; }
 .back-link:hover { color: var(--accent); }
-.ai-provider { display: grid; gap: 6px; margin-bottom: 10px; font-size: 12px; color: var(--muted); }
-.ai-provider select { min-height: 34px; padding: 0 10px; border: 1px solid var(--line); border-radius: 10px; background: var(--surface); color: var(--ink); font: inherit; }
-.workout-hero { position: relative; overflow: hidden; display: grid; gap: 18px; padding: 22px; border: 1px solid rgba(226,234,242,.1); border-radius: 24px; background: radial-gradient(circle at 88% 18%, rgba(43,179,192,.14), transparent 30%), linear-gradient(145deg, #20242b 0%, #191c21 58%, #171a1f 100%); box-shadow: 0 22px 70px rgba(4,6,8,.22); }
+.ai-provider { display: grid; gap: 6px; margin-bottom: 10px; font-size: var(--fs-sm); color: var(--muted); }
+.ai-provider select { min-height: 34px; padding: 0 10px; border: 1px solid var(--line-control); border-radius: 10px; background: var(--surface); color: var(--ink); font: inherit; }
+.workout-hero { position: relative; overflow: hidden; display: grid; gap: 18px; padding: 22px; border: 1px solid rgba(226,234,242,.1); border-radius: 24px; background: radial-gradient(circle at 88% 18%, rgba(43,179,192,.14), transparent 30%), linear-gradient(145deg, #1D2128 0%, #171B20 58%, #14171C 100%); box-shadow: 0 22px 70px rgba(4,6,8,.22); }
 .workout-hero::before { position: absolute; inset: 0; pointer-events: none; content: ''; background: linear-gradient(120deg, rgba(255,255,255,.035), transparent 38%); }
 .hero-copy { position: relative; z-index: 1; display: flex; align-items: center; gap: 20px; min-width: 0; }
 .hero-device { display: grid; justify-items: center; gap: 7px; flex: 0 0 auto; }
-.hero-device :deep(.device-visual) { width: 112px; height: 112px; flex-basis: 112px; border-radius: 22px; background: rgba(11,14,17,.5); box-shadow: inset 0 0 24px rgba(255,255,255,.025); }
+.hero-device :deep(.device-visual) { width: 112px; height: 112px; flex-basis: 112px; border-radius: 22px; background: rgba(8,10,13,.5); box-shadow: inset 0 0 24px rgba(255,255,255,.025); }
 .hero-device :deep(.device-visual img) { padding: 8px; }
-.device-live { display: inline-flex; align-items: center; gap: 5px; max-width: 132px; overflow: hidden; color: var(--muted); font-size: 10px; text-overflow: ellipsis; white-space: nowrap; }
+.device-live { display: inline-flex; align-items: center; gap: 5px; max-width: 132px; overflow: hidden; color: var(--muted); font-size: var(--fs-2xs); text-overflow: ellipsis; white-space: nowrap; }
 .device-live i { width: 6px; height: 6px; border-radius: 50%; background: var(--readiness); box-shadow: 0 0 0 4px rgba(61,216,76,.1); }
 .hero-title-group { min-width: 0; }
-.source-chip { display: inline-flex; align-items: center; gap: 6px; min-height: 27px; padding: 3px 10px 3px 5px; border: 1px solid rgba(125,163,62,.25); border-radius: 999px; background: rgba(125,163,62,.08); color: #b8ce90; font-size: 11px; }
+.source-chip { display: inline-flex; align-items: center; gap: 6px; min-height: 27px; padding: 3px 10px 3px 5px; border: 1px solid rgba(125,163,62,.25); border-radius: 999px; background: rgba(125,163,62,.08); color: #b8ce90; font-size: var(--fs-xs); }
 .sport-line { display: flex; align-items: center; gap: 12px; margin-top: 8px; }
-.hero-kicker, .section-eyebrow { margin: 0; color: var(--subtle); font-family: var(--font-mono); font-size: 9px; font-weight: 700; letter-spacing: .16em; }
+.hero-kicker, .section-eyebrow { margin: 0; color: var(--subtle); font-family: var(--font-mono); font-size: var(--fs-2xs); font-weight: 700; letter-spacing: .16em; }
 .sport-line h1 { margin: 1px 0 0; color: var(--ink); font-size: clamp(25px, 3vw, 38px); line-height: 1.1; letter-spacing: -.04em; }
-.sport-time { display: inline-flex; align-items: center; gap: 6px; margin: 9px 0 0; color: var(--muted); font-size: 12px; }
-.type-evidence { display: flex; flex-wrap: wrap; align-items: center; gap: 7px 12px; margin-top: 10px; color: var(--muted); font-size: 11px; }
+.sport-time { display: inline-flex; align-items: center; gap: 6px; margin: 9px 0 0; color: var(--muted); font-size: var(--fs-sm); }
+.type-evidence { display: flex; flex-wrap: wrap; align-items: center; gap: 7px 12px; margin-top: 10px; color: var(--muted); font-size: var(--fs-xs); }
 .type-evidence > span { padding: 5px 8px; border: 1px solid var(--line); border-radius: 8px; background: rgba(255,255,255,.025); }
 /* 「我的纠正」这一格是标签 + 选择器；`> span` 的边框不该套在它外面。
    选择器本身不做任何尺寸覆盖——全应用只有一种下拉长相，这是用户点名要的。 */
@@ -1194,28 +1194,28 @@ watch([dataRevision, workoutId], () => void loadDetail());
 .type-correct-menu { min-width: 180px; }
 .hero-signal { position: absolute; z-index: 0; top: -8px; right: 3%; opacity: .13; filter: saturate(1.4); transform: rotate(5deg); }
 .metric-list { position: relative; z-index: 1; display: grid; grid-template-columns: repeat(7, minmax(112px, 1fr)); gap: 9px; }
-.metric-tile { display: flex; align-items: center; gap: 8px; min-width: 0; min-height: 78px; padding: 10px; border: 1px solid rgba(226,234,242,.08); border-radius: 15px; background: rgba(11,14,17,.42); }
+.metric-tile { display: flex; align-items: center; gap: 8px; min-width: 0; min-height: 78px; padding: 10px; border: 1px solid rgba(226,234,242,.08); border-radius: 15px; background: rgba(8,10,13,.42); }
 .metric-tile > .design-icon { flex: 0 0 auto; }
-.metric-tile.tone-heart { background: linear-gradient(135deg, rgba(240,97,106,.12), rgba(11,14,17,.45)); } .metric-tile.tone-pace { background: linear-gradient(135deg, rgba(74,168,232,.12), rgba(11,14,17,.45)); } .metric-tile.tone-altitude { background: linear-gradient(135deg, rgba(245,195,59,.11), rgba(11,14,17,.45)); } .metric-tile.tone-training { background: linear-gradient(135deg, rgba(125,163,62,.12), rgba(11,14,17,.45)); } .metric-tile.tone-distance { background: linear-gradient(135deg, rgba(47,169,107,.13), rgba(11,14,17,.45)); } .metric-tile.tone-vo2 { background: linear-gradient(135deg, rgba(139,92,246,.12), rgba(11,14,17,.45)); }
-.metric-label { margin: 0; color: var(--muted); font-size: 12px; }
+.metric-tile.tone-heart { background: linear-gradient(135deg, rgba(240,97,106,.12), rgba(8,10,13,.45)); } .metric-tile.tone-pace { background: linear-gradient(135deg, rgba(74,168,232,.12), rgba(8,10,13,.45)); } .metric-tile.tone-altitude { background: linear-gradient(135deg, rgba(245,195,59,.11), rgba(8,10,13,.45)); } .metric-tile.tone-training { background: linear-gradient(135deg, rgba(125,163,62,.12), rgba(8,10,13,.45)); } .metric-tile.tone-distance { background: linear-gradient(135deg, rgba(47,169,107,.13), rgba(8,10,13,.45)); } .metric-tile.tone-vo2 { background: linear-gradient(135deg, rgba(139,92,246,.12), rgba(8,10,13,.45)); }
+.metric-label { margin: 0; color: var(--muted); font-size: var(--fs-sm); }
 .metric-value { display: flex; align-items: baseline; gap: 5px; margin: 3px 0 0; flex-wrap: wrap; }
-.metric-value strong { color: var(--ink); font-family: var(--font-mono); font-size: 15px; font-variant-numeric: tabular-nums; font-weight: 700; letter-spacing: -.02em; }
-.metric-value span { color: var(--muted); font-size: 11px; }
+.metric-value strong { color: var(--ink); font-family: var(--font-mono); font-size: var(--fs-xl); font-variant-numeric: tabular-nums; font-weight: 700; letter-spacing: -.02em; }
+.metric-value span { color: var(--muted); font-size: var(--fs-xs); }
 .lower { display: grid; grid-template-columns: minmax(0, 1.4fr) minmax(310px, .72fr); align-items: start; gap: 16px; }
 .main-col, .side-col { display: grid; gap: 16px; min-width: 0; }
 .surface-card { min-width: 0; }
-.card-title { margin: 0; color: var(--ink); font-size: 14px; font-weight: 700; }
-.card-title em { color: var(--subtle); font-size: 12px; font-style: normal; font-weight: 400; }
-.card-sub { margin: 0 0 12px; color: var(--muted); font-size: 12px; }
+.card-title { margin: 0; color: var(--ink); font-size: var(--fs-lg); font-weight: 700; }
+.card-title em { color: var(--subtle); font-size: var(--fs-sm); font-style: normal; font-weight: 400; }
+.card-sub { margin: 0 0 12px; color: var(--muted); font-size: var(--fs-sm); }
 .series-card, .side-card { padding: 16px 18px 18px; border-radius: 19px; }
 .section-head { display: flex; align-items: center; gap: 10px; margin-bottom: 13px; }
-.section-head h2 { margin: 1px 0 0; font-size: 16px; letter-spacing: -.02em; }
+.section-head h2 { margin: 1px 0 0; font-size: var(--fs-2xl); letter-spacing: -.02em; }
 .section-head.compact { margin-bottom: 14px; }
 .section-icon { display: grid; place-items: center; width: 44px; height: 44px; border-radius: 13px; background: rgba(47,169,107,.11); }
 .section-icon.data-tone { background: rgba(74,168,232,.12); } .section-icon.export-tone { background: rgba(139,92,246,.12); } .section-icon.source-tone { background: rgba(245,195,59,.1); }
 .chart-head { display: flex; align-items: flex-start; gap: 8px; min-width: 0; }
 .chart-head .card-title { flex: 1 1 auto; min-width: 72px; }
-.route-note { color: var(--subtle); font-size: 11px; }
+.route-note { color: var(--subtle); font-size: var(--fs-xs); }
 .section-head .route-note { margin-left: auto; }
 .route-wrap { position: relative; overflow: hidden; min-height: 320px; border: 1px solid var(--line); border-radius: var(--radius-sm); background: #171a14; }
 .route-canvas-texture { position: absolute; inset: 0; pointer-events: none; background:
@@ -1230,21 +1230,21 @@ watch([dataRevision, workoutId], () => void loadDetail());
 .route-end-mark { fill: none; stroke: #12150f; stroke-width: 1.6; stroke-linecap: round; }
 .pause-mark circle { fill: rgba(17,21,24,.88); stroke: var(--route-amber); stroke-width: 1.2; }
 .pause-mark path { fill: none; stroke: var(--route-amber); stroke-width: 1.4; stroke-linecap: round; }
-.route-legend { position: absolute; right: 10px; bottom: 10px; left: 10px; display: flex; align-items: center; gap: 10px; flex-wrap: wrap; padding: 5px 8px; border: 1px solid var(--line); border-radius: 8px; background: rgba(14,17,19,.88); color: var(--muted); font-size: 10px; }
+.route-legend { position: absolute; right: 10px; bottom: 10px; left: 10px; display: flex; align-items: center; gap: 10px; flex-wrap: wrap; padding: 5px 8px; border: 1px solid var(--line); border-radius: 8px; background: rgba(14,17,19,.88); color: var(--muted); font-size: var(--fs-2xs); }
 .route-legend span { display: inline-flex; align-items: center; gap: 4px; }
 .route-legend i { width: 9px; height: 4px; border-radius: 999px; background: var(--route-neutral); }
 .route-legend .fast-dot { background: var(--route-mint); }
 .route-legend .steady-dot { background: var(--route-cyan); }
 .route-legend .warm-dot { background: var(--route-amber); }
 .route-legend .slow-dot { background: var(--route-coral); }
-.route-empty { display: grid; justify-items: center; gap: 6px; padding: 46px 16px; border: 1px dashed var(--line-strong); border-radius: var(--radius-sm); color: var(--subtle); font-size: 12px; text-align: center; background: radial-gradient(circle at 50% 50%, rgba(47,169,107,.07), transparent 45%); }
+.route-empty { display: grid; justify-items: center; gap: 6px; padding: 46px 16px; border: 1px dashed var(--line-strong); border-radius: var(--radius-sm); color: var(--subtle); font-size: var(--fs-sm); text-align: center; background: radial-gradient(circle at 50% 50%, rgba(47,169,107,.07), transparent 45%); }
 .route-empty strong { color: var(--muted); }
 .route-empty p { margin: 0; }
 .section-icon.heart-tone { background: rgba(240,97,106,.12); }
 .hr-zone-bar { display: flex; overflow: hidden; height: 15px; border: 1px solid var(--line); border-radius: 999px; background: rgba(11,14,17,.45); }
 .hr-zone-fill { min-width: 0; }
 .hr-zone-list { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 5px 20px; margin: 13px 0 0; padding: 0; list-style: none; font-variant-numeric: tabular-nums; }
-.hr-zone-list li { display: flex; align-items: center; gap: 8px; font-size: 12px; }
+.hr-zone-list li { display: flex; align-items: center; gap: 8px; font-size: var(--fs-sm); }
 .hr-zone-list .hr-zone-range { flex: 1 1 auto; color: var(--muted); }
 .hr-zone-list strong { color: var(--ink); font-weight: 600; }
 .hr-zone-list em { min-width: 46px; color: var(--subtle); font-style: normal; text-align: right; }
@@ -1259,31 +1259,31 @@ watch([dataRevision, workoutId], () => void loadDetail());
 .chart-icon { display: grid; place-items: center; width: 38px; height: 38px; border-radius: 11px; background: rgba(255,255,255,.025); }
 .chart-stats { display: grid; grid-template-columns: repeat(3, max-content); justify-content: end; gap: 8px 16px; margin: 1px 0 0 auto; min-width: 0; padding: 0; list-style: none; color: var(--subtle); font-variant-numeric: tabular-nums; }
 .chart-stats li { display: grid; gap: 1px; min-width: 0; }
-.chart-stats em { color: #7E856D; font-size: 10px; font-style: normal; line-height: 1.2; }
-.chart-stats strong { color: #E8EBD8; font-size: 13px; font-weight: 600; line-height: 1.2; white-space: nowrap; }
+.chart-stats em { color: var(--subtle); font-size: var(--fs-2xs); font-style: normal; line-height: 1.2; }
+.chart-stats strong { color: #E8EBD8; font-size: var(--fs-md); font-weight: 600; line-height: 1.2; white-space: nowrap; }
 .series-chart { width: 100%; height: 170px; }
-.chart-empty { display: flex; align-items: center; gap: 12px; padding: 20px; color: var(--muted); font-size: 12px; }
+.chart-empty { display: flex; align-items: center; gap: 12px; padding: 20px; color: var(--muted); font-size: var(--fs-sm); }
 .chart-empty strong { color: var(--ink); }
 .chart-empty p { margin: 2px 0 0; }
 .decoded-list { display: grid; gap: 4px; }
 .decoded-list > div { display: grid; grid-template-columns: 34px minmax(0,1fr) auto; align-items: center; gap: 7px; min-height: 43px; padding: 4px 3px; border-bottom: 1px solid var(--line); }
 .decoded-list > div:last-child { border-bottom: 0; }
-.decoded-list span { color: var(--muted); font-size: 11px; }
-.decoded-list strong { color: var(--ink); font-family: var(--font-mono); font-size: 11px; font-variant-numeric: tabular-nums; }
-.mapping-note { display: flex; align-items: flex-start; gap: 7px; margin: 12px 0 0; padding: 9px; border-radius: 10px; background: rgba(125,163,62,.08); color: #aeb99b; font-size: 10px; }
+.decoded-list span { color: var(--muted); font-size: var(--fs-xs); }
+.decoded-list strong { color: var(--ink); font-family: var(--font-mono); font-size: var(--fs-xs); font-variant-numeric: tabular-nums; }
+.mapping-note { display: flex; align-items: flex-start; gap: 7px; margin: 12px 0 0; padding: 9px; border-radius: 10px; background: rgba(125,163,62,.08); color: #aeb99b; font-size: var(--fs-2xs); }
 .mapping-note .design-icon { flex: 0 0 auto; }
 .format-row { display: flex; gap: 8px; flex-wrap: wrap; }
-.format-pill { flex: 1; min-width: 58px; padding: 7px 10px; border: 1px solid var(--line); border-radius: 9px; background: var(--surface-raised); color: var(--muted); font-size: 11px; cursor: pointer; }
+.format-pill { flex: 1; min-width: 58px; padding: 7px 10px; border: 1px solid var(--line-control); border-radius: 9px; background: var(--surface-raised); color: var(--muted); font-size: var(--fs-xs); cursor: pointer; }
 .format-pill.is-on { border-color: var(--accent); background: var(--accent-soft); color: var(--accent); }
 .export-go { display: flex; align-items: center; justify-content: center; gap: 8px; width: 100%; min-height: 43px; margin-top: 10px; border: 1px solid rgba(125,163,62,.36); border-radius: 11px; background: var(--action-green); color: #f2f4ee; font-weight: 700; cursor: pointer; }
 .export-go:hover { background: var(--action-green-hover); }
-.action-note { display: inline-flex; align-items: center; gap: 6px; margin: 10px 0 0; font-size: 12px; }
+.action-note { display: inline-flex; align-items: center; gap: 6px; margin: 10px 0 0; font-size: var(--fs-sm); }
 .action-note.ok { color: var(--readiness); } .action-note.bad { color: var(--danger); }
 .meta-card dl { display: grid; gap: 8px; margin: 0; }
 .meta-card dl > div { display: flex; align-items: baseline; justify-content: space-between; gap: 10px; min-width: 0; }
-.meta-card dt { color: var(--muted); font-size: 12px; } .meta-card dd { margin: 0; color: var(--ink); font-size: 12px; overflow-wrap: anywhere; text-align: right; }
-.page-foot { display: flex; align-items: center; justify-content: center; gap: 6px; margin: 2px 0 0; color: var(--subtle); font-size: 11px; }
+.meta-card dt { color: var(--muted); font-size: var(--fs-sm); } .meta-card dd { margin: 0; color: var(--ink); font-size: var(--fs-sm); overflow-wrap: anywhere; text-align: right; }
+.page-foot { display: flex; align-items: center; justify-content: center; gap: 6px; margin: 2px 0 0; color: var(--subtle); font-size: var(--fs-xs); }
 @media (max-width: 1320px) { .metric-list { grid-template-columns: repeat(4, minmax(130px, 1fr)); } }
 @media (max-width: 1180px) { .lower { grid-template-columns: minmax(0, 1fr); } .side-col { grid-template-columns: repeat(2, minmax(0,1fr)); } .decoded-card { grid-row: span 2; } }
-@media (max-width: 760px) { .page-toolbar { align-items: flex-start; } .ai-action span { display: none; } .workout-hero { padding: 16px; border-radius: 19px; } .hero-copy { align-items: flex-start; gap: 12px; } .hero-device :deep(.device-visual) { width: 78px; height: 78px; flex-basis: 78px; } .device-live { display: none; } .sport-line > .design-icon { width: 45px !important; height: 45px !important; } .sport-line h1 { font-size: 24px; } .source-chip { font-size: 10px; } .metric-list { grid-template-columns: repeat(2, minmax(0, 1fr)); } .metric-tile { min-height: 70px; } .chart-grid, .side-col { grid-template-columns: minmax(0, 1fr); } .decoded-card { grid-row: auto; } .route-wrap { min-height: 240px; } .route-note { display: none; } .chart-head { flex-wrap: wrap; } .chart-stats { width: 100%; justify-content: flex-start; } }
+@media (max-width: 760px) { .page-toolbar { align-items: flex-start; } .ai-action span { display: none; } .workout-hero { padding: 16px; border-radius: 19px; } .hero-copy { align-items: flex-start; gap: 12px; } .hero-device :deep(.device-visual) { width: 78px; height: 78px; flex-basis: 78px; } .device-live { display: none; } .sport-line > .design-icon { width: 45px !important; height: 45px !important; } .sport-line h1 { font-size: 24px; } .source-chip { font-size: var(--fs-2xs); } .metric-list { grid-template-columns: repeat(2, minmax(0, 1fr)); } .metric-tile { min-height: 70px; } .chart-grid, .side-col { grid-template-columns: minmax(0, 1fr); } .decoded-card { grid-row: auto; } .route-wrap { min-height: 240px; } .route-note { display: none; } .chart-head { flex-wrap: wrap; } .chart-stats { width: 100%; justify-content: flex-start; } }
 </style>

--- a/src/views/WorkoutList.vue
+++ b/src/views/WorkoutList.vue
@@ -191,7 +191,7 @@ watch(dataRevision, () => void loadList());
   gap: 6px;
   margin-bottom: 8px;
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   text-decoration: none;
 }
 .back-link:hover { color: var(--accent); }
@@ -199,6 +199,6 @@ watch(dataRevision, () => void loadList());
 .footnote {
   margin: 12px 0 0;
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--fs-sm);
 }
 </style>


### PR DESCRIPTION
## Summary

Fixes #60.

- Increase the shared type scale and chart labels/tooltips while keeping the default interface geometry at 100%, avoiding CSS zoom as the readability mechanism.
- Raise secondary text contrast, darken the neutral surface palette, and give interactive control boundaries and deep-sleep graphics at least 3:1 contrast.
- Add symbols or patterns to good/bad/flat states so colour is not the only cue.
- Widen the sidebar and weekly report layout for the larger text, and stop the training threshold chart clipping its bpm labels.
- Update the bilingual changelog and UI design guidance to match the final tokens.

## Accessibility details

- Body text: 13px to 16.5px.
- Small text: former 8–11px roles now use 11–14.5px.
- The previous faint grey tier, measured at about 2.0:1, now aliases the passing subtle tier.
- Interactive boundaries use a separate high-contrast token instead of making every decorative divider prominent.
- Deep-sleep blue was raised from 2.59:1 to above 3:1 on its chart surfaces.
- Delta states use ✓, !, or =; negative bars also use a stripe pattern.

## Before
<img width="2560" height="1508" alt="image" src="https://github.com/user-attachments/assets/4c42fdf3-af2b-496d-8052-72b3b2a76617" />

## After
<img width="2560" height="1508" alt="image" src="https://github.com/user-attachments/assets/5ae921c7-9c9f-4e0c-a007-37c1746873ec" />