### PR TITLE
fix(headless): preserve local data in exports and sleep queries

### DIFF
--- a/src-tauri/crates/cli/src/main.rs
+++ b/src-tauri/crates/cli/src/main.rs
@@ -13,7 +13,7 @@
 //! * **写库一律走跨进程写锁**。桌面应用开着的时候跑 `sync`，这里会拿不到锁
 //!   并以 `EXIT_BUSY` 退出，而不是和 GUI 抢着写同一个库。
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 use std::process::ExitCode;
 use std::sync::atomic::AtomicBool;
@@ -30,7 +30,7 @@ use zeppbridge_core::models::error::HeadlessProblem;
 use zeppbridge_core::models::{error::ZeppBridgeError, ExportDetail, ExportScope, ExportSelection};
 use zeppbridge_core::paths;
 use zeppbridge_core::storage::write_lock::{self, WriteLockError, WritePurpose};
-use zeppbridge_core::storage::{Database, ReplayPlan, NORMALIZER_REVISION};
+use zeppbridge_core::storage::{Database, ReplayPlan, EXPORT_DATA_TYPES, NORMALIZER_REVISION};
 use zeppbridge_core::sync::{SyncManager, SyncReport};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -98,11 +98,15 @@ reprocess options:
 
 export options:
   --format <json|csv|gpx|fit>  Default: json; fit needs --out to point at a directory
-                               (fit always exports full detail: that is what a FIT file is)
+                               (csv, gpx and fit always export full detail)
   --from <YYYY-MM-DD>       Use together with --to
   --to <YYYY-MM-DD>
   --workout <id>            Export one workout; mutually exclusive with --from/--to
-  --types <a,b,c>           Default: workouts,daily,sleep
+  --types <a,b,c>           Default: workouts,daily_activity,sleep
+                            Allowed: heart_rate, hrv, hrv_rmssd, respiratory_rate,
+                            pai, lactate_threshold, daily_activity, sleep, workouts,
+                            recovery, steps, spo2, stress, training_load, vo2max,
+                            weight, food
   --detail <summary|full>   Default: summary
   --out <path>              Default: write to stdout
 
