### PR TITLE
fix(desktop): restore unreachable windows and avoid Windows recovery deadlocks

### DIFF
--- a/src-tauri/src/diagnostics.rs
+++ b/src-tauri/src/diagnostics.rs
@@ -36,6 +36,16 @@ static BANNER_WRITTEN: AtomicBool = AtomicBool::new(false);
 /// `storage::write_lock`，日志不需要那么强。
 static WRITE_LOCK: Mutex<()> = Mutex::new(());
 
+/// Tauri can panic while creating configured windows, before application setup.
+/// Release builds on Windows have no stderr, so retain the panic in our log.
+pub fn install_panic_hook() {
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        log(&format!("Application panic: {info}"));
+        previous(info);
+    }));
+}
+
 /// 日志目录：数据目录旁边的 `logs/`。
 pub fn log_dir(data_dir: &Path) -> PathBuf {
     data_dir.join("logs")

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod diagnostics;
 mod ipc_error;
 mod ipc_types;
 mod local_api;
+mod main_window;
 mod updates;
 
 // The desktop shell is an adapter over the shared core: models, storage,
@@ -41,39 +42,6 @@ use tauri::tray::TrayIconBuilder;
 use tauri::{AppHandle, Emitter, Manager};
 use zeppbridge_core::models::RawPayloadCompaction;
 
-fn show_main_window(app: &AppHandle) {
-    let window = match app.get_webview_window("main") {
-        Some(window) => window,
-        // 主窗口不在了。这不是假设出来的状态：WebView2 崩溃、用户的
-        // 显卡驱动重启、或者窗口被系统销毁之后，进程还活着、托盘图标也还
-        // 在，但这里以前是一个 `if let Some(...)`——拿不到就静静 return，
-        // 于是「点 Open ZeppBridge 没任何反应」成了一个没有出口的死局。
-        // 重建一个；建不起来至少还会落一条日志。
-        None => {
-            diagnostics::log("主窗口不在了，正在重建");
-            match tauri::WebviewWindowBuilder::from_config(
-                app,
-                &app.config().app.windows[0].clone(),
-            )
-            .and_then(|builder| builder.build())
-            {
-                Ok(window) => window,
-                Err(error) => {
-                    diagnostics::log(&format!("主窗口重建失败: {error}"));
-                    return;
-                }
-            }
-        }
-    };
-    let _ = window.unminimize();
-    let _ = window.show();
-    // A second launch is the foreground process on Windows; briefly raise
-    // z-order so the existing hidden-to-tray window can steal focus.
-    let _ = window.set_always_on_top(true);
-    let _ = window.set_focus();
-    let _ = window.set_always_on_top(false);
-}
-
 /// `tauri.conf.json` 里 `minWidth` / `minHeight` 的那两个数。
 ///
 /// 算出来的初始尺寸不能低于它们：低于了窗口会小到点不着，而 Tauri 只在用户
@@ -90,12 +58,8 @@ const MIN_WINDOW_HEIGHT: f64 = 560.0;
 /// let width  = (work_w * 0.88).max(1280.0_f64.min(work_w));
 /// ```
 ///
-/// `current_monitor()` 返回 `0x0` 的工作区不是假想的状态——远程桌面会话、
-/// 显示器热插拔、以及窗口比显示器先就绪的那一瞬都会给出它。那时
-/// `work_w = -24.0`，宽度算成 `-21.1`，`set_size` 收到一个负数。用户看到的
-/// 正是「托盘图标活着、进程活着、点 Open ZeppBridge 一点反应都没有」——
-/// 窗口在，只是没有可见像素，而重装当然也修不好。
-/// 见 2026-09-04 Reddit u/poseidon1111。
+/// 零工作区会使旧算法算出负数，因此保留输入检查。但用户提供的日志没有
+/// 记录到这一分支，不能把它当作该用户打不开窗口的已确认原因。
 ///
 /// 返回 `None` 表示这台显示器的信息不可信，那就一个字都别改，让
 /// `tauri.conf.json` 里的 1280x800 原样生效。
@@ -275,11 +239,14 @@ pub fn run() {
             }
         }
     }
