### PR TITLE
fix(export): 补齐运动详情 FIT 入口与 CSV 指标，记录反馈排查结论

### DIFF
--- a/docs/evidence/workout-export-investigation-2026-09-09.md
+++ b/docs/evidence/workout-export-investigation-2026-09-09.md
@@ -1,0 +1,87 @@
+# Workout feedback investigation — 2026-09-09
+
+## Implemented: individual workout FIT export
+
+[Issue #28 comment](https://github.com/lingcang728/ZeppBridge/issues/28#issuecomment-5588711932)
+correctly identifies a missing entry point. The detail page only offered clipboard
+JSON/CSV/GPX, while the main export page already invoked the FIT backend.
+
+The detail page now offers FIT, selects an output folder, and invokes the existing
+backend with an explicit single-workout scope and full detail. Cancelling the
+picker writes nothing. Buttons are disabled while export is pending. Backend
+errors are displayed instead of being replaced by a clipboard error.
+
+Its CSV field list also omitted all five already decoded power/running-form
+fields. Those columns are now included; absent measurements remain empty.
+
+## Investigated: missing FIT power, not reproduced
+
+The same comment reports intermittent missing power. The decoder reads
+`power_meter`; storage persists `power_watts`; the FIT writer emits record power
+and session average/maximum power. The desktop FIT command forces full detail.
+
+A new integration regression exercises raw detail decoding, database storage,
+single-workout export, FIT encoding and FIT decoding. The readings 200, 250, 0
+and 300 W survive, including empty time deltas and zero watts.
+
+Read-only inspection of the available local database found nonempty power streams
+in 71 of 176 raw workout details and 283,477 stored power samples. This is evidence
+that the local path works, not a reproduction of the reporter's workout.
+No fallback power is synthesized from a summary average.
+
+Remaining evidence: the affected workout's raw detail and exported FIT, ideally
+paired with Zepp's export of the same activity. Compare timestamps and the presence
+of `power_meter` before assigning the fault to retrieval, decoding or encoding.
+
+## Unresolved: trail running labelled as open-water swimming
+
+[Issue #24](https://github.com/lingcang728/ZeppBridge/issues/24) reports a trail run
+being assigned the swimming type. The [new comment](https://github.com/lingcang728/ZeppBridge/issues/24#issuecomment-5588483563)
+describes 500 m ascent on that mislabelled activity. Removing altitude would discard
+potentially correct running data and would not fix classification.
+
+The catalog maps 7 to open-water swimming using the device protocol, while several
+other entries use different cloud-history codes. Trail running has no verified
+cloud code. The official [device workout table](https://docs.zepp.com/docs/guides/workout-extension/quick-start/)
+does identify 7 as swimming, but it does not establish the cloud-history mapping.
+The available issue comments and diagnostic note provide no numeric code; the
+local database has no relevant activity. Therefore no numeric mapping was changed.
+
+Remaining evidence: one affected raw history row (`type`, source and any sport
+name fields), plus the sport shown by Zepp. An actual open-water swim row provides
+the counterexample needed to check any shared-code hypothesis. The existing manual
+Trail Running correction remains available; it is a workaround, not an automatic
+classification fix.
+
+## Unresolved: missing scuba depth, water temperature and NDL
+
+The supplied screenshot reports a T-Rex 3 scuba record exporting only heart rate.
+The current sample model and decoder have no depth, water temperature or NDL
+fields, and consequently cannot export those curves. `altitude_m` is elevation,
+not a placeholder for dive depth. Its absence does not establish where depth was
+lost. No scuba payload or FIT was available for this investigation.
+
+Remaining evidence: one dive's raw cloud detail and, if available, Zepp's own FIT
+for the same dive. Establish field names, time encoding, units and missing-value
+sentinels before adding model/storage/JSON/CSV/FIT support and replaying historical
+raw details. Device UI constants do not establish cloud payload encoding. No
+depth is inferred from altitude and no NDL curve is calculated or fabricated.
+
+These unresolved reports are deliberately not marked fixed or closed by this PR.
+
+## Validation
+
+- Frontend build, 109 Vitest tests, i18n checks and documentation-link checks pass.
+- `cargo test --manifest-path src-tauri/Cargo.toml --workspace --locked` passes
+  (the existing ignored test remains ignored).
+- `tauri build --no-bundle --ci` produces the tested Windows EXE. Plain
+  `cargo build --release` is not the packaging path: it can retain the dev URL.
+- The EXE was tested against an isolated SQLite backup, without copying auth.
+  The FIT option renders and selects correctly. Invoking the real FIT command
+  for one workout writes one file; independent Python `fitdecode` reads 122
+  records whose 122 power readings all match SQLite. Clicking CSV produces
+  122 rows whose power values also match SQLite.
+- Native folder-picker interaction was not automated. The FIT command was
+  invoked directly in the EXE; the CSV clipboard sink was captured by the test.
+  This is not a claim that a native dialog click-through was tested.
+- The existing `release/ZeppBridge.exe` and its data were not replaced.

--- a/src-tauri/crates/core/src/export_fit.rs
+++ b/src-tauri/crates/core/src/export_fit.rs
@@ -1456,6 +1456,56 @@ mod tests {
         assert_eq!(messages_of(&fit, typedef::MesgNum::ACTIVITY).len(), 1);
     }
 
+    #[test]
+    fn raw_power_survives_storage_and_single_workout_fit_export() {
+        use crate::models::types::{ExportDetail, ExportScope, ExportSelection, Workout};
+        use crate::storage::Database;
+        let db = Database::in_memory().unwrap();
+        let start = DateTime::from_timestamp(1_700_000_000, 0).unwrap();
+        let id = "1700000000";
+        db.insert_workout(&Workout {
+            workout_id: id.into(),
+            workout_type: "run".into(),
+            normalized_type: "run".into(),
+            effective_type: "run".into(),
+            start_time: start,
+            end_time: start + chrono::Duration::seconds(3),
+            ..Default::default()
+        })
+        .unwrap();
+        let payload = json!({
+            "trackid": 1_700_000_000i64,
+            "time": "0;1;1;1;",
+            "heart_rate": "0,120;1,1;1,1;1,1;",
+            "power_meter": "0,200;,250;,0;,300;"
+        });
+        db.normalize_and_persist_raw(
+            0,
+            "workout_detail",
+            "workout_detail:1700000000:run.gps",
+            &payload,
+        )
+        .unwrap();
+        let selection = ExportSelection {
+            scope: Some(ExportScope::Workout {
+                workout_id: id.into(),
+            }),
+            start_date: None,
+            end_date: None,
+            data_types: vec!["workouts".into()],
+            detail: ExportDetail::Full,
+        };
+        let (encoded, _) = db.build_ai_export(&selection).unwrap();
+        let (files, _) = to_fit(&serde_json::from_str(&encoded).unwrap()).unwrap();
+        assert_eq!(files.len(), 1);
+        let fit = decode(&files[0].1);
+        let powers: Vec<_> = messages_of(&fit, typedef::MesgNum::RECORD)
+            .iter()
+            .map(|record| int_of(record, mesgdef::Record::POWER))
+            .collect();
+        assert_eq!(powers, vec![Some(200), Some(250), Some(0), Some(300)]);
+    }
+
     /// 没有 splits 的运动也必须有 lap，且 `num_laps >= 1`。
     ///
     /// 室内运动（跑步机、划船机、瑜伽、自由训练）和距离不足 1 km 的户外运动，

--- a/src/views/WorkoutDetail.vue
+++ b/src/views/WorkoutDetail.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue';
+import { open as showOpenDialog } from '@tauri-apps/plugin-dialog';
 import { RouterLink, useRoute } from 'vue-router';
 import { VChart } from '../lib/echartsSetup';
 import DesignIcon, { type DesignIconName } from '../components/DesignIcon.vue';
@@ -145,9 +146,12 @@ const messages = defineMessages(
 
     exportAria: '导出与分享',
     exportTitle: '导出与分享',
-    exportSub: '复制本地解码后的结构化数据，不访问地图服务。',
+    exportSub: '复制 JSON、CSV、GPX，或选择文件夹保存这条运动的 FIT 文件。',
     exportFormatAria: '导出格式',
     exportGo: (format: string) => `复制 ${format} 数据`,
+    saveFit: '保存 FIT 文件',
+    savedFit: 'FIT 文件已保存',
+    exportFailed: '导出失败',
 
     handoffAria: '交给 AI',
     handoffTitle: '交给 AI',
@@ -281,9 +285,12 @@ Answer in Markdown.`,
 
     exportAria: 'Export and share',
     exportTitle: 'Export and share',
-    exportSub: 'Copy the locally decoded structured data. No map service is contacted.',
+    exportSub: 'Copy JSON, CSV or GPX, or choose a folder to save this workout as FIT.',
     exportFormatAria: 'Export format',
     exportGo: (format: string) => `Copy ${format} data`,
+    saveFit: 'Save FIT file',
+    savedFit: 'FIT file saved',
+    exportFailed: 'Export failed',
 
     handoffAria: 'Hand to AI',
     handoffTitle: 'Hand to AI',
@@ -344,7 +351,8 @@ const loading = ref(true);
 const error = ref<string | null>(null);
 const actionError = ref<string | null>(null);
 const exportedNote = ref<string | null>(null);
-const activeFormat = ref<'json' | 'csv' | 'gpx'>('json');
+const activeFormat = ref<'json' | 'csv' | 'gpx' | 'fit'>('json');
+const exportBusy = ref(false);
 const workoutId = computed(() => String(route.params.workoutId || ''));
 const displayType = computed(() => workout.value ? workoutDisplayType(workout.value) : 'unknown');
 const insight = ref<WorkoutInsight | null>(null);
@@ -960,13 +968,26 @@ const changeWorkoutOverride = async (value: string | number) => {
 };
 
 const exportRecord = async () => {
-  if (!workout.value) return;
+  if (!workout.value || exportBusy.value) return;
+  const exportWorkoutId = workout.value.workout_id;
   actionError.value = null;
   exportedNote.value = null;
+  exportBusy.value = true;
   try {
+    if (activeFormat.value === 'fit') {
+      const path = await showOpenDialog({ title: t.value.saveFit, directory: true, multiple: false });
+      if (!path || typeof path !== 'string') return;
+      await tauriApi.saveFitExport({
+        scope: { kind: 'workout', workoutId: exportWorkoutId },
+        dataTypes: ['workouts'],
+        detail: 'full',
+      }, path);
+      exportedNote.value = t.value.savedFit;
+      return;
+    }
     const csvCell = (value: unknown): string => `"${String(value ?? '').replace(/"/g, '""')}"`;
     const csv = () => {
-      const fields: Array<keyof WorkoutSeriesSample> = ['timestamp', 'heart_rate', 'speed', 'pace', 'cadence', 'stride_cm', 'altitude_m'];
+      const fields: Array<keyof WorkoutSeriesSample> = ['timestamp', 'heart_rate', 'speed', 'pace', 'cadence', 'stride_cm', 'altitude_m', 'power_watts', 'ground_contact_ms', 'vertical_oscillation_mm', 'vertical_ratio_pct', 'equivalent_pace_s_per_km'];
       return [fields.join(','), ...(series.value?.samples ?? []).map((sample) => fields.map((field) => csvCell(sample[field])).join(','))].join('\r\n');
     };
     const xmlEscape = (value: unknown): string => String(value ?? '').replace(/[&<>"']/g, (character) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&apos;' })[character] ?? character);
@@ -976,7 +997,8 @@ const exportRecord = async () => {
       : activeFormat.value === 'csv' ? csv() : gpx();
     await navigator.clipboard.writeText(payload);
     exportedNote.value = t.value.copied(activeFormat.value.toUpperCase());
-  } catch { actionError.value = t.value.copyFailed; }
+  } catch (cause) { actionError.value = toUserMessage(cause, t.value.exportFailed); }
+  finally { exportBusy.value = false; }
 };
 
 onMounted(() => {
@@ -1129,8 +1151,8 @@ watch([dataRevision, workoutId], () => void loadDetail());
           <section class="surface-card side-card" :aria-label="t.exportAria">
             <div class="section-head compact"><span class="section-icon export-tone"><DesignIcon name="document" :size="32" /></span><div><p class="section-eyebrow">EXPORT</p><h2>{{ t.exportTitle }}</h2></div></div>
             <p class="card-sub">{{ t.exportSub }}</p>
-            <div class="format-row" role="radiogroup" :aria-label="t.exportFormatAria"><button v-for="format in (['json', 'csv', 'gpx'] as const)" :key="format" type="button" role="radio" :aria-checked="activeFormat === format" :class="['format-pill', { 'is-on': activeFormat === format }]" @click="activeFormat = format">{{ format === 'gpx' ? 'GPX' : format.toUpperCase() }}</button></div>
-            <button class="export-go" type="button" @click="exportRecord"><DesignIcon name="cloud-output" :size="27" />{{ t.exportGo(activeFormat.toUpperCase()) }}</button>
+            <div class="format-row" role="radiogroup" :aria-label="t.exportFormatAria"><button v-for="format in (['json', 'csv', 'gpx', 'fit'] as const)" :key="format" type="button" role="radio" :disabled="exportBusy || (format === 'fit' && !isTauri())" :aria-checked="activeFormat === format" :class="['format-pill', { 'is-on': activeFormat === format }]" @click="activeFormat = format">{{ format.toUpperCase() }}</button></div>
+            <button class="export-go" type="button" :disabled="exportBusy" @click="exportRecord"><DesignIcon name="cloud-output" :size="27" />{{ activeFormat === 'fit' ? t.saveFit : t.exportGo(activeFormat.toUpperCase()) }}</button>
             <p v-if="exportedNote" class="action-note ok" role="status"><Icon name="circle-check" :size="13" />{{ exportedNote }}</p><p v-if="actionError" class="action-note bad" role="alert"><Icon name="warning" :size="13" />{{ actionError }}</p>
           </section>
 


### PR DESCRIPTION
运动详情页原来只能复制 JSON/CSV/GPX，即使后台已经支持 FIT，也没有单条运动的保存入口。现在可以在详情页选择 FIT，选定文件夹后只导出当前运动；取消不写文件，导出期间防止重复操作，并显示真实后端错误。同时补齐详情页 CSV 遗漏的功率、触地时间、垂直振幅、垂直比和等效配速列。

关联反馈：[#28 评论](https://github.com/lingcang728/ZeppBridge/issues/28#issuecomment-5588711932)。新增原始 power_meter → 数据库 → 单条导出 → FIT 编解码回归，验证普通功率、零功率和空时间差均保留。

本 PR **没有完成全部反馈的修复**：

- #24 是越野跑被识别为游泳，500 m 爬升可能是真实跑步数据，不应删除海拔。缺少反馈记录的云端原始类型码，未冒用手表协议编号改映射。
- 潜水曲线缺失：现有解码模型确实没有深度、水温、NDL，但没有潜水原始载荷，无法确认云端字段、单位和时间编码；没有伪造深度或 NDL。
- 评论里的 FIT 功率缺失没有复现。本机功率链路正常，不声称该间歇问题已修复。

详细证据和所需样本见 `docs/evidence/workout-export-investigation-2026-09-09.md`。这些问题不随本 PR 自动关闭。

验证：前端构建、109 项 Vitest、Rust workspace 测试、i18n、文档链接和 diff 检查通过。Tauri 正式构建的 Windows EXE 在隔离数据库副本上验证：FIT 入口正常显示，真实后端导出 1 个 FIT，独立 fitdecode 解码的 122 个功率值与 SQLite 一致；详情页 CSV 的 122 行功率也一致。FIT 后端通过 IPC 直接调用，原生文件夹选择器未自动化验收；CSV 剪贴板写入由测试捕获。日常 release EXE 和数据没有被替换。
