### PR TITLE
fix(workouts): recognize trail running and repair code 7 history

### DIFF
--- a/src-tauri/crates/core/src/export_fit.rs
+++ b/src-tauri/crates/core/src/export_fit.rs
@@ -1397,6 +1397,36 @@ mod tests {
     }
 
     #[test]
+    fn issue_24_cloud_trail_run_exports_as_trail_in_json_gpx_and_fit() {
+        let workouts = crate::normalizer::Normalizer::normalize_workouts(&json!({"data": [{
+            "trackid": 1_700_000_000i64, "end_time": 1_700_000_600i64, "type": 7
+        }]}))
+        .unwrap();
+        let mut workout = serde_json::to_value(&workouts[0]).unwrap();
+        assert_eq!(workout["workout_type"], "trail_running");
+        workout["route"] = json!([{
+            "timestamp": "2023-11-14T22:13:20Z", "latitude": 0.0, "longitude": 0.0
+        }]);
+        let export = export_with(json!({"workouts": [workout]}));
+        let (gpx, points) = crate::export_formats::to_gpx(&export).unwrap();
+        assert_eq!(points, 1);
+        assert!(gpx.contains("<type>trail_running</type>"));
+        assert!(!gpx.contains("swimming"));
+        let (files, _) = to_fit(&export).unwrap();
+        assert!(files[0].0.ends_with("-trail-running.fit"));
+        let fit = decode(&files[0].1);
+        let session = messages_of(&fit, typedef::MesgNum::SESSION);
+        assert_eq!(
+            int_of(session[0], mesgdef::Session::SPORT),
+            Some(i64::from(typedef::Sport::RUNNING.0))
+        );
+        assert_eq!(
+            int_of(session[0], mesgdef::Session::SUB_SPORT),
+            Some(i64::from(typedef::SubSport::TRAIL.0))
+        );
+    }
+
+    #[test]
     fn writes_one_file_per_workout_and_decodes_back() {
         let (files, records) = to_fit(&running_export()).unwrap();
 

--- a/src-tauri/crates/core/src/normalizer/mod.rs
+++ b/src-tauri/crates/core/src/normalizer/mod.rs
@@ -2719,6 +2719,40 @@ mod tests {
     }
 
     #[test]
+    fn issue_24_cloud_code_7_is_trail_running() {
+        // Reconstructed cloud-shaped input from the public screenshot and
+        // exported summary, not a claim that the full raw response was supplied.
+        // The original workout ID, location and health measurements are omitted.
+        for field in ["type", "sport_mode"] {
+            for code in [json!(7), json!("7")] {
+                let mut item = json!({
+                    "trackid": 1_700_000_000i64,
+                    "end_time": 1_700_000_600i64
+                });
+                item[field] = code;
+                let workouts = Normalizer::normalize_workouts_with_sport(
+                    &json!({"data": {"summary": [item]}}),
+                    Some("run"),
+                )
+                .unwrap();
+                let workout = &workouts[0];
+                assert_eq!(workout.zepp_type, Some(7));
+                assert_eq!(workout.normalized_type, "trail_running");
+                assert_eq!(workout.workout_type, "trail_running");
+                assert_eq!(workout.effective_type, "trail_running");
+                assert_eq!(workout.type_source, "numeric_mapped");
+                assert!(workout.user_override.is_none());
+            }
+        }
+        let swims = Normalizer::normalize_workouts(&json!({"data": [
+            {"trackid": 1_700_001_000i64, "end_time": 1_700_001_600i64, "type": 14},
+            {"trackid": 1_700_002_000i64, "end_time": 1_700_002_600i64, "sport_name": "Open Water Swimming"}
+        ]})).unwrap();
+        assert_eq!(swims[0].normalized_type, "pool_swimming");
+        assert_eq!(swims[1].normalized_type, "open_water_swimming");
+    }
+
+    #[test]
     fn code_225_is_normalized_as_rucking_with_numeric_evidence() {
         let result = Normalizer::normalize_workouts(&json!({
             "data": { "summary": [{

--- a/src-tauri/crates/core/src/sport_catalog.rs
+++ b/src-tauri/crates/core/src/sport_catalog.rs
@@ -128,22 +128,26 @@ mod tests {
         assert!(is_known_key("elliptical"));
     }
 
-    /// 越野跑能被选，但不会被自动派上。
-    ///
-    /// 有用户报告越野跑被显示成公开水域游泳，并且在纠正列表里找不到越野跑
-    /// （反馈 af3fba3c）。后半句是确定的缺口，补上；前半句不是——那条报告里
-    /// 没有编号信息（未知编号为空、冲突数为 0），而 Gadgetbridge 的 Zepp OS
-    /// 表里 7 确实是公开水域游泳。云端编号是不是另一套，手上没有第二个来源
-    /// 能证实，所以 code 7 的映射一个字都没改。
+    /// Issue #24 supplies code 7, matching Zepp/ZeppBridge screenshots and
+    /// a Zepp GPX labelled Trail running. Cloud history codes are not the
+    /// Zepp OS device-protocol enum. Do not guess a replacement swimming code.
     #[test]
-    fn trail_running_is_selectable_but_never_auto_assigned() {
+    fn cloud_code_7_is_trail_running_and_swimming_remains_selectable() {
+        assert_eq!(resolve(7), Some("trail_running"));
         assert!(is_known_key("trail_running"));
-        assert!(
-            !entries().values().any(|key| key == "trail_running"),
-            "没有编号该派给越野跑——凭空编一个会把一批历史记录改错"
-        );
-        // 反过来也要成立：code 7 仍然是公开水域游泳，没有被顺手改掉。
-        assert_eq!(resolve(7), Some("open_water_swimming"));
+        assert!(is_known_key("open_water_swimming"));
+        assert_eq!(resolve(14), Some("pool_swimming"));
+    }
+
+    #[test]
+    fn numeric_codes_are_unique() {
+        let document: CatalogDocument = serde_json::from_str(CATALOG_JSON).unwrap();
+        let mut codes = HashSet::new();
+        for entry in document.sports {
+            if let Some(code) = entry.code {
+                assert!(codes.insert(code), "duplicate cloud code {code}");
+            }
+        }
     }
 
     #[test]

--- a/src-tauri/crates/core/src/storage/migrations.rs
+++ b/src-tauri/crates/core/src/storage/migrations.rs
@@ -711,6 +711,23 @@ impl Database {
             "INSERT OR IGNORE INTO schema_migrations(version, applied_at) VALUES(21, ?1)",
             [Utc::now().to_rfc3339()],
         )?;
+        // Cloud code 7 is trail running (issue #24), not the device-protocol
+        // open-water code. Repair stored interpretations even when retention
+        // has removed their raw payloads. Overrides, metrics and provenance
+        // stay intact; explicitly named swimming records are not affected.
+        if version < 22 {
+            self.conn.execute_batch(
+                "UPDATE workouts SET workout_type = 'trail_running'
+                 WHERE zepp_type = 7
+                   AND workout_type = 'open_water_swimming'
+                   AND workout_type_source = 'numeric_mapped';",
+            )?;
+        }
+        self.conn.execute_batch("PRAGMA user_version = 22;")?;
+        self.conn.execute(
+            "INSERT OR IGNORE INTO schema_migrations(version, applied_at) VALUES(22, ?1)",
+            [Utc::now().to_rfc3339()],
+        )?;
         // Earlier migrations are intentionally idempotent and still stamp
         // their historical versions on every launch, so the current schema
         // marker is restored only after all of them have run.

--- a/src-tauri/crates/core/src/storage/mod.rs
+++ b/src-tauri/crates/core/src/storage/mod.rs
@@ -9,7 +9,7 @@ use std::path::{Path, PathBuf};
 
 /// 当前 SQLite schema 版本（`PRAGMA user_version`）。加新版本只能追加迁移
 /// 步骤，不要改已有 DDL。
-pub const CURRENT_SCHEMA_VERSION: i64 = 21;
+pub const CURRENT_SCHEMA_VERSION: i64 = 22;
 /// 写进备份 manifest 的应用版本。Core 是独立 crate，用它自己的包版本。
 const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -43,11 +43,10 @@ pub const EXPORT_DATA_TYPES: [&str; 17] = [
 /// `raw_records` 重新跑一遍。不动它，新加的编号只对以后同步来的记录生效，
 /// 已经存成 `unknown:211` 的那 199 条记录会永远挂着——而报这个问题的人恰恰
 /// 是因为历史记录才来报的。
-pub const NORMALIZER_REVISION: &str = "zepp-normalizer-2026-09-v23-rucking";
-/// 上一版的修订号。从它升上来时只重放这几条流。
+pub const NORMALIZER_REVISION: &str = "zepp-normalizer-2026-09-v24-trail-running";
+/// 较早公开版本的修订号。从它升上来时仍需重放这几条流。
 ///
-/// v21 是上一个公开发布版本；v22 的圈解析和 v23 的 Rucking 映射都要在
-/// 这次升级中补到历史数据里。
+/// v21 还没有 v22 的圈解析和 v23 的 Rucking 映射；跳版本升级时要一并补齐。
 const PREVIOUS_RELEASE_NORMALIZER_REVISION: &str = "zepp-normalizer-2026-09-v21-elliptical";
 /// 从上一版升上来时要重放的流。**改归一化规则时必须一起看这里**：漏掉一条
 /// 流，那条流的历史记录就永远停在旧规则上，而升级看起来是成功的。
@@ -2160,10 +2159,13 @@ impl Database {
         if stored.as_deref() == Some(NORMALIZER_REVISION) {
             return Ok(None);
         }
-        // 从公开 v21 升到 v23 时重放这一版涉及的 workout_detail 和 workouts。
+        // v23 already decoded laps; only the cloud workout catalog changed in v24.
+        // 从公开 v21 升级时仍需补齐 workout_detail 和 workouts。
         // 其他修订号（包括未发布的 v22）仍走整库重放，避免跳过中间版本带来的归一化变化。
         let streams: Vec<String> =
-            if stored.as_deref() == Some(PREVIOUS_RELEASE_NORMALIZER_REVISION) {
+            if stored.as_deref() == Some("zepp-normalizer-2026-09-v23-rucking") {
+                vec!["workouts".to_string()]
+            } else if stored.as_deref() == Some(PREVIOUS_RELEASE_NORMALIZER_REVISION) {
                 PREVIOUS_RELEASE_REPLAY_STREAMS
                     .iter()
                     .map(|stream| (*stream).to_string())
@@ -7044,6 +7046,126 @@ mod tests {
             db.get_recent_workouts(10).unwrap()[0].workout_type,
             "road_cycling"
         );
+    }
+
+    #[test]
+    fn issue_24_migration_repairs_history_without_raw_and_preserves_overrides() {
+        let db = Database::in_memory().unwrap();
+        for (id, code, kind, source) in [
+            ("trail", Some(7), "open_water_swimming", "numeric_mapped"),
+            ("override", Some(7), "open_water_swimming", "numeric_mapped"),
+            (
+                "explicit-swim",
+                Some(7),
+                "open_water_swimming",
+                "string_field",
+            ),
+            ("pool", Some(14), "pool_swimming", "numeric_mapped"),
+            ("no-code", None, "open_water_swimming", "string_field"),
+        ] {
+            let mut workout = workout_with_type(code, kind, source);
+            workout.workout_id = id.into();
+            db.insert_workout(&workout).unwrap();
+        }
+        db.set_workout_type_override("override", Some("open_water_swimming"))
+            .unwrap();
+        assert_eq!(db.raw_record_count().unwrap(), 0);
+        db.conn
+            .execute_batch(
+                "PRAGMA user_version = 21; DELETE FROM schema_migrations WHERE version = 22;",
+            )
+            .unwrap();
+        db.migrate().unwrap();
+        let trail = db.get_workout_detail("trail").unwrap().unwrap();
+        assert_eq!(trail.normalized_type, "trail_running");
+        assert_eq!(trail.effective_type, "trail_running");
+        assert_eq!(trail.zepp_type, Some(7));
+        assert_eq!(trail.calories, Some(100));
+        assert_eq!(trail.start_time, ts());
+        assert_eq!(trail.synced_at, Some(ts() + chrono::Duration::hours(1)));
+        let corrected = db.get_workout_detail("override").unwrap().unwrap();
+        assert_eq!(corrected.normalized_type, "trail_running");
+        assert_eq!(corrected.effective_type, "open_water_swimming");
+        for id in ["explicit-swim", "no-code"] {
+            assert_eq!(
+                db.get_workout_detail(id).unwrap().unwrap().normalized_type,
+                "open_water_swimming"
+            );
+        }
+        assert_eq!(
+            db.get_workout_detail("pool")
+                .unwrap()
+                .unwrap()
+                .normalized_type,
+            "pool_swimming"
+        );
+        let before =
+            parsed_export(&db, &["workouts"], ExportDetail::Full)["data"]["workouts"].clone();
+        db.migrate().unwrap();
+        assert_eq!(
+            parsed_export(&db, &["workouts"], ExportDetail::Full)["data"]["workouts"],
+            before
+        );
+        let exported = before
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|w| w["workout_id"] == "trail")
+            .unwrap();
+        assert_eq!(exported["workout_type"], "trail_running");
+        assert_eq!(exported["normalized_type"], "trail_running");
+        assert_eq!(exported["effective_type"], "trail_running");
+    }
+
+    #[test]
+    fn issue_24_v23_replay_repairs_code_7_without_losing_corrections() {
+        let db = Database::in_memory().unwrap();
+        db.insert_workout(&workout_with_type(
+            Some(7),
+            "open_water_swimming",
+            "numeric_mapped",
+        ))
+        .unwrap();
+        db.set_workout_type_override("same-workout", Some("hiking"))
+            .unwrap();
+        let payload = serde_json::json!({"data": [{
+            "workout_id": "same-workout", "start_time": 1_700_000_000i64,
+            "end_time": 1_700_000_600i64, "type": 7
+        }]});
+        db.insert_raw_record(&RawRecord {
+            stream: "workouts".into(),
+            source_key: "issue-24".into(),
+            source_scope: SourceScope::Device,
+            device_id: None,
+            start_utc: ts(),
+            end_utc: None,
+            payload,
+            capability: CapabilityStatus::Verified,
+        })
+        .unwrap();
+        db.conn.execute(
+            "INSERT INTO app_meta(key, value, updated_at) VALUES('normalizer_revision', ?1, ?2)",
+            params!["zepp-normalizer-2026-09-v23-rucking", ts().to_rfc3339()],
+        ).unwrap();
+        assert_eq!(
+            db.pending_replay_plan().unwrap().unwrap().streams,
+            vec!["workouts"]
+        );
+        db.reprocess_raw_records_if_needed().unwrap().unwrap();
+        let stored = db.get_workout_detail("same-workout").unwrap().unwrap();
+        assert_eq!(stored.normalized_type, "trail_running");
+        assert_eq!(stored.zepp_type, Some(7));
+        assert_eq!(stored.user_override.as_deref(), Some("hiking"));
+        assert_eq!(stored.effective_type, "hiking");
+        db.set_workout_type_override("same-workout", None).unwrap();
+        assert_eq!(
+            db.get_workout_detail("same-workout")
+                .unwrap()
+                .unwrap()
+                .effective_type,
+            "trail_running"
+        );
+        assert!(db.reprocess_raw_records_if_needed().unwrap().is_none());
     }
 
     /// 升级之后，旧的 `unknown:211` 会被重新认成公路骑行。

--- a/src/assets/workouts/catalog.json
+++ b/src/assets/workouts/catalog.json
@@ -1,6 +1,6 @@
 {
-  "version": 6,
-  "checked_at": "2026-09-04",
+  "version": 7,
+  "checked_at": "2026-09-10",
   "notes": "Zepp cloud-history observations take precedence where its numeric types differ from the Zepp OS device protocol. Extended identifiers are cross-checked against Gadgetbridge's Zepp OS catalog and user-supplied Zepp App screenshots. A null code means the sport is offered as a manual correction but no Zepp numeric type is known to produce it -- never guess one in to make the entry look complete.",
   "sports": [
     { "code": 1, "key": "run", "label_zh": "户外跑步", "label_en": "Outdoor Running", "source": "cloud_verified" },
@@ -9,7 +9,7 @@
     { "code": 4, "key": "ride", "label_zh": "户外骑行", "label_en": "Outdoor Cycling", "source": "zepp_os_compatible" },
     { "code": 5, "key": "free_training", "label_zh": "自由训练", "label_en": "Free Training", "source": "zepp_os_compatible" },
     { "code": 6, "key": "walking", "label_zh": "健走", "label_en": "Walking", "source": "cloud_verified" },
-    { "code": 7, "key": "open_water_swimming", "label_zh": "公开水域游泳", "label_en": "Open Water Swimming", "source": "zepp_os_compatible" },
+    { "code": 7, "key": "trail_running", "label_zh": "越野跑", "label_en": "Trail Running", "source": "cloud_verified", "evidence": "https://github.com/lingcang728/ZeppBridge/issues/24#issuecomment-5604235159" },
     { "code": 8, "key": "treadmill", "label_zh": "跑步机", "label_en": "Treadmill", "source": "cloud_reference" },
     { "code": 9, "key": "ride", "label_zh": "户外骑行", "label_en": "Outdoor Cycling", "source": "cloud_verified" },
     { "code": 10, "key": "indoor_cycling", "label_zh": "室内骑行", "label_en": "Indoor Cycling", "source": "cloud_reference" },
@@ -137,6 +137,6 @@
     { "code": 211, "key": "road_cycling", "label_zh": "公路骑行", "label_en": "Road Cycling", "source": "user_reported" },
     { "code": 223, "key": "activity", "label_zh": "AI 识别活动", "label_en": "AI-Detected Activity", "source": "cloud_verified" },
     { "code": 225, "key": "rucking", "label_zh": "负重徒步", "label_en": "Rucking", "source": "user_reported" },
-    { "code": null, "key": "trail_running", "label_zh": "越野跑", "label_en": "Trail Running", "source": "correction_only" }
+    { "code": null, "key": "open_water_swimming", "label_zh": "公开水域游泳", "label_en": "Open Water Swimming", "source": "correction_only" }
   ]
 }

--- a/src/lib/__tests__/workouts.test.ts
+++ b/src/lib/__tests__/workouts.test.ts
@@ -26,6 +26,24 @@ const base = (overrides: Partial<Workout> = {}): Workout =>
   }) as Workout;
 
 describe('哪些运动可以出现在界面上', () => {
+  it('shows automatically detected trail running in both languages', () => {
+    const trail = base({
+      zepp_type: 7,
+      workout_type: 'trail_running',
+      normalized_type: 'trail_running',
+      effective_type: 'trail_running',
+      type_source: 'numeric_mapped',
+    });
+    setLocale('en');
+    expect(workoutDisplayLabel(trail)).toBe('Trail Running');
+    setLocale('zh');
+    expect(workoutDisplayLabel(trail)).toBe('越野跑');
+    setLocale('en');
+    expect(workoutDisplayLabel(base({
+      ...trail, user_override: 'open_water_swimming', effective_type: 'open_water_swimming',
+    }))).toBe('Open Water Swimming');
+  });
+
   it('解码出来的空壳不算一条运动', () => {
     // 有 id 有时间但一个指标都没有的记录，多半是解码器的空壳。
     // 让它变成列表行，用户会以为那天真的练过。


### PR DESCRIPTION
Fixes #24.

Zepp cloud-history code `7` was mapped using the Zepp OS device-protocol meaning, `open_water_swimming`. It now normalizes to `trail_running`, so the activity label and JSON, GPX and FIT exports reflect trail running automatically.

The evidence is [visualcurrent's September 9 comment](https://github.com/lingcang728/ZeppBridge/issues/24#issuecomment-5604235159): the ZeppBridge screenshot shows raw code 7 and no correction; the matching Zepp screenshot identifies an Amazfit Balance trail run. The supplied JSON confirms `numeric_mapped`, and the official Zepp GPX identifies the same activity as Trail running. Both screenshots and the export snippets were checked. Tests reconstruct minimal cloud-shaped inputs from that evidence; the comment did not include a complete raw cloud response. No personal identifiers or GPS coordinates from the report are committed.

- Update the shared catalog with the evidence link. Keep Open Water Swimming available for explicit names and manual corrections without inventing an unverified replacement cloud code; preserve pool-swimming code 14.
- Add schema migration 22 to repair existing `numeric_mapped` code-7 swimming rows, including libraries whose raw payloads have expired. Only the stored interpretation changes; user overrides, metrics, routes and sync timestamps remain intact. Existing migration locking, transaction and pre-upgrade backup apply.
- Advance the normalizer to v24. Upgrade from v23 replays workout summaries only; older upgrade paths still include their required streams.
- Cover numeric/string code inputs, swimming non-regression, historical repair without raw data, replay/override preservation, English/Chinese labels, and JSON/GPX/FIT output (including decoding FIT sport/sub-sport as Running/Trail).

Validation: workspace Rust tests (389 passed, 1 pre-existing ignored), Clippy with warnings denied, rustfmt, frontend build/tests (110 passed), Functions tests (33 passed), version/docs/i18n checks and bundle budget. Also ran the compiled Windows CLI against an isolated on-disk v21 library with no raw payloads: verified migration, exact preservation of all other workout columns, routes, the original v21 backup, JSON/GPX/FIT exports and idempotent replay.

Reporter-device retesting remains for the eventual release. Existing export files must be exported again. This PR is ready for the maintainer to review and merge; no release is published here.