-    tauri::Builder::default()
+    diagnostics::install_panic_hook();
+    diagnostics::log("Startup: building Tauri runtime");
+    let app = tauri::Builder::default()
+        .manage(main_window::MainWindowState::default())
         // Single-instance must be registered first so a second launch never
         // reaches tray setup and creates a duplicate icon.
         .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
-            show_main_window(app);
+            main_window::request_show(app, "second-instance");
         }))
         // Main-window AI handoff links call the opener API explicitly.  Do
         // not inject its `_blank` click interceptor into the Zepp login
@@ -292,7 +259,15 @@ pub fn run() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
+        .on_window_event(main_window::on_window_event)
+        .on_page_load(|webview, payload| {
+            if webview.label() == "main" {
+                // Do not log URLs: the login webview can contain OAuth credentials.
+                diagnostics::log(&format!("Main webview page load: {:?}", payload.event()));
+            }
+        })
         .setup(|app| {
+            diagnostics::log("Startup: entered application setup");
             // 这三步以前都是光秃的 `?`。任一步失败，`setup` 返回 Err，
             // 进程就没了——而 Windows 上既没有终端也没有日志，用户只能看到
             // 通知区里一个点不动的死图标。现在每一条都会写日志、弹对话框，
@@ -355,6 +330,7 @@ pub fn run() {
             }
             app.manage(local_api::LocalApi(local_api.clone()));
             app.manage(state);
+            diagnostics::log("Startup: database and application state ready");
 
             // 解析器修订号变化后，后台一次性重放本地原始报文以纠正派生数据
             // （运动类型、睡眠阶段等）。独立连接 + 后台线程，不阻塞窗口创建。
@@ -434,44 +410,7 @@ pub fn run() {
                 }
             });
 
-            // 托盘到底建起来没有。窗口的关闭行为要看它，所以先声明后赋值。
-            let tray_present = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
-
-            if let Some(window) = app.get_webview_window("main") {
-                if let Ok(Some(monitor)) = window.current_monitor() {
-                    let work = monitor.work_area();
-                    let scale = monitor.scale_factor();
-                    match main_window_size(work.size.width, work.size.height, scale) {
-                        Some((width, height)) => {
-                            diagnostics::log(&format!(
-                                "窗口尺寸：工作区 {}x{} @{scale} → {width:.0}x{height:.0}",
-                                work.size.width, work.size.height
-                            ));
-                            let _ = window.set_size(tauri::LogicalSize::new(width, height));
-                        }
-                        // 下一个报「打不开」的人，日志里会有这一行。
-                        None => diagnostics::log(&format!(
-                            "工作区信息不可用（{}x{} @{scale}），沿用配置里的默认尺寸",
-                            work.size.width, work.size.height
-                        )),
-                    }
-                }
-                let hidden = window.clone();
-                let tray_alive = tray_present.clone();
-                window.on_window_event(move |event| {
-                    if let tauri::WindowEvent::CloseRequested { api, .. } = event {
-                        // 没有托盘就不能藏到托盘里：那样窗口关掉之后再也没有
-                        // 入口把它叫回来，进程还活着，看起来就是「点了关闭，
-                        // 应用没了但也没退出」。托盘建不起来时按正常关闭走。
-                        if !tray_alive.load(std::sync::atomic::Ordering::Relaxed) {
-                            return;
-                        }
-                        api.prevent_close();
-                        let _ = hidden.hide();
-                        let _ = hidden.app_handle().emit("app://hidden-to-tray", ());
-                    }
-                });
-            }
+            main_window::initialize(app.handle());
 
             // 托盘菜单是原生的，界面那套 i18n 到不了这里，而它又是英文用户
             // 一定会右键点开的东西。托盘在前端加载之前就要建起来，所以先按