@@ -994,79 +998,122 @@ fn cmd_sync(args: &[String]) -> u8 {
 
 /* ------------------------------ export ------------------------------ */
 
-fn cmd_export(args: &[String]) -> u8 {
-    let flags = match Flags::parse(args) {
-        Ok(flags) => flags,
-        Err(message) => return fail(false, EXIT_USAGE, "usage", &message),
-    };
-    if let Err(message) = flags.reject_unknown(&[
+#[derive(Debug)]
+struct ExportOptions {
+    format: String,
+    out: Option<String>,
+    selection: ExportSelection,
+}
+
+/// 参数必须先通过校验，才能打开数据库或生成输出。
+fn parse_export_args(args: &[String]) -> Result<ExportOptions, String> {
+    let flags = Flags::parse(args)?;
+    flags.reject_unknown(&[
         "json", "format", "from", "to", "workout", "types", "detail", "out",
-    ]) {
-        return fail(false, EXIT_USAGE, "usage", &message);
+    ])?;
+    let mut seen = BTreeSet::new();
+    for (name, value) in &flags.values {
+        if !seen.insert(name.as_str()) {
+            return Err(format!("--{name} must not be repeated"));
+        }
+        if name == "json" {
+            if value.is_some() {
+                return Err("--json does not take a value".into());
+            }
+        } else if value.as_deref().is_none_or(|value| value.trim().is_empty()) {
+            return Err(format!("--{name} needs a non-empty value"));
+        }
     }
-    let json_mode = flags.has("json");
+
     let format = flags.get("format").unwrap_or("json");
     if !matches!(format, "json" | "csv" | "gpx" | "fit") {
-        return fail(
-            json_mode,
-            EXIT_USAGE,
-            "usage",
-            "--format must be json, csv, gpx or fit",
+        return Err("--format must be json, csv, gpx or fit".into());
+    }
+    if format == "fit" && !flags.has("out") {
+        return Err(
+            "--format fit needs --out to point at a directory: FIT is binary and one file per workout, so it cannot go to stdout"
+                .into(),
         );
     }
 
     // 范围互斥：同时给日期和单条运动是矛盾请求，不定优先级，直接报错。
     let scope = match (flags.get("from"), flags.get("to"), flags.get("workout")) {
         (Some(_), _, Some(_)) | (_, Some(_), Some(_)) => {
-            return fail(
-                json_mode,
-                EXIT_USAGE,
-                "usage",
-                "--from/--to and --workout are mutually exclusive ranges; give only one",
+            return Err(
+                "--from/--to and --workout are mutually exclusive ranges; give only one".into(),
             )
         }
         (Some(from), Some(to), None) => ExportScope::date_range(from, to),
         (Some(_), None, None) | (None, Some(_), None) => {
-            return fail(
-                json_mode,
-                EXIT_USAGE,
-                "usage",
-                "--from and --to must be given together",
-            )
+            return Err("--from and --to must be given together".into())
         }
         (None, None, Some(workout)) => ExportScope::Workout {
             workout_id: workout.to_string(),
         },
         (None, None, None) => {
-            return fail(
-                json_mode,
-                EXIT_USAGE,
-                "usage",
-                "An export range is required: --from/--to or --workout",
-            )
+            return Err("An export range is required: --from/--to or --workout".into())
         }
-    };
+    }
+    .validated()?;
 
     let types: Vec<String> = flags
         .get("types")
-        .unwrap_or("workouts,daily,sleep")
+        .unwrap_or("workouts,daily_activity,sleep")
         .split(',')
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .map(str::to_string)
+        .map(str::to_ascii_lowercase)
         .collect();
+    if types.is_empty() {
+        return Err("--types must select at least one data type".into());
+    }
+    let unknown: Vec<&str> = types
+        .iter()
+        .map(String::as_str)
+        .filter(|value| !EXPORT_DATA_TYPES.contains(value))
+        .collect();
+    if !unknown.is_empty() {
+        return Err(format!(
+            "--types does not accept {}; valid types are {}",
+            unknown.join(", "),
+            EXPORT_DATA_TYPES.join(", ")
+        ));
+    }
     let detail = match flags.get("detail").unwrap_or("summary") {
         "summary" => ExportDetail::Summary,
         "full" => ExportDetail::Full,
-        _ => {
-            return fail(
-                json_mode,
-                EXIT_USAGE,
-                "usage",
-                "--detail must be summary or full",
-            )
-        }
+        _ => return Err("--detail must be summary or full".into()),
     };
+    // Summary 会聚合逐点指标，并省略运动轨迹；文件导出需要原始明细。
+    let detail = if matches!(format, "csv" | "gpx" | "fit") {
+        ExportDetail::Full
+    } else {
+        detail
+    };
+
+    Ok(ExportOptions {
+        format: format.to_string(),
+        out: flags.get("out").map(str::to_string),
+        selection: ExportSelection {
+            scope: Some(scope),
+            start_date: None,
+            end_date: None,
+            data_types: types,
+            detail,
+        },
+    })
+}
+
+fn cmd_export(args: &[String]) -> u8 {
+    // 解析也可能失败，所以不能等 Flags 构造成功才决定错误的输出格式。
+    let json_mode = args
+        .iter()
+        .any(|arg| arg == "--json" || arg.starts_with("--json="));
+    let options = match parse_export_args(args) {
+        Ok(options) => options,
+        Err(message) => return fail(json_mode, EXIT_USAGE, "usage", &message),
+    };
+    let format = options.format.as_str();
 
     let db = match open_read_only() {
         Ok(db) => db,
@@ -1083,27 +1130,8 @@ fn cmd_export(args: &[String]) -> u8 {
     {
         eprintln!("Note: {notice}");
     }
-    // FIT 只有 full 一档有意义。
-    //
-    // `--detail` 默认是 summary，而 summary 不带 `samples` / `route`——那正是
-    // FIT 的全部内容。于是 `export --format fit` 在不加 `--detail full` 时**永远**
-    // 导不出任何文件，只回一句「这段时间没有可导出的运动明细」，而那句话在有
-    // 明细的库上完全是误导。桌面端那条路一直是写死 full 的（commands/data.rs），
-    // 只有命令行漏了。
-    let detail = if format == "fit" {
-        ExportDetail::Full
-    } else {
-        detail
-    };
-    let selection = ExportSelection {
-        scope: Some(scope),
-        start_date: None,
-        end_date: None,
-        data_types: types,
-        detail,
-    };
     // 和 GUI 走同一个 builder：导出语义只在 core 里实现一次。
-    let (json_text, records) = match db.build_ai_export(&selection) {
+    let (json_text, records) = match db.build_ai_export(&options.selection) {
         Ok(value) => value,
         Err(error) => {
             let (code, kind) = exit_code_for(&error);
@@ -1112,7 +1140,7 @@ fn cmd_export(args: &[String]) -> u8 {
     };
 
     if format == "fit" {
-        return export_fit_files(json_mode, &json_text, flags.get("out"));
+        return export_fit_files(json_mode, &json_text, options.out.as_deref());
     }
 
     let (body, count) = match format {
@@ -1141,7 +1169,7 @@ fn cmd_export(args: &[String]) -> u8 {
         }
     };
 
-    match flags.get("out") {
+    match options.out.as_deref() {
         Some(path) => {
             if let Err(error) = std::fs::write(path, &body) {
                 return fail(
@@ -1185,8 +1213,8 @@ fn export_fit_files(json_mode: bool, json_text: &str, out: Option<&str>) -> u8 {
     let Some(directory) = out else {
         return fail(
             json_mode,
-            EXIT_FAILED,
-            "failed",
+            EXIT_USAGE,
+            "usage",
             "--format fit needs --out to point at a directory: FIT is binary and one file per workout, so it cannot go to stdout",
         );
     };
@@ -1289,6 +1317,79 @@ mod tests {
     fn a_misspelled_flag_is_a_usage_error_not_a_silent_default() {
         let flags = Flags::parse(&args(&["--form", "csv"])).unwrap();
         assert!(flags.reject_unknown(&["format"]).is_err());
+    }
+
+    #[test]
+    fn export_defaults_include_daily_activity_and_keep_json_summary() {
+        let options =
+            parse_export_args(&args(&["--from", "2026-01-01", "--to", "2026-01-31"])).unwrap();
+        assert_eq!(options.format, "json");
+        assert_eq!(options.out, None);
+        assert_eq!(
+            options.selection.data_types,
+            ["workouts", "daily_activity", "sleep"]
+        );
+        assert_eq!(options.selection.detail, ExportDetail::Summary);
+        assert_eq!(
+            options.selection.scope,
+            Some(ExportScope::date_range("2026-01-01", "2026-01-31"))
+        );
+        for data_type in &options.selection.data_types {
+            assert!(EXPORT_DATA_TYPES.contains(&data_type.as_str()));
+        }
+    }
+
+    #[test]
+    fn archival_formats_always_request_full_detail() {
+        for format in ["csv", "gpx", "fit"] {
+            for detail in [None, Some("summary"), Some("full")] {
+                let mut input = args(&[
+                    "--workout",
+                    "run-1",
+                    "--format",
+                    format,
+                    "--out",
+                    "export-output",
+                ]);
+                if let Some(detail) = detail {
+                    input.extend(args(&["--detail", detail]));
+                }
+                let options = parse_export_args(&input).unwrap();
+                assert_eq!(options.selection.detail, ExportDetail::Full, "{format}");
+                assert_eq!(
+                    options.selection.scope,
+                    Some(ExportScope::Workout {
+                        workout_id: "run-1".into(),
+                    })
+                );
+            }
+        }
+        let options = parse_export_args(&args(&[
+            "--workout",
+            "run-1",
+            "--format",
+            "json",
+            "--detail",
+            "full",
+        ]))
+        .unwrap();
+        assert_eq!(options.selection.detail, ExportDetail::Full);
+    }
+
+    #[test]
+    fn export_type_validation_uses_the_core_names_and_normalization() {
+        let options = parse_export_args(&args(&[
+            "--workout=run-1",
+            "--types= WORKOUTS , HeArt_RaTe ",
+        ]))
+        .unwrap();
+        assert_eq!(options.selection.data_types, ["workouts", "heart_rate"]);
+        for types in ["workouts,typo", "daily", "", "  ", ", ,"] {
+            let input = args(&["--workout", "run-1", "--types", types, "--json"]);
+            let message = parse_export_args(&input).unwrap_err();
+            assert!(message.contains("--types"), "{message}");
+            assert_eq!(cmd_export(&input), EXIT_USAGE);
+        }
     }
 
     #[test]

--- a/src-tauri/crates/cli/tests/export.rs
+++ b/src-tauri/crates/cli/tests/export.rs
@@ -1,0 +1,80 @@
+use std::process::Command;
+
+#[test]
+fn invalid_export_arguments_return_json_usage_errors_before_opening_a_database() {
+    let missing_data_dir = std::env::temp_dir().join(format!(
+        "zeppbridge-export-usage-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    assert!(!missing_data_dir.exists());
+
+    let cases: &[&[&str]] = &[
+        &["--json", "--form", "csv"],
+        &["--form", "csv", "--json"],
+        &["unexpected", "--json"],
+        &["--json", "unexpected", "--workout", "run-1"],
+        &["--json=false", "--workout", "run-1"],
+        &["--workout", "run-1", "--format", "--json"],
+        &["--workout", "run-1", "--types", "--json"],
+        &["--workout", "run-1", "--detail", "--json"],
+        &["--workout", "run-1", "--out", "--json"],
+        &["--workout", "run-1", "--from", "--json"],
+        &["--workout", "run-1", "--to", "--json"],
+        &[
+            "--from",
+            "2026-01-01",
+            "--to",
+            "2026-01-31",
+            "--workout",
+            "--json",
+        ],
+        &["--workout", "run-1", "--types=", "--json"],
+        &["--workout", "run-1", "--types", ", ,", "--json"],
+        &["--workout", "run-1", "--types", "workouts,typo", "--json"],
+        &[
+            "--workout",
+            "run-1",
+            "--format",
+            "json",
+            "--format",
+            "bogus",
+            "--json",
+        ],
+        &[
+            "--workout",
+            "run-1",
+            "--out",
+            "first.json",
+            "--out",
+            "second.json",
+            "--json",
+        ],
+        &["--workout", "run-1", "--json", "--json"],
+        &["--workout", "run-1", "--format", "fit", "--json"],
+        &["--from", "invalid", "--to", "2026-01-31", "--json"],
+    ];
+
+    for args in cases {
+        let output = Command::new(env!("CARGO_BIN_EXE_zeppbridge-cli"))
+            .arg("export")
+            .args(*args)
+            .env("ZEPPBRIDGE_DATA_DIR", &missing_data_dir)
+            .output()
+            .unwrap();
+        assert_eq!(output.status.code(), Some(2), "{args:?}: {output:?}");
+        let payload: serde_json::Value = serde_json::from_slice(&output.stdout)
+            .unwrap_or_else(|error| panic!("{args:?}: {error}; {output:?}"));
+        assert_eq!(payload["ok"], false, "{args:?}");
+        assert_eq!(payload["errorKind"], "usage", "{args:?}");
+        assert!(!payload["message"].as_str().unwrap().is_empty());
+        assert!(output.stderr.is_empty(), "{args:?}: {output:?}");
+        assert!(
+            !missing_data_dir.exists(),
+            "{args:?}: invalid arguments reached data directory initialization"
+        );
+    }
+}

--- a/src-tauri/crates/cli/tests/export_data.rs
+++ b/src-tauri/crates/cli/tests/export_data.rs
@@ -1,0 +1,185 @@
+use std::fs;
+use std::path::PathBuf;
+use std::process::{Command, Output};
+
+use chrono::{Duration, TimeZone, Utc};
+use serde_json::{json, Value};
+use zeppbridge_core::decoder::workout_detail::{RoutePoint, WorkoutSample};
+use zeppbridge_core::decoder::DecodedWorkout;
+use zeppbridge_core::models::{
+    DailyMetric, DeviceIdentityHint, MetricSample, SourceScope, Workout,
+};
+use zeppbridge_core::storage::Database;
+
+struct Fixture(PathBuf);
+
+impl Fixture {
+    fn new() -> Self {
+        let dir = std::env::temp_dir().join(format!(
+            "zeppbridge-export-data-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir(&dir).unwrap();
+        let fixture = Self(dir);
+        let db = Database::open_migrated(&fixture.0.join("zepp.db")).unwrap();
+        let start = Utc.with_ymd_and_hms(2023, 11, 5, 12, 0, 0).unwrap();
+        let end = start + Duration::minutes(30);
+        db.upsert_device_identity(&DeviceIdentityHint {
+            aliases: vec!["private-device-id".into()],
+            device_id: Some("private-device-id".into()),
+            serial: Some("private-serial".into()),
+            ..Default::default()
+        })
+        .unwrap();
+        db.insert_daily_metric(&DailyMetric {
+            date: "2023-11-05".into(),
+            metric: "steps".into(),
+            value: 1234.0,
+            unit: "steps".into(),
+            source_scope: SourceScope::Device,
+            device_id: Some("private-device-id".into()),
+        })
+        .unwrap();
+        let workout: Workout = serde_json::from_value(json!({
+            "workout_id": "synthetic-run",
+            "workout_type": "outdoor_running",
+            "normalized_type": "outdoor_running",
+            "type_source": "string_field",
+            "effective_type": "outdoor_running",
+            "start_time": start,
+            "end_time": end,
+            "source_scope": "device",
+            "device_id": "private-device-id"
+        }))
+        .unwrap();
+        db.insert_workout(&workout).unwrap();
+        let mut decoded = DecodedWorkout {
+            start_time: start,
+            end_time: end,
+            ..Default::default()
+        };
+        for (offset, value) in [(0, 72), (60, 84)] {
+            let timestamp = start + Duration::seconds(offset);
+            db.insert_metric_sample_with_raw(
+                &MetricSample {
+                    metric: "heart_rate".into(),
+                    timestamp,
+                    value: f64::from(value),
+                    unit: "bpm".into(),
+                    source_scope: SourceScope::Device,
+                    device_id: Some("private-device-id".into()),
+                },
+                None,
+            )
+            .unwrap();
+            decoded.route.push(RoutePoint {
+                timestamp,
+                latitude: 22.0,
+                longitude: 114.0,
+                altitude_m: None,
+            });
+            decoded.samples.push(
+                serde_json::from_value::<WorkoutSample>(json!({
+                    "timestamp": timestamp,
+                    "heart_rate": value
+                }))
+                .unwrap(),
+            );
+        }
+        db.replace_workout_series("synthetic-run", &decoded)
+            .unwrap();
+        fixture
+    }
+
+    fn export(&self, args: &[&str]) -> Output {
+        Command::new(env!("CARGO_BIN_EXE_zeppbridge-cli"))
+            .arg("export")
+            .args(args)
+            .env("ZEPPBRIDGE_DATA_DIR", &self.0)
+            .output()
+            .unwrap()
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+#[test]
+fn exports_preserve_data_and_do_not_modify_the_source_database() {
+    let fixture = Fixture::new();
+    let original_db = fs::read(fixture.0.join("zepp.db")).unwrap();
+    let dates = ["--from", "2023-11-01", "--to", "2023-11-30"];
+
+    let output = fixture.export(&dates);
+    assert!(output.status.success(), "{output:?}");
+    let payload: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(payload["data"]["daily_metrics"][0]["value"], 1234.0);
+    assert_eq!(payload["data"]["workouts"].as_array().unwrap().len(), 1);
+    assert!(payload["data"]["workouts"][0].get("route").is_none());
+
+    let output =
+        fixture.export(&[&dates[..], &["--types", " HEART_RATE ", "--format", "json"]].concat());
+    assert!(output.status.success(), "{output:?}");
+    let payload: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(payload["data"]["metric_samples"][0]["samples"], 2);
+
+    let output =
+        fixture.export(&[&dates[..], &["--types", "heart_rate", "--format", "csv"]].concat());
+    assert!(output.status.success(), "{output:?}");
+    let csv = String::from_utf8(output.stdout).unwrap();
+    assert_eq!(
+        csv.lines().count(),
+        3,
+        "header and both individual readings"
+    );
+    assert!(csv.contains(",heart_rate,72,"));
+    assert!(csv.contains(",heart_rate,84,"));
+    assert!(csv.lines().skip(1).all(|line| line.ends_with(",device_1")));
+    assert!(!csv.contains("private-device-id"));
+
+    for scope in [&dates[..], &["--workout", "synthetic-run"][..]] {
+        let output = fixture.export(&[scope, &["--format", "gpx"]].concat());
+        assert!(output.status.success(), "{output:?}");
+        let gpx = String::from_utf8(output.stdout).unwrap();
+        assert_eq!(gpx.matches("<trkpt ").count(), 2);
+        assert_eq!(gpx.matches("<gpxtpx:hr>").count(), 2);
+    }
+
+    let fit_dir = fixture.0.join("fit");
+    let output = fixture.export(&[
+        "--workout",
+        "synthetic-run",
+        "--format",
+        "fit",
+        "--out",
+        fit_dir.to_str().unwrap(),
+        "--json",
+    ]);
+    assert!(output.status.success(), "{output:?}");
+    let files: Vec<_> = fs::read_dir(&fit_dir).unwrap().collect();
+    assert_eq!(files.len(), 1);
+    let bytes = fs::read(files[0].as_ref().unwrap().path()).unwrap();
+    assert_eq!(&bytes[8..12], b".FIT");
+
+    let existing = fixture.0.join("existing.json");
+    fs::write(&existing, "keep this file").unwrap();
+    let output = fixture.export(&[
+        "--workout",
+        "synthetic-run",
+        "--types",
+        "workouts,typo",
+        "--out",
+        existing.to_str().unwrap(),
+        "--json",
+    ]);
+    assert_eq!(output.status.code(), Some(2));
+    assert_eq!(fs::read_to_string(existing).unwrap(), "keep this file");
+    assert_eq!(fs::read(fixture.0.join("zepp.db")).unwrap(), original_db);
+}

--- a/src-tauri/crates/core/src/export_formats.rs
+++ b/src-tauri/crates/core/src/export_formats.rs
@@ -13,6 +13,7 @@ use serde_json::Value;
 
 /// CSV 用长表（tidy）而不是宽表：四类记录字段集合完全不同，宽表会逼出大量
 /// 空列，长表则天然表达「这条记录没有这个指标」。
+/// 保留 device_id 列名以兼容现有 CSV；其值使用 builder 的匿名 device_label。
 const CSV_HEADER: &str =
     "record_type,record_id,start_time,end_time,metric,value,unit,source_scope,device_id";
 
@@ -41,8 +42,7 @@ const WORKOUT_METRICS: [(&str, &str); 6] = [
 
 /// 把标准化导出 JSON 转成长表 CSV，返回 `(文本, 数据行数)`。
 ///
-/// 逐点采样与 GPS 轨迹**不进 CSV**：它们是每秒一条的序列，混进汇总表会让
-/// 行数暴涨且语义混乱。需要序列请用 GPX 或 JSON。
+/// 日常指标使用 full payload 中的逐条 value；运动逐秒序列与 GPS 轨迹不进 CSV。
 pub fn to_csv(export: &Value) -> Result<(String, usize), String> {
     let data = export
         .get("data")
@@ -66,7 +66,7 @@ pub fn to_csv(export: &Value) -> Result<(String, usize), String> {
                 &value,
                 text(sample.get("unit")),
                 text(sample.get("source_scope")),
-                text(sample.get("device_id")),
+                text(sample.get("device_label")),
             ],
         );
         count += 1;
@@ -87,7 +87,7 @@ pub fn to_csv(export: &Value) -> Result<(String, usize), String> {
                 &value,
                 text(daily.get("unit")),
                 text(daily.get("source_scope")),
-                text(daily.get("device_id")),
+                text(daily.get("device_label")),
             ],
         );
         count += 1;
@@ -109,7 +109,7 @@ pub fn to_csv(export: &Value) -> Result<(String, usize), String> {
                     &value,
                     unit,
                     text(session.get("source_scope")),
-                    text(session.get("device_id")),
+                    text(session.get("device_label")),
                 ],
             );
             count += 1;
@@ -121,7 +121,7 @@ pub fn to_csv(export: &Value) -> Result<(String, usize), String> {
         let start = text(workout.get("start_time"));
         let end = text(workout.get("end_time"));
         let scope = text(workout.get("source_scope"));
-        let device = text(workout.get("device_id"));
+        let device = text(workout.get("device_label"));
 
         // 运动类型是字符串而不是数值，但丢掉它会让 CSV 无法区分跑步和骑行，
         // 因此单独占一行放进 value 列。
@@ -365,6 +365,8 @@ fn escape_xml(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::models::{ExportDetail, ExportScope, ExportSelection};
+    use crate::storage::Database;
     use serde_json::json;
 
     fn export_with(data: Value) -> Value {
@@ -426,6 +428,67 @@ mod tests {
         let export = export_with(json!({ "metric_samples": [], "workouts": [] }));
         let error = to_csv(&export).unwrap_err();
         assert!(error.contains("没有可写入 CSV 的记录"), "实际错误：{error}");
+    }
+
+    #[test]
+    fn csv_preserves_anonymous_device_labels_from_the_export_builder() {
+        let db = Database::in_memory().unwrap();
+        db.conn
+            .execute_batch(
+                "INSERT INTO device_identities (alias, serial, device_id, updated_at)
+                 VALUES ('private-device-id', 'private-serial', 'private-device-id',
+                         '2023-11-05T12:00:00+00:00');
+                 INSERT INTO metric_samples
+                     (metric, timestamp, value, unit, source_scope, device_id)
+                 VALUES ('heart_rate', '2023-11-05T12:00:00+00:00', 72, 'bpm',
+                         'device', 'private-device-id');
+                 INSERT INTO daily_metrics
+                     (date, metric, value, unit, source_scope, device_id)
+                 VALUES ('2023-11-05', 'steps', 1234, 'steps', 'device', 'private-device-id');
+                 INSERT INTO sleep_sessions
+                     (sleep_id, start_time, end_time, duration_minutes, deep_minutes,
+                      light_minutes, rem_minutes, awake_minutes, source_scope, device_id)
+                 VALUES ('s1', '2023-11-05T00:00:00+00:00', '2023-11-05T07:00:00+00:00',
+                         420, 60, 360, 0, 0, 'device', 'private-device-id');
+                 INSERT INTO workouts
+                     (workout_id, workout_type, start_time, end_time, source_scope, device_id)
+                 VALUES ('w1', 'run', '2023-11-05T12:00:00+00:00',
+                         '2023-11-05T13:00:00+00:00', 'device', 'private-device-id');",
+            )
+            .unwrap();
+        let selection = ExportSelection {
+            scope: Some(ExportScope::date_range("2023-11-01", "2023-11-30")),
+            start_date: None,
+            end_date: None,
+            data_types: ["heart_rate", "steps", "sleep", "workouts"]
+                .into_iter()
+                .map(str::to_string)
+                .collect(),
+            detail: ExportDetail::Full,
+        };
+        let (encoded, _) = db.build_ai_export(&selection).unwrap();
+        let export = serde_json::from_str(&encoded).unwrap();
+        let (csv, _) = to_csv(&export).unwrap();
+
+        // Keep the existing column contract, but only put the builder's anonymous
+        // label in it. Raw device identifiers must never return via CSV.
+        assert_eq!(
+            csv.lines().next().unwrap(),
+            format!("{UTF8_BOM}{CSV_HEADER}")
+        );
+        for record_type in ["metric_sample", "daily_metric", "sleep_session", "workout"] {
+            let rows: Vec<_> = csv
+                .lines()
+                .filter(|line| line.starts_with(&format!("{record_type},")))
+                .collect();
+            assert!(!rows.is_empty(), "missing {record_type}");
+            assert!(
+                rows.iter().all(|line| line.ends_with(",device_1")),
+                "missing device label for {record_type}: {rows:?}"
+            );
+        }
+        assert!(!csv.contains("private-device-id"));
+        assert!(!csv.contains("private-serial"));
     }
 
     #[test]

--- a/src-tauri/crates/core/src/storage/mod.rs
+++ b/src-tauri/crates/core/src/storage/mod.rs
@@ -12,6 +12,31 @@ use std::path::{Path, PathBuf};
 pub const CURRENT_SCHEMA_VERSION: i64 = 21;
 /// 写进备份 manifest 的应用版本。Core 是独立 crate，用它自己的包版本。
 const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Accepted `ExportSelection::data_types`, shared with callers that validate input.
+pub const EXPORT_DATA_TYPES: [&str; 17] = [
+    "heart_rate",
+    "hrv",
+    "hrv_rmssd",
+    "respiratory_rate",
+    "pai",
+    "lactate_threshold",
+    "daily_activity",
+    "sleep",
+    "workouts",
+    "recovery",
+    "steps",
+    "spo2",
+    "stress",
+    "training_load",
+    "vo2max",
+    "weight",
+    // 饮食一度只登记在能力表（`CapabilityEvidence::DailyPrefix("intake_")`）
+    // 里，却从来没进过这张允许表：`--types food` 被静默丢掉，摄入数据
+    // 入了库、能画图、却导不出来。
+    "food",
+];
+
 /// 解析器修订号。**改了运动目录或任何归一化规则，就必须往前走一格。**
 ///
 /// 它是自动重放的唯一触发条件：启动时发现库里存的修订号和这个不一样，就把
@@ -4623,30 +4648,7 @@ impl Database {
             // 一天吃了什么和某一条运动同样没有关系，理由同上。
             "food",
         ];
-        let allowed: BTreeSet<&str> = [
-            "heart_rate",
-            "hrv",
-            "hrv_rmssd",
-            "respiratory_rate",
-            "pai",
-            "lactate_threshold",
-            "daily_activity",
-            "sleep",
-            "workouts",
-            "recovery",
-            "steps",
-            "spo2",
-            "stress",
-            "training_load",
-            "vo2max",
-            "weight",
-            // 饮食一度只登记在能力表（`CapabilityEvidence::DailyPrefix("intake_")`）
-            // 里，却从来没进过这张允许表：`--types food` 被静默丢掉，摄入数据
-            // 入了库、能画图、却导不出来。
-            "food",
-        ]
-        .into_iter()
-        .collect();
+        let allowed: BTreeSet<&str> = EXPORT_DATA_TYPES.into_iter().collect();
         let selected: BTreeSet<String> = selection
             .data_types
             .iter()
@@ -4673,6 +4675,8 @@ impl Database {
         let mut metric_samples = Vec::new();
         if selected.contains("heart_rate")
             || selected.contains("hrv")
+            || selected.contains("hrv_rmssd")
+            || selected.contains("respiratory_rate")
             || selected.contains("spo2")
             || selected.contains("stress")
             || selected.contains("weight")
@@ -4690,12 +4694,18 @@ impl Database {
                  FROM metric_samples
                  WHERE (?5 IS NULL OR timestamp >= ?5)
                    AND (?6 IS NULL OR timestamp < ?6)
-                   AND date(timestamp, 'localtime') BETWEEN ?1 AND ?2
+                   AND (?3 IS NOT NULL OR date(timestamp, 'localtime') BETWEEN ?1 AND ?2)
                    AND (?3 IS NULL OR timestamp >= ?3)
                    AND (?4 IS NULL OR timestamp <= ?4)
                  ORDER BY timestamp",
             )?;
-            let day_bounds = local_day_range_utc_bounds(&start_text, &end_text);
+            // A workout can cross local midnight. Its actual time window must
+            // not be clipped to the calendar day on which it started.
+            let day_bounds = if single_workout {
+                None
+            } else {
+                local_day_range_utc_bounds(&start_text, &end_text)
+            };
             let (day_lower, day_upper) = match &day_bounds {
                 Some((lower, upper)) => (Some(lower.as_str()), Some(upper.as_str())),
                 None => (None, None),
@@ -4744,6 +4754,9 @@ impl Database {
                 let Some(matched_type) = matched_type else {
                     continue;
                 };
+                if single_workout && DAY_LEVEL_TYPES.contains(&matched_type.as_str()) {
+                    continue;
+                }
                 *produced.entry(matched_type.clone()).or_default() += 1;
                 let device_label = devices.label(device_id.as_deref());
                 if !full && HOURLY_AGGREGATED_METRICS.contains(&metric.as_str()) {
@@ -4804,6 +4817,10 @@ impl Database {
         if !single_workout
             && (selected.contains("daily_activity")
                 || selected.contains("recovery")
+                || selected.contains("respiratory_rate")
+                || selected.contains("lactate_threshold")
+                || selected.contains("pai")
+                || selected.contains("hrv_rmssd")
                 || selected.contains("steps")
                 || selected.contains("spo2")
                 || selected.contains("stress")
@@ -7178,6 +7195,155 @@ mod tests {
         serde_json::from_str(&encoded).unwrap()
     }
 
+    #[test]
+    fn metric_sample_types_export_without_an_unrelated_selection() {
+        let db = Database::in_memory().unwrap();
+        for (metric, value, unit) in [
+            ("hrv_rmssd", 42.0, "ms"),
+            ("respiratory_rate", 16.0, "brpm"),
+        ] {
+            db.insert_metric_sample(&MetricSample {
+                metric: metric.into(),
+                timestamp: ts(),
+                value,
+                unit: unit.into(),
+                source_scope: SourceScope::Device,
+                device_id: None,
+            })
+            .unwrap();
+        }
+
+        for detail in [ExportDetail::Summary, ExportDetail::Full] {
+            for (metric, expected) in [("hrv_rmssd", 42.0), ("respiratory_rate", 16.0)] {
+                let export = parsed_export(&db, &[metric], detail);
+                let samples = export["data"]["metric_samples"].as_array().unwrap();
+                assert_eq!(samples.len(), 1, "{metric}, {detail:?}");
+                assert_eq!(samples[0]["metric"], metric);
+                assert_eq!(samples[0]["value"], expected);
+                assert_eq!(export["record_count"], 1);
+                assert_eq!(export["capabilities"][metric]["status"], "available");
+                assert_eq!(export["capabilities"][metric]["source_records"], 1);
+                assert_eq!(export["capabilities"][metric]["rows_in_export"], 1);
+            }
+        }
+    }
+
+    #[test]
+    fn daily_metric_types_export_alone_but_stay_outside_workout_scope() {
+        let db = Database::in_memory().unwrap();
+        let workout = workout_with_type(None, "run", "string_field");
+        let date = workout
+            .start_time
+            .with_timezone(&Local)
+            .format("%Y-%m-%d")
+            .to_string();
+        db.insert_workout(&workout).unwrap();
+        let cases = [
+            ("respiratory_rate", "respiratory_rate", 16.0, "brpm"),
+            ("lactate_threshold", "lactate_threshold_hr", 170.0, "bpm"),
+            ("pai", "pai_daily", 20.0, "pai"),
+            ("hrv_rmssd", "hrv_rmssd", 42.0, "ms"),
+        ];
+        for (_, metric, value, unit) in cases {
+            db.insert_daily_metric(&DailyMetric {
+                date: date.clone(),
+                metric: metric.into(),
+                value,
+                unit: unit.into(),
+                source_scope: SourceScope::Device,
+                device_id: None,
+            })
+            .unwrap();
+        }
+
+        for detail in [ExportDetail::Summary, ExportDetail::Full] {
+            for (selected_type, metric, value, _) in cases {
+                let export = parsed_export(&db, &[selected_type], detail);
+                let daily = export["data"]["daily_metrics"].as_array().unwrap();
+                assert_eq!(daily.len(), 1, "{selected_type}, {detail:?}");
+                assert_eq!(daily[0]["metric"], metric);
+                assert_eq!(daily[0]["value"], value);
+                assert_eq!(export["record_count"], 1);
+                let capability = &export["capabilities"][selected_type];
+                assert_eq!(capability["status"], "available");
+                assert_eq!(capability["source_records"], 1);
+                assert_eq!(capability["rows_in_export"], 1);
+
+                let mut selection = export_selection(&[selected_type], detail);
+                selection.scope = Some(ExportScope::Workout {
+                    workout_id: workout.workout_id.clone(),
+                });
+                let (encoded, records) = db.build_ai_export(&selection).unwrap();
+                let scoped: serde_json::Value = serde_json::from_str(&encoded).unwrap();
+                assert_eq!(records, 0, "daily {metric} is outside workout scope");
+                assert!(scoped["data"]["daily_metrics"]
+                    .as_array()
+                    .unwrap()
+                    .is_empty());
+                if matches!(selected_type, "lactate_threshold" | "pai") {
+                    assert_eq!(
+                        scoped["capabilities"][selected_type]["status"],
+                        "excluded_by_scope"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn workout_export_excludes_weight_samples_that_overlap_the_workout() {
+        let db = Database::in_memory().unwrap();
+        let workout = workout_with_type(None, "run", "string_field");
+        db.insert_workout(&workout).unwrap();
+        for (metric, value, unit) in [
+            ("weight", 70.0, "kg"),
+            ("body_fat_rate", 18.5, "%"),
+            ("heart_rate", 120.0, "bpm"),
+        ] {
+            db.insert_metric_sample(&MetricSample {
+                metric: metric.into(),
+                timestamp: workout.start_time + chrono::Duration::minutes(5),
+                value,
+                unit: unit.into(),
+                source_scope: SourceScope::Device,
+                device_id: None,
+            })
+            .unwrap();
+        }
+
+        for detail in [ExportDetail::Summary, ExportDetail::Full] {
+            let date_export = parsed_export(&db, &["weight", "heart_rate"], detail);
+            let samples = date_export["data"]["metric_samples"].as_array().unwrap();
+            assert_eq!(samples.len(), 3);
+            for (metric, value) in [("weight", 70.0), ("body_fat_rate", 18.5)] {
+                let sample = samples.iter().find(|row| row["metric"] == metric).unwrap();
+                assert_eq!(sample["value"], value);
+            }
+            assert_eq!(date_export["capabilities"]["weight"]["status"], "available");
+            assert_eq!(date_export["capabilities"]["weight"]["source_records"], 2);
+            assert_eq!(date_export["capabilities"]["weight"]["rows_in_export"], 2);
+
+            let mut selection = export_selection(&["weight", "heart_rate"], detail);
+            selection.scope = Some(ExportScope::Workout {
+                workout_id: workout.workout_id.clone(),
+            });
+            let (encoded, records) = db.build_ai_export(&selection).unwrap();
+            let export: serde_json::Value = serde_json::from_str(&encoded).unwrap();
+            let samples = export["data"]["metric_samples"].as_array().unwrap();
+            assert_eq!(records, 1);
+            assert_eq!(samples.len(), 1);
+            assert_eq!(samples[0]["metric"], "heart_rate");
+            assert_eq!(export["capabilities"]["heart_rate"]["status"], "available");
+            assert_eq!(export["capabilities"]["heart_rate"]["source_records"], 1);
+            assert_eq!(export["capabilities"]["heart_rate"]["rows_in_export"], 1);
+            assert_eq!(
+                export["capabilities"]["weight"]["status"],
+                "excluded_by_scope"
+            );
+            assert_eq!(export["capabilities"]["weight"]["rows_in_export"], 0);
+        }
+    }
+
     /// 饮食能导出，而且不会被「日常活动」兜底扫走。
     ///
     /// `food` 一度只登记在能力表里，从来没进过导出的允许类型表：`--types food`
@@ -7578,6 +7744,72 @@ mod tests {
         assert!(upper.as_str() > "2026-08-29T00:00:00");
         // 日期无效时返回 None，让调用方退回不带边界的查询而不是查空。
         assert!(local_day_range_utc_bounds("not-a-date", "2026-08-29").is_none());
+    }
+
+    #[test]
+    fn workout_export_keeps_samples_after_local_midnight_within_its_window() {
+        let db = Database::in_memory().unwrap();
+        let start = NaiveDate::from_ymd_opt(2023, 11, 15)
+            .unwrap()
+            .and_hms_opt(23, 50, 0)
+            .unwrap()
+            .and_local_timezone(Local)
+            .single()
+            .unwrap()
+            .with_timezone(&Utc);
+        let mut workout = workout_with_type(None, "run", "string_field");
+        workout.start_time = start;
+        workout.end_time = start + chrono::Duration::minutes(20);
+        db.insert_workout(&workout).unwrap();
+        for (minutes, value) in [(-5, 60.0), (5, 100.0), (15, 110.0), (25, 70.0)] {
+            db.insert_metric_sample(&MetricSample {
+                metric: "heart_rate".into(),
+                timestamp: start + chrono::Duration::minutes(minutes),
+                value,
+                unit: "bpm".into(),
+                source_scope: SourceScope::Device,
+                device_id: None,
+            })
+            .unwrap();
+        }
+
+        for detail in [ExportDetail::Summary, ExportDetail::Full] {
+            let mut selection = export_selection(&["heart_rate"], detail);
+            selection.scope = Some(ExportScope::Workout {
+                workout_id: workout.workout_id.clone(),
+            });
+            let (encoded, _) = db.build_ai_export(&selection).unwrap();
+            let export: serde_json::Value = serde_json::from_str(&encoded).unwrap();
+            assert_eq!(export["capabilities"]["heart_rate"]["source_records"], 2);
+            let samples = export["data"]["metric_samples"].as_array().unwrap();
+            if detail.is_full() {
+                assert_eq!(samples.len(), 2);
+                assert_eq!(samples[0]["value"], 100.0);
+                assert_eq!(samples[1]["value"], 110.0);
+            } else {
+                assert_eq!(
+                    samples
+                        .iter()
+                        .map(|sample| sample["samples"].as_u64().unwrap())
+                        .sum::<u64>(),
+                    2
+                );
+                for sample in samples {
+                    assert!(sample["min"].as_f64().unwrap() >= 100.0);
+                    assert!(sample["max"].as_f64().unwrap() <= 110.0);
+                }
+            }
+        }
+
+        let day = start.with_timezone(&Local).format("%Y-%m-%d").to_string();
+        let mut selection = export_selection(&["heart_rate"], ExportDetail::Full);
+        selection.scope = Some(ExportScope::date_range(&day, &day));
+        let (encoded, _) = db.build_ai_export(&selection).unwrap();
+        let export: serde_json::Value = serde_json::from_str(&encoded).unwrap();
+        let samples = export["data"]["metric_samples"].as_array().unwrap();
+        assert_eq!(samples.len(), 2);
+        assert_eq!(samples[0]["value"], 60.0);
+        assert_eq!(samples[1]["value"], 100.0);
     }
 
     #[test]

--- a/src-tauri/crates/mcp/src/main.rs
+++ b/src-tauri/crates/mcp/src/main.rs
@@ -414,12 +414,19 @@ fn open_db() -> Result<(Database, u64), (i64, String)> {
 }
 
 fn call_tool(params: &Value) -> Result<Value, (i64, String)> {
+    call_tool_with_db(params, open_db)
+}
+
+fn call_tool_with_db(
+    params: &Value,
+    open: impl FnOnce() -> Result<(Database, u64), (i64, String)>,
+) -> Result<Value, (i64, String)> {
     let name = params
         .get("name")
         .and_then(Value::as_str)
         .ok_or((ERR_INVALID_PARAMS, "缺少工具名".to_string()))?;
     let args = params.get("arguments").cloned().unwrap_or(json!({}));
-    let (db, database_bytes) = open_db()?;
+    let (db, database_bytes) = open()?;
 
     let payload = match name {
         "list_workouts" => {
@@ -493,11 +500,21 @@ fn call_tool(params: &Value) -> Result<Value, (i64, String)> {
                 Some(id) => db
                     .get_sleep_detail(id)
                     .map_err(|error| (ERR_DATABASE, error.user_message()))?,
-                None => db
-                    .get_recent_sleep_sessions(1)
-                    .map_err(|error| (ERR_DATABASE, error.user_message()))?
-                    .into_iter()
-                    .next(),
+                None => {
+                    let latest = db
+                        .get_recent_sleep_sessions(1)
+                        .map_err(|error| (ERR_DATABASE, error.user_message()))?
+                        .into_iter()
+                        .next();
+                    // The list deliberately omits stages; load the same detail
+                    // as an explicit sleepId instead of returning that summary.
+                    match latest {
+                        Some(session) => db
+                            .get_sleep_detail(&session.sleep_id)
+                            .map_err(|error| (ERR_DATABASE, error.user_message()))?,
+                        None => None,
+                    }
+                }
             };
             match session {
                 Some(session) => json!({
@@ -544,6 +561,123 @@ fn call_tool(params: &Value) -> Result<Value, (i64, String)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::{TimeZone, Utc};
+    use std::path::PathBuf;
+    use zeppbridge_core::models::{SleepSession, SleepStageSlice, SourceScope};
+
+    struct TestLibrary(PathBuf);
+
+    impl TestLibrary {
+        fn new(sessions: &[SleepSession]) -> Self {
+            let nonce = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let dir = std::env::temp_dir().join(format!(
+                "zeppbridge-mcp-sleep-{}-{nonce}",
+                std::process::id()
+            ));
+            std::fs::create_dir_all(&dir).unwrap();
+            let library = Self(dir);
+            let db = Database::open_migrated(&library.0.join("zepp.db")).unwrap();
+            for session in sessions {
+                db.insert_sleep_session(session).unwrap();
+            }
+            library
+        }
+
+        fn call_sleep(&self, arguments: Value) -> Value {
+            call_tool_with_db(
+                &json!({ "name": "get_sleep_detail", "arguments": arguments }),
+                || {
+                    let db = Database::open_read_only(self.0.join("zepp.db"))
+                        .map_err(|error| (ERR_DATABASE, error.user_message()))?;
+                    Ok((db, 0))
+                },
+            )
+            .unwrap()
+        }
+    }
+
+    impl Drop for TestLibrary {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn sleep_session(id: &str, day: u32, stage: Option<&str>) -> SleepSession {
+        let start = Utc.with_ymd_and_hms(2026, 1, day, 20, 0, 0).unwrap();
+        let end = start + chrono::Duration::minutes(60);
+        SleepSession {
+            sleep_id: id.into(),
+            start_time: start,
+            end_time: end,
+            score: Some(80),
+            duration_minutes: 60,
+            deep_minutes: 30,
+            light_minutes: 30,
+            rem_minutes: None,
+            awake_minutes: 0,
+            source_scope: SourceScope::Device,
+            device_id: None,
+            synced_at: Some(end + chrono::Duration::hours(1)),
+            time_in_bed_minutes: None,
+            stages: stage
+                .map(|stage| SleepStageSlice {
+                    stage: stage.into(),
+                    start_time: start,
+                    end_time: start + chrono::Duration::minutes(30),
+                    raw_mode: Some(5),
+                })
+                .into_iter()
+                .collect(),
+            wake_count: Some(1),
+        }
+    }
+
+    #[test]
+    fn latest_sleep_returns_the_same_full_detail_as_an_explicit_id() {
+        let older = sleep_session("older", 1, Some("light"));
+        let latest = sleep_session("latest", 2, Some("deep"));
+        let library = TestLibrary::new(&[older, latest.clone()]);
+
+        let implicit = library.call_sleep(json!({}));
+        let explicit = library.call_sleep(json!({ "sleepId": "latest" }));
+        assert_eq!(implicit, explicit);
+        assert_eq!(implicit["isError"], json!(false));
+        assert_eq!(
+            implicit["structuredContent"]["sleep"],
+            serde_json::to_value(latest).unwrap()
+        );
+        let text: Value =
+            serde_json::from_str(implicit["content"][0]["text"].as_str().unwrap()).unwrap();
+        assert_eq!(text, implicit["structuredContent"]);
+
+        let previous = library.call_sleep(json!({ "sleepId": "older" }));
+        assert_eq!(previous["structuredContent"]["sleep"]["sleep_id"], "older");
+        assert_eq!(
+            previous["structuredContent"]["sleep"]["stages"][0]["stage"],
+            "light"
+        );
+    }
+
+    #[test]
+    fn sleep_queries_preserve_missing_sessions_and_missing_stages() {
+        let empty = TestLibrary::new(&[]);
+        let recent = empty.call_sleep(json!({}));
+        assert_eq!(recent["isError"], json!(false));
+        assert_eq!(recent["structuredContent"]["sleep"], Value::Null);
+
+        let library = TestLibrary::new(&[sleep_session("no-stages", 1, None)]);
+        let recent = library.call_sleep(json!({}));
+        assert_eq!(
+            recent["structuredContent"]["sleep"]["sleep_id"],
+            "no-stages"
+        );
+        assert_eq!(recent["structuredContent"]["sleep"]["stages"], json!([]));
+        let missing = library.call_sleep(json!({ "sleepId": "unknown" }));
+        assert_eq!(missing["structuredContent"]["sleep"], Value::Null);
+    }
 
     #[test]
     fn every_tool_declares_units_and_the_missing_value_rule() {


### PR DESCRIPTION
This fixes #68: CLI GPX exports use the default summary payload, which omits the route, so a workout with recorded GPS is incorrectly reported as having no GPS data.

Additional, independently reproduced data omissions are included: the default type list contains `daily`, CSV consumes a summary payload, and several supported types never enter the corresponding core queries. This also fixes CSV device provenance, workout samples after local midnight, and weight records that contradict the workout scope's exclusion metadata.

- Correct the default type name and reject invalid export arguments before opening the database or touching output; retain JSON usage errors and the existing exit-code contract.
- Use full payloads for CSV/GPX/FIT while preserving JSON's summary default and CSV's column layout. Device values remain anonymized.
- Complete the core's type-query guards and enforce the existing workout time/scope boundaries.
- Load the full latest sleep detail for MCP, including its recorded stage timeline.

Regression tests exercise the shared export builder and real CLI subprocesses with synthetic SQLite libraries, including GPX/FIT output, unchanged source databases, unchanged existing output on usage errors, and complete/missing sleep stages.

No schema, dependency, normalizer, sync, desktop UI, or repository documentation changes.

Validation on Windows with Rust 1.98.1 and the existing lockfile:

- `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`
- `cargo check --manifest-path src-tauri/Cargo.toml --workspace --locked --offline --all-targets`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --locked --offline --all-targets -- -D warnings`
- `cargo test --manifest-path src-tauri/Cargo.toml --workspace --locked --offline`: 383 passed, 0 failed; 1 existing real-old-database fixture test remains ignored.

GitHub CI, Linux/macOS execution, and the unchanged frontend build/tests have not been run locally.

Fixes #68.