@@ -490,7 +429,7 @@ pub fn run() {
                 .menu(&menu)
                 .tooltip("ZeppBridge")
                 .on_menu_event(|app, event| match event.id.as_ref() {
-                    "show" => show_main_window(app),
+                    "show" => main_window::request_show(app, "tray-menu"),
                     "sync" => {
                         let _ = app.emit("tray://sync", ());
                     }
@@ -504,7 +443,7 @@ pub fn run() {
                         ..
                     } = event
                     {
-                        show_main_window(tray.app_handle());
+                        main_window::request_show(tray.app_handle(), "tray-click");
                     }
                 });
             if let Some(icon) = app.default_window_icon() {
@@ -522,7 +461,9 @@ pub fn run() {
             let built = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| tray.build(app)));
             match built {
                 Ok(Ok(_)) => {
-                    tray_present.store(true, std::sync::atomic::Ordering::Relaxed);
+                    app.state::<main_window::MainWindowState>()
+                        .set_tray_present();
+                    diagnostics::log("Startup: tray ready");
                 }
                 Ok(Err(error)) => {
                     diagnostics::log(&format!(
@@ -539,6 +480,8 @@ pub fn run() {
                     );
                 }
             }
+            app.state::<main_window::MainWindowState>().set_ready();
+            diagnostics::log("Startup: application setup complete");
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -623,10 +566,20 @@ pub fn run() {
             local_api::reveal_local_api_token,
             local_api::rotate_local_api_token,
         ])
-        .run(tauri::generate_context!())
-        .unwrap_or_else(|error| {
-            diagnostics::log(&format!("Tauri application exited with an error: {error}"));
-        });
+        .build(tauri::generate_context!());
+    match app {
+        Ok(app) => app.run(|app, event| {
+            if let tauri::RunEvent::Ready = event {
+                diagnostics::log("Startup: event loop ready");
+                main_window::request_show(app, "startup");
+            }
+        }),
+        Err(error) => {
+            // Builder/plugin failures otherwise disappear in Windows releases.
+            // Configured-window failures inside run() are logged by the panic hook.
+            let _ = diagnostics::fatal_startup("Tauri initialization failed", error);
+        }
+    }
 }
 
 #[cfg(all(test, windows))]

--- a/src-tauri/src/main_window.rs
+++ b/src-tauri/src/main_window.rs
@@ -1,0 +1,295 @@
+//! Main-window restoration must not build a WebView inside a native event callback.
+//! Tauri documents a Windows deadlock for that path. Keep callbacks short and
+//! serialize recovery on a worker, including requests from a second process.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use tauri::{AppHandle, Emitter, Manager, Monitor, WebviewWindow, Window, WindowEvent};
+
+use crate::{diagnostics, main_window_size};
+
+#[path = "window_geometry.rs"]
+mod geometry;
+use geometry::Rect;
+
+#[derive(Default)]
+pub(crate) struct MainWindowState {
+    ready: AtomicBool,
+    tray_present: AtomicBool,
+    opening: Arc<AtomicBool>,
+}
+
+impl MainWindowState {
+    pub(crate) fn set_ready(&self) {
+        self.ready.store(true, Ordering::Release);
+    }
+
+    pub(crate) fn set_tray_present(&self) {
+        self.tray_present.store(true, Ordering::Release);
+    }
+}
+
+struct OpenGuard(Arc<AtomicBool>);
+
+impl OpenGuard {
+    fn acquire(opening: &Arc<AtomicBool>) -> Option<Self> {
+        opening
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .ok()
+            .map(|_| Self(opening.clone()))
+    }
+}
+
+impl Drop for OpenGuard {
+    fn drop(&mut self) {
+        self.0.store(false, Ordering::Release);
+    }
+}
+
+fn checked<T>(operation: &str, result: tauri::Result<T>) -> Option<T> {
+    match result {
+        Ok(value) => Some(value),
+        Err(error) => {
+            diagnostics::log(&format!("Main window {operation} failed: {error}"));
+            None
+        }
+    }
+}
+
+pub(crate) fn request_show(app: &AppHandle, source: &'static str) {
+    diagnostics::log(&format!("Main window open requested: {source}"));
+    let state = app.state::<MainWindowState>();
+    // A second launch can arrive while the configured window is still being
+    // constructed. Ready will show it; do not create another window meanwhile.
+    if !state.ready.load(Ordering::Acquire) {
+        diagnostics::log("Main window open deferred until startup is ready");
+        return;
+    }
+    let Some(guard) = OpenGuard::acquire(&state.opening) else {
+        diagnostics::log("Main window open already in progress");
+        return;
+    };
+    let app = app.clone();
+    // Do not use run_on_main_thread here: rebuilding there reintroduces the
+    // WebView2 deadlock. Dropping the closure on spawn failure releases the gate.
+    if let Err(error) = std::thread::Builder::new()
+        .name("main-window-recovery".into())
+        .spawn(move || {
+            let _guard = guard;
+            show(&app);
+        })
+    {
+        diagnostics::log(&format!("Main window recovery worker failed: {error}"));
+    }
+}
+
+pub(crate) fn initialize(app: &AppHandle) {
+    diagnostics::log("Startup: looking up main window");
+    match app.get_webview_window("main") {
+        Some(window) => {
+            diagnostics::log("Startup: main window found; querying monitor");
+            if let Some(monitor) = preferred_monitor(&window) {
+                fit_to_monitor(&window, &monitor);
+            }
+        }
+        None => diagnostics::log("Startup: main window missing; recovery will run when ready"),
+    }
+}
+
+fn usable_monitor(monitor: &Monitor) -> bool {
+    let work = monitor.work_area();
+    main_window_size(work.size.width, work.size.height, monitor.scale_factor()).is_some()
+}
+
+fn preferred_monitor(window: &WebviewWindow) -> Option<Monitor> {
+    if let Some(Some(monitor)) = checked("current_monitor", window.current_monitor()) {
+        if usable_monitor(&monitor) {
+            return Some(monitor);
+        }
+    }
+    diagnostics::log(
+        "Main window current monitor unavailable; checking primary/available monitors",
+    );
+    if let Some(Some(monitor)) = checked("primary_monitor", window.primary_monitor()) {
+        if usable_monitor(&monitor) {
+            return Some(monitor);
+        }
+    }
+    if let Some(monitors) = checked("available_monitors", window.available_monitors()) {
+        if let Some(monitor) = monitors.into_iter().find(usable_monitor) {
+            return Some(monitor);
+        }
+    }
+    diagnostics::log("Main window has no usable monitor; retaining configured geometry");
+    None
+}
+
+fn fit_to_monitor(window: &WebviewWindow, monitor: &Monitor) {
+    let work = monitor.work_area();
+    let scale = monitor.scale_factor();
+    let Some((width, height)) = main_window_size(work.size.width, work.size.height, scale) else {
+        return;
+    };
+    diagnostics::log(&format!(
+        "Main window fitting: work={}x{} at {},{} scale={scale}; logical={width:.0}x{height:.0}",
+        work.size.width, work.size.height, work.position.x, work.position.y
+    ));
+    if checked(
+        "set_size",
+        window.set_size(tauri::LogicalSize::new(width, height)),
+    )
+    .is_none()
+    {
+        return;
+    }
+    if let Some(size) = checked("outer_size", window.outer_size()) {
+        // Use the selected monitor's physical work area, including negative
+        // multi-monitor origins. center() can select the unavailable monitor.
+        let (x, y) = Rect::new(
+            work.position.x,
+            work.position.y,
+            work.size.width,
+            work.size.height,
+        )
+        .centered_origin(size.width, size.height);
+        let _ = checked(
+            "set_position",
+            window.set_position(tauri::PhysicalPosition::new(x, y)),
+        );
+    }
+}
+
+fn recover_geometry(window: &WebviewWindow) {
+    let Some(monitors) = checked("available_monitors", window.available_monitors()) else {
+        return;
+    };
+    let monitors: Vec<_> = monitors.into_iter().filter(usable_monitor).collect();
+    if monitors.is_empty() {
+        diagnostics::log("Main window geometry recovery skipped: no usable monitors");
+        return;
+    }
+    let position = checked("outer_position", window.outer_position());
+    let size = checked("outer_size", window.outer_size());
+    if let (Some(position), Some(size)) = (position, size) {
+        let window_rect = Rect::new(position.x, position.y, size.width, size.height);
+        if monitors.iter().any(|monitor| {
+            let work = monitor.work_area();
+            window_rect.has_reachable_titlebar(Rect::new(
+                work.position.x,
+                work.position.y,
+                work.size.width,
+                work.size.height,
+            ))
+        }) {
+            return;
+        }
+    }
+    diagnostics::log("Main window geometry is unreachable; restoring onto a usable monitor");
+    // Unmaximize only for recovery; retain maximized/normal geometry otherwise.
+    let _ = checked("unmaximize", window.unmaximize());
+    if let Some(monitor) = preferred_monitor(window) {
+        fit_to_monitor(window, &monitor);
+    }
+}
+
+fn show(app: &AppHandle) {
+    let window = match app.get_webview_window("main") {
+        Some(window) => window,
+        None => {
+            diagnostics::log("Main window missing; rebuilding on recovery worker");
+            let Some(config) = app
+                .config()
+                .app
+                .windows
+                .iter()
+                .find(|config| config.label == "main")
+            else {
+                diagnostics::log("Main window rebuild failed: configuration for main is missing");
+                return;
+            };
+            let result = tauri::WebviewWindowBuilder::from_config(app, config)
+                .and_then(|builder| builder.build());
+            let Some(window) = checked("rebuild", result) else {
+                return;
+            };
+            diagnostics::log("Main window rebuilt");
+            window
+        }
+    };
+    let _ = checked("unminimize", window.unminimize());
+    recover_geometry(&window);
+    let _ = checked("show", window.show());
+    // Preserve an existing always-on-top preference when temporarily raising it.
+    let was_on_top = checked("is_always_on_top", window.is_always_on_top());
+    if was_on_top == Some(false) {
+        let _ = checked("raise", window.set_always_on_top(true));
+    }
+    let _ = checked("set_focus", window.set_focus());
+    if was_on_top == Some(false) {
+        let _ = checked("restore z-order", window.set_always_on_top(false));
+    }
+    diagnostics::log(&format!(
+        "Main window open completed: visible={:?}, minimized={:?}, position={:?}, size={:?}",
+        window.is_visible(),
+        window.is_minimized(),
+        window.outer_position(),
+        window.outer_size()
+    ));
+}
+
+// A global handler also applies to reconstructed windows. A per-window handler
+// installed only in setup leaves reconstructed windows without close-to-tray.
+pub(crate) fn on_window_event(window: &Window, event: &WindowEvent) {
+    if window.label() != "main" {
+        return;
+    }
+    match event {
+        WindowEvent::CloseRequested { api, .. } => {
+            if window
+                .app_handle()
+                .state::<MainWindowState>()
+                .tray_present
+                .load(Ordering::Acquire)
+            {
+                api.prevent_close();
+                if checked("hide", window.hide()).is_some() {
+                    diagnostics::log("Main window hidden to tray");
+                    let _ = window.emit("app://hidden-to-tray", ());
+                }
+            }
+        }
+        WindowEvent::Destroyed => diagnostics::log("Main window destroyed"),
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn concurrent_open_requests_are_coalesced_and_retries_are_allowed() {
+        let opening = Arc::new(AtomicBool::new(false));
+        let first = OpenGuard::acquire(&opening).unwrap();
+        let another_thread = opening.clone();
+        assert!(
+            std::thread::spawn(move || OpenGuard::acquire(&another_thread).is_none())
+                .join()
+                .unwrap()
+        );
+        drop(first);
+        assert!(OpenGuard::acquire(&opening).is_some());
+    }
+
+    #[test]
+    fn failed_recovery_releases_the_gate() {
+        let opening = Arc::new(AtomicBool::new(false));
+        let shared = opening.clone();
+        let result = std::panic::catch_unwind(move || {
+            let _guard = OpenGuard::acquire(&shared).unwrap();
+            panic!("simulated recovery failure");
+        });
+        assert!(result.is_err());
+        assert!(OpenGuard::acquire(&opening).is_some());
+    }
+}

--- a/src-tauri/src/main_window.rs
+++ b/src-tauri/src/main_window.rs
@@ -160,6 +160,11 @@ fn fit_to_monitor(window: &WebviewWindow, monitor: &Monitor) {
 }
 
 fn recover_geometry(window: &WebviewWindow) {
+    // Fullscreen windows intentionally have no reachable titlebar and can
+    // cover the menu/taskbar area. Let the window manager position those.
+    if checked("is_fullscreen", window.is_fullscreen()) == Some(true) {
+        return;
+    }
     let Some(monitors) = checked("available_monitors", window.available_monitors()) else {
         return;
     };

--- a/src-tauri/src/window_geometry.rs
+++ b/src-tauri/src/window_geometry.rs
@@ -1,0 +1,99 @@
+//! Physical-pixel geometry for restoring windows after display changes.
+
+#[derive(Clone, Copy)]
+pub(super) struct Rect {
+    x: i64,
+    y: i64,
+    width: i64,
+    height: i64,
+}
+
+impl Rect {
+    pub(super) fn new(x: i32, y: i32, width: u32, height: u32) -> Self {
+        Self {
+            x: i64::from(x),
+            y: i64::from(y),
+            width: i64::from(width),
+            height: i64::from(height),
+        }
+    }
+
+    pub(super) fn has_reachable_titlebar(self, work: Self) -> bool {
+        if self.width < 64 || self.height < 48 || work.width == 0 || work.height == 0 {
+            return false;
+        }
+        // Requiring some titlebar, rather than any body pixel, lets the user
+        // drag the window back. Maximized frames can extend above the work area.
+        let overlap_width = (self.x + self.width).min(work.x + work.width) - self.x.max(work.x);
+        let overlap_height = (self.y + 32).min(work.y + work.height) - self.y.max(work.y);
+        overlap_width >= 64 && overlap_height >= 16
+    }
+
+    pub(super) fn centered_origin(self, width: u32, height: u32) -> (i32, i32) {
+        // Oversized windows start at the work-area origin to keep the titlebar
+        // reachable even when minimum logical size exceeds a high-DPI screen.
+        let x = self.x + (self.width - i64::from(width)).max(0) / 2;
+        let y = self.y + (self.height - i64::from(height)).max(0) / 2;
+        (
+            x.clamp(i64::from(i32::MIN), i64::from(i32::MAX)) as i32,
+            y.clamp(i64::from(i32::MIN), i64::from(i32::MAX)) as i32,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Rect;
+
+    const PRIMARY: Rect = Rect {
+        x: 0,
+        y: 0,
+        width: 1920,
+        height: 1040,
+    };
+
+    #[test]
+    fn disconnected_monitor_position_requires_recovery() {
+        assert!(!Rect::new(2400, 100, 1280, 800).has_reachable_titlebar(PRIMARY));
+    }
+
+    #[test]
+    fn negative_monitor_origins_are_valid() {
+        let left = Rect::new(-1920, -200, 1920, 1040);
+        assert!(Rect::new(-1800, -100, 1280, 800).has_reachable_titlebar(left));
+        assert_eq!(left.centered_origin(1280, 800), (-1600, -80));
+    }
+
+    #[test]
+    fn visible_body_with_inaccessible_titlebar_requires_recovery() {
+        assert!(!Rect::new(100, -200, 1280, 800).has_reachable_titlebar(PRIMARY));
+        assert!(!Rect::new(1900, 100, 1280, 800).has_reachable_titlebar(PRIMARY));
+    }
+
+    #[test]
+    fn normal_and_maximized_windows_keep_their_geometry() {
+        assert!(Rect::new(100, 100, 1280, 800).has_reachable_titlebar(PRIMARY));
+        assert!(Rect::new(-8, -8, 1936, 1056).has_reachable_titlebar(PRIMARY));
+    }
+
+    #[test]
+    fn empty_and_tiny_windows_require_recovery() {
+        assert!(!Rect::new(100, 100, 0, 800).has_reachable_titlebar(PRIMARY));
+        assert!(!Rect::new(100, 100, 1280, 0).has_reachable_titlebar(PRIMARY));
+        assert!(!Rect::new(100, 100, 10, 10).has_reachable_titlebar(PRIMARY));
+    }
+
+    #[test]
+    fn oversized_window_keeps_titlebar_at_work_area_origin() {
+        let work = Rect::new(200, 40, 800, 600);
+        assert_eq!(work.centered_origin(1040, 1120), (200, 40));
+        assert_eq!(work.centered_origin(640, 480), (280, 100));
+    }
+
+    #[test]
+    fn extreme_coordinates_do_not_overflow() {
+        let far = Rect::new(i32::MAX, i32::MIN, u32::MAX, u32::MAX);
+        assert!(!far.has_reachable_titlebar(PRIMARY));
+        assert_eq!(far.centered_origin(1, 1), (i32::MAX, -1));
+    }
+}


### PR DESCRIPTION
## Why

A Windows user reports that ZeppBridge initially worked, but subsequent launches leave a tray icon and no accessible app window, including after reinstalling v2.1.2 and v2.2.0. The supplied log reaches background normalizer replay, which confirms database initialization succeeded on those launches. It contains no monitor-sizing, window-open, or fatal-startup diagnostics.

The existing code has a confirmed recovery defect: when `main` is absent, tray and single-instance callbacks build a WebView synchronously. Tauri explicitly documents a Windows deadlock for window creation in synchronous event handlers: https://docs.rs/tauri/2.11.5/tauri/webview/struct.WebviewWindowBuilder.html. Existing-window recovery also ignores window API failures and never repairs off-screen geometry. `current_monitor()` returning `None` or an error produces no log at all.

**The supplied log does not prove which path caused this user's original failure.** In particular, neither a zero-sized monitor nor a WebView crash is established. This PR fixes the concrete recovery defects and fills the diagnostic gaps needed to verify the affected machine. No private logs or account data are included.

## Changes

- Run tray, repeated-launch, and startup window restoration on a worker. Coalesce concurrent requests with a guard that releases on failure, and defer early second-instance requests until setup is ready.
- Find the main-window config by label when rebuilding. Apply the global close-to-tray handler to rebuilt windows too.
- Fall back from an unavailable current monitor to a usable primary/available monitor. Move inaccessible windows back into a physical work area, handling negative monitor origins and oversized high-DPI windows while preserving reachable geometry during normal reopening and leaving intentional fullscreen geometry to the window manager.
- Record startup stages, main-page load events, missing windows, monitor failures, open requests, and resulting visibility/geometry. Log native-operation errors and runtime panics instead of losing them in Windows release builds.
- Retain existing minimum-size checks and correct a nearby comment that presented an unverified cause as confirmed.

## Validation

- Passed locally: production frontend build (`npm run build`), workspace Rust formatting, `git diff --check`, and seven executable Rust geometry tests (disconnected displays, negative origins, inaccessible titlebars, normal/maximized windows, zero/tiny sizes, oversized windows, and overflow boundaries).
- Also passed locally: two concurrency/failure tests for the recovery guard. These nine tests were executed from the actual source in standalone Rust harnesses, without linking Tauri. The repository's Windows/Linux/macOS CI compiles and executes them again in the full application.
- CI on commit `5b22b3497e879acbab8ce6017df931394e2d64fe`: **Windows, macOS, and Linux all passed full-workspace Rust checking (`--all-targets`) and Clippy (`-D warnings`)**. Windows frontend/function tests also passed. Full Rust test jobs were still running at this update; see the live [CI run](https://github.com/lingcang728/ZeppBridge/actions/runs/34087161848) for the final outcome.
- Local full Tauri compilation was unavailable because this container cannot install the required GTK/WebKit system packages; the platform compile/lint results above come from CI.
- Still needs an affected-machine check: launch, close/reopen from tray, launch a second instance, and try a display disconnect/reconnect. If it still fails, the new log should identify the last completed stage. CI alone cannot establish that this user's desktop issue is resolved.

No version bump, release publication, authentication changes, or user-data deletion.