### PR TITLE
fix: triage device feedback and distinguish workout moving time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ## Unreleased / 未发布
 
+- **Paused workouts show moving and paused time separately.** Workout details show moving pace alongside pace including pauses; FIT session, lap and activity timer totals exclude recorded pauses. Overlapping intervals count once and intervals are clipped to the activity or lap.
+- **含暂停的运动可分别查看运动用时、暂停用时、运动配速和含暂停配速。** FIT 的运动、圈与活动计时同步扣除已记录的暂停，重复、重叠与越界区间不会重复扣时。
+- Added seven evidence-backed deviceSource mappings for T-Rex 3 Pro, Balance 3, Balance 2 XT, Active, Active 2 and Cheetah 2 Ultra. Refresh the device list to update a previously cached unknown model. User model corrections retain priority.
+- 新增 7 个有反馈证据的设备编号映射，覆盖 T-Rex 3 Pro、Balance 3、Balance 2 XT、Active、Active 2 与 Cheetah 2 Ultra。刷新设备列表即可更新旧的未知型号缓存；用户手动指认仍优先。
+
 - **A managed macOS login keychain no longer has to block sign-in.** macOS can explicitly select file credential storage with `ZEPPBRIDGE_CREDENTIAL_STORE=file`; a saved credential file is reused on normal launches. Keychain remains the default, and a Keychain failure never silently enables plaintext storage. See the [setup guide](docs/guides/macos-credentials.md). This also corrects the error message that incorrectly suggested HAR import or manual entry could bypass the same blocked store. Fixes [#72](https://github.com/lingcang728/ZeppBridge/issues/72).
 - **macOS 登录钥匙串受管理时，可以改用文件存储。** 用 `ZEPPBRIDGE_CREDENTIAL_STORE=file` 显式选择后，令牌保存在权限为 `0600` 的文件中，后续正常启动会继续使用。钥匙串仍为默认，访问失败不会自动降级；[操作指南](docs/guides/macos-credentials.zh-CN.md)说明了保护边界与切换方法。报错提示也已修正：HAR 导入和手填 Token 共用同一个存储，无法绕过存储故障。修复 [#72](https://github.com/lingcang728/ZeppBridge/issues/72)。
 

--- a/docs/evidence/feedback-triage-2026-09-11.md
+++ b/docs/evidence/feedback-triage-2026-09-11.md
@@ -1,0 +1,149 @@
+# Feedback triage — 2026-09-11
+
+The supplied screenshot shows seven pending reports dated September 5–6.
+The live ZeppDock/D1 snapshot contains 264 reports: 208 already resolved and
+56 new. This pass reviews those 56; no raw payload, credentials, account identity,
+health measurements or locations are included in this document.
+
+## Changes awaiting release
+
+- Workout details now separate elapsed, moving and paused time, and display both
+  moving and elapsed pace. The cloud's existing `moving_seconds` field takes
+  priority; if unavailable, recorded pauses are clipped and unioned. Missing
+  samples are never interpreted as pauses.
+- FIT session and activity timer totals prefer cloud moving time, and lap totals
+  subtract recorded pauses, with
+  average speed calculated from the corresponding timer duration. Elapsed time
+  remains distinct. Timer events remain ordered when samples fall inside a pause.
+- Seven deviceSource mappings were added to the generator and bundled catalog.
+  The same catalog is copied to ZeppDock; its previously stale copy omitted three
+  selectable entries, including Balance 2 XT and the two scales.
+
+| Source number | Catalog model | Evidence |
+| --- | --- | --- |
+| 10551553 | T-Rex 3 Pro | 8 submissions across Linux, Windows and macOS; same-session repeats counted once |
+| 10682624 | T-Rex 3 Pro | August 31 Windows and September 5 macOS reports agree |
+| 11141377 | Balance 3 | 9 submissions across Windows/macOS and several device contexts; no contrary model |
+| 10092803 | Active 2 44mm | 3 submissions, including a separate macOS device context |
+| 8323329 | Active 42mm | August 31 and September 6 submissions have different device contexts; two adjacent September 6 submissions count once |
+| 10486019 | Balance 2 XT | Linux multi-device context and separate Windows single-device context agree |
+| 9978112 | Cheetah 2 Ultra | macOS single-device and Windows multi-device contexts agree |
+
+These diagnostics intentionally contain no reporter identity. Distinct contexts
+support the admission decision but do not prove a count of unique people. No code
+is admitted solely because two adjacent submissions carry different report IDs.
+User assignments still override automatic recognition. Cached device profiles need
+a device-list refresh because older caches do not contain deviceSource.
+
+## Reviewed, without enough evidence for automatic changes
+
+- `8126720` (Cheetah Pro) has one submission.
+- `92` was assigned to Bip 6 and then GTS 2 Mini 80 seconds later. Neither a
+  unique model nor a reliable new low-band mapping is established.
+- Low source numbers, notably `102`, `104`, `200`, `209`, `254`, and all
+  `deviceType` numbers remain excluded; conflicting model assignments exist.
+- `10813699`, `8913155` and `7930112` retain contrary assignments. Repeated
+  votes and neighbouring codes do not settle those conflicts.
+- `9765121`, `11469059` and `11092224` have adjacent submissions from the same
+  apparent context; `11272451` and `10682627` have only one. All remain unmapped.
+- Unknown workout-code counts alone do not identify sports. The device assignments
+  attached to reports containing `108`, `137`, `214`, `222`, etc. do not name them.
+- Scuba report `3b88d194` confirms missing depth, water-temperature and NDL curves
+  are an unsupported path. It does not provide their cloud field names, encoding,
+  units or sentinels. Keep the request tracked; obtain a redacted dive detail and
+  the matching official export before implementing the decoder. Elevation must not
+  be reinterpreted as depth, and NDL must not be synthesized.
+- “this is not my device”, “Amazfit Neo”, and “Model 19 - Xiaomi Mi Band 3” lack
+  sufficient per-device evidence for a new automatic mapping. Existing manual
+  correction and unknown-device behaviour are retained.
+
+## Already fixed / issue disposition
+
+- Trail running reported as open-water swimming is fixed by PR #71 and included
+  in v2.2.3. Its feedback can be marked resolved.
+- [#59](https://github.com/lingcang728/ZeppBridge/issues/59): v2.2.3 contains
+  one-session and persistent Hero collapse plus a restore button; close as completed.
+- [#40](https://github.com/lingcang728/ZeppBridge/issues/40): the reporter confirmed
+  CLI authentication and Home Assistant/MQTT integration work. The original login
+  issue is completed; a future incremental MQTT integration is a separate request.
+- [#10](https://github.com/lingcang728/ZeppBridge/issues/10): the released backfill
+  loop snapshots its work queue once, so a failed chunk cannot monopolize the same
+  run. The maintainer already reported the fix; close the original issue.
+- [#62](https://github.com/lingcang728/ZeppBridge/issues/62): keep open. The reporter
+  has not supplied the requested comparison with Zepp altitude calibration disabled.
+  No calibrated elevation or offset is guessed.
+
+## Feedback status policy
+
+Move the reviewed snapshot out of `new`. Use `resolved` only for the already
+released trail-running correction, and `reviewed` for this pass's unpublished
+changes and retained evidence requests. This is an administrative triage archive,
+not a claim that every report is fixed in an installable public release.
+
+## Verification
+
+Frontend regression tests cover timing, overlapping/invalid/clipped pauses and
+missing distance. Rust regressions cover all admitted/excluded device codes and
+FIT elapsed/timer totals. The real Tauri production build is used for desktop
+verification; source-only checks are not treated as proof of the packaged UI.
+
+## Snapshot disposition ledger
+
+| Report prefix | Status | Disposition |
+| --- | --- | --- |
+| 08860e13 | reviewed | Device-source evidence admitted; remaining unknown workout codes retained |
+| fdf55bdb | reviewed | Device-source evidence admitted; remaining unknown workout codes retained |
+| f04e7ab8 | reviewed | Reviewed contribution; insufficient, conflicting, low-band or already-known device evidence |
+| 871a1a79 | reviewed | Reviewed contribution; insufficient, conflicting, low-band or already-known device evidence |
+| 253e721f | reviewed | Device-source evidence admitted; remaining unknown workout codes retained |
+| 63343156 | reviewed | Reviewed contribution; insufficient, conflicting, low-band or already-known device evidence |
+| 7373cc86 | reviewed | Reviewed contribution; insufficient, conflicting, low-band or already-known device evidence |
+| ddde4a19 | reviewed | Reviewed contribution; insufficient, conflicting, low-band or already-known device evidence |
+| e8c87f4f | reviewed | Reviewed contribution; insufficient, conflicting, low-band or already-known device evidence |
+| de2259f6 | reviewed | Reviewed contribution; insufficient, conflicting, low-band or already-known device evidence |
+| 5c28fe03 | reviewed | Device-source evidence admitted; remaining unknown workout codes retained |
+| ee1fa9c3 | reviewed | Device-source evidence admitted; remaining unknown workout codes retained |
+| 6040dc54 | reviewed | Device-source evidence admitted; remaining unknown workout codes retained |
+| bd14fa1b | reviewed | Reviewed contribution; insufficient, conflicting, low-band or already-known device evidence |
+| db0e96e7 | reviewed | Reviewed contribution; insufficient, conflicting, low-band or already-known device evidence |
+| d54f8c86 | reviewed | Reviewed contribution; insufficient, conflicting, low-band or already-known device evidence |
+| d4153868 | reviewed | Device-source evidence admitted; remaining unknown workout codes retained |
+| e02212d7 | reviewed | Wrong-device note lacks identification of the affected device |
+| 8fa3239d | reviewed | Device-source evidence admitted; remaining unknown workout codes retained |
+| ff3d3624 | reviewed | Device-source evidence admitted; remaining unknown workout codes retained |
+| e30938e6 | resolved | Trail running code 7 corrected in released v2.2.3 |
+| 545bcfb7 | reviewed | Moving time and FIT timer correction implemented; awaiting release |
+| 8189382e | reviewed | Device-source evidence admitted; remaining unknown workout codes retained |
+| cd02d353 | reviewed | Device-source evidence admitted; remaining unknown workout codes retained |
+| 84f5da66 | reviewed | Device-source evidence admitted; remaining unknown workout codes retained |
+| f5a7a2dc | reviewed | Device-source evidence admitted; remaining unknown workout codes retained |
+| 934f2d0e | reviewed | Amazfit Neo note lacks reliable per-device source evidence |
+| e4b9d804 | reviewed | Reviewed contribution; insufficient, conflicting, low-band or already-known device evidence |
+| 957cdfa8 | reviewed | Device-source evidence admitted; remaining unknown workout codes retained |
+| 3608ed9e | reviewed | Reviewed contribution; insufficient, conflicting, low-band or already-known device evidence |
+| 471a3ead | reviewed | Reviewed contribution; insufficient, conflicting, low-band or already-known device evidence |
+| 7edd13e8 | reviewed | Reviewed contribution; insufficient, conflicting, low-band or already-known device evidence |
+| bc51dd49 | reviewed | Reviewed contribution; insufficient, conflicting, low-band or already-known device evidence |
+| a7de77f4 | reviewed | Reviewed contribution; insufficient, conflicting, low-band or already-known device evidence |
+| 29f6ba85 | reviewed | Device-source evidence admitted; remaining unknown workout codes retained |
+| ec9ba28f | reviewed | Reviewed contribution; insufficient, conflicting, low-band or already-known device evidence |
+| 83ba5e73 | reviewed | Model 19 / Mi Band 3 note lacks a matching per-device source hint |
+| 18fd1ab4 | reviewed | Reviewed contribution; insufficient, conflicting, low-band or already-known device evidence |
+| 3d03b941 | reviewed | Reviewed contribution; insufficient, conflicting, low-band or already-known device evidence |
+| 4166bef0 | reviewed | Device-source evidence admitted; remaining unknown workout codes retained |
+| 4d48b7ec | reviewed | Device-source evidence admitted; remaining unknown workout codes retained |
+| c5d7815c | reviewed | Device-source evidence admitted; remaining unknown workout codes retained |
+| 3cb9a120 | reviewed | Device-source evidence admitted; remaining unknown workout codes retained |
+| 3b88d194 | reviewed | Dive curves require raw encoding and official export evidence |
+| 85266e96 | reviewed | Reviewed contribution; insufficient, conflicting, low-band or already-known device evidence |
+| ea84c1d7 | reviewed | Reviewed contribution; insufficient, conflicting, low-band or already-known device evidence |
+| bd788c0c | reviewed | Reviewed contribution; insufficient, conflicting, low-band or already-known device evidence |
+| 3454a4a9 | reviewed | Reviewed contribution; insufficient, conflicting, low-band or already-known device evidence |
+| 8f11480e | reviewed | Reviewed contribution; insufficient, conflicting, low-band or already-known device evidence |
+| ab19c05e | reviewed | Reviewed contribution; insufficient, conflicting, low-band or already-known device evidence |
+| f8113a26 | reviewed | Reviewed contribution; insufficient, conflicting, low-band or already-known device evidence |
+| ef71fa1d | reviewed | Reviewed contribution; insufficient, conflicting, low-band or already-known device evidence |
+| b05c9707 | reviewed | Reviewed contribution; insufficient, conflicting, low-band or already-known device evidence |
+| 5d4974ea | reviewed | Reviewed contribution; insufficient, conflicting, low-band or already-known device evidence |
+| 6ffd664b | reviewed | Device-source evidence admitted; remaining unknown workout codes retained |
+| 570c85f2 | reviewed | Reviewed contribution; insufficient, conflicting, low-band or already-known device evidence |

--- a/docs/reference/device-catalog.md
+++ b/docs/reference/device-catalog.md
@@ -2,14 +2,19 @@
 
 `src/assets/devices/catalog.json` is a maintenance-time snapshot; the model
 list was checked on 2026-08-15 and `device_source_codes` was added on
-2026-09-01. It contains 52 total entries, of which 51 are `active`/`supported`,
-covering 50 canonical model keys. The 48-card baseline is the supplied official
+2026-09-01 and extended on 2026-09-11. It contains 55 total entries, of which 54 are `active`/`supported`,
+covering 52 canonical model keys. The 48-card baseline is the supplied official
 Amazfit Japan store capture set (`design_picture/Product`, 12 rows × 4 cards);
 the duplicate GTR 4 black colour card shares the canonical GTR 4 material and
 is not counted as a second model. Three active official extras (Helio Strap Pro,
 Helio Core, and Helio Ring) bring the canonical count above 48. Helio Armband
 remains listed for provenance as `status=accessory` and `supported=false`, so it
 is not counted as a connectable device.
+
+Balance 2 XT, Amazfit Smart Scale and Mi Body Composition Scale 2 are also
+selectable. Their product art is unavailable, so they use the existing placeholder.
+The seven additional source numbers and rejected evidence are recorded in
+[the September 11 triage](../evidence/feedback-triage-2026-09-11.md).
 
 The card-by-card mapping is kept in
 [`device-catalog-audit.json`](./device-catalog-audit.json) and
@@ -117,6 +122,12 @@ the repository does not install a second copy of either tool.
 py -3 scripts/assets/build-device-catalog.py
 py -3 scripts/assets/verify-device-assets.py
 ```
+
+For source-number changes alone, use `--catalog-only`. It updates the catalog
+from `DEVICE_SOURCE_CODES` while retaining the existing art, hashes and provenance;
+it requires only Python's standard library. Device-source matching runs when the
+device list is refreshed, independently of the health-record normalizer revision.
+Existing caches do not retain the source number, so they require that refresh.
 
 Use `--refresh-official` only when deliberately refreshing the four official
 CDN extras. The verifier checks the exact catalog/asset counts, card audit

--- a/scripts/assets/build-device-catalog.py
+++ b/scripts/assets/build-device-catalog.py
@@ -18,11 +18,6 @@ import urllib.request
 from pathlib import Path
 from typing import Any
 
-import cv2
-import numpy as np
-from PIL import Image, ImageOps
-
-
 ROOT = Path(__file__).resolve().parents[2]
 SCREENSHOT_DIR = ROOT / "design_picture" / "Product"
 ASSET_DIR = ROOT / "src" / "assets" / "devices"
@@ -68,23 +63,25 @@ DEVICE_SOURCE_CODES: dict[str, list[int]] = {
     # 报告里指认成 Helio Strap 的那 2 份，同一份报告里还指认了另一块表——是
     # 在设备选择器里挑错了那一台，不是这个数字有歧义。
     "amazfit-balance-2": [9568512, 9568513, 9568515, 10486017],
-    "amazfit-active-2-44mm": [10092800, 10092801, 10092807],
+    "amazfit-active-2-44mm": [10092800, 10092801, 10092803, 10092807],
+    "amazfit-active-42mm": [8323329],
+    "amazfit-balance-2-xt": [10486019],
     "amazfit-active-2-square": [10223873],
     "amazfit-bip-6": [10158337],
-    "amazfit-cheetah-2-ultra": [9978113],
+    "amazfit-cheetah-2-ultra": [9978112, 9978113],
     # 10289411 同样是人工裁决：17 份里 14 份 Helio Strap，相邻的 10289410
     # 三份一致，3 份异议同样来自「一个账号两块表、挑错了」。
     "amazfit-helio-strap": [10289410, 10289411],
     # 10551555 是 2026-09-02 那批新增的：2 份报告一致，无异议，且和已经收了
     # 的 10551552 同族。10682625 是 2026-09-03 这一批（反馈库 183 行）：同样
     # 2 份一致、零异议，两份分别来自 v1.1.1 和 v1.1.5，不是同一次提交的重复。
-    # 相邻的 10682624 仍然只有一份，继续等。
-    "amazfit-t-rex-3-pro-48-44mm": [10551552, 10551555, 10682625],
+    # 2026-09-11 又收录 10551553 和 10682624，见本轮反馈裁决记录。
+    "amazfit-t-rex-3-pro-48-44mm": [10551552, 10551553, 10551555, 10682624, 10682625],
     # Helio Ring 的第一个编号：2 份独立报告一致，其中一份来自 2.0.0。
     "amazfit-helio-ring": [8651008],
     # 11145472 是 2026-09-01 那批新增的：3 份报告一致指向 Balance 3，和已经
     # 收了的相邻编号 11141379 同族。
-    "amazfit-balance-3": [11141379, 11145472],
+    "amazfit-balance-3": [11141377, 11141379, 11145472],
     "amazfit-gtr-4-46mm": [7930113],
     # 下面两个上一轮还只有一份报告，这一轮凑够了独立第二份：
     #   10944769 -> Active 3 Premium（3 份，无异议）
@@ -100,6 +97,10 @@ DEVICE_SOURCE_CODES: dict[str, list[int]] = {
     "amazfit-active-max": [10813697],
     "amazfit-bip-max": [11206915],
 }
+# 2026-09-11: seven additional codes accepted from distinct submission contexts;
+# adjacent-time duplicate reports were counted only once. See the dated feedback
+# triage evidence for counts, conflict exclusions and the privacy limitation that
+# these reports deliberately contain no reporter identity.
 # 明确不收（2026-09-03 的 183 行反馈快照上复核过）：
 #   * 10813699 —— Active 2 44mm 4 份 vs Active MAX 3 份。前两轮分别是 2:2 和
 #     3:3，这一轮 Active 2 那边多了一份（v2.1.0 / macOS），平票被打破了，但
@@ -111,8 +112,8 @@ DEVICE_SOURCE_CODES: dict[str, list[int]] = {
 #   * 7930112 —— GTR 4 46mm 2 份 vs T-Rex 3 1 份，同样是单设备报告提出的真实
 #     异议。附带一提，相邻的 7930113 已经收为 GTR 4 46mm，邻接性是支持 GTR 4
 #     的；但邻接性在这里只是旁证，不足以推翻一份明确的异议。
-#   * 只有一份报告的高位编号（11141376、11141377、10223872、10223875、
-#     10682624、8323329、10944768）——等第二份。原来在这一行里的 10813697、
+#   * 只有一份报告的高位编号（11141376、10223872、10223875、
+#     10944768）——等第二份。原来在这一行里的 10813697、
 #     11206915、10944771 在 2026-09-02 那批里凑够了，10682625 在 2026-09-03
 #     这一批里凑够了，都已经收进上表；
 #   * 全部低位段编号和全部 deviceType。低位段不是漏收：同一个 102 被指认成
@@ -836,7 +837,26 @@ def enrich_entry(entry: dict[str, Any], hash_value: str | None) -> dict[str, Any
 def build_catalog() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--refresh-official", action="store_true", help="download the four extra official CDN images")
+    parser.add_argument("--catalog-only", action="store_true", help="update model codes using existing catalog art and metadata")
     args = parser.parse_args()
+
+    if args.catalog_only:
+        document = json.loads(CATALOG_PATH.read_text(encoding="utf-8"))
+        document["version"] = 6
+        known_ids = {device["catalog_id"] for device in document["devices"]}
+        if unknown := sorted(set(DEVICE_SOURCE_CODES) - known_ids):
+            raise SystemExit(f"Unknown catalog IDs: {unknown}")
+        for device in document["devices"]:
+            device["device_source_codes"] = DEVICE_SOURCE_CODES.get(device["catalog_id"], [])
+        CATALOG_PATH.write_text(json.dumps(document, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        print(f"DEVICE_CATALOG_UPDATED entries={len(known_ids)}")
+        return
+
+    # Metadata-only maintenance does not need the image-processing runtime.
+    global cv2, np, Image, ImageOps
+    import cv2
+    import numpy as np
+    from PIL import Image, ImageOps
 
     hashes: dict[str, str] = {}
     # One physical image per canonical asset key; the GTR 4 colour card shares
@@ -869,7 +889,7 @@ def build_catalog() -> None:
     if unknown:
         raise SystemExit(f"DEVICE_SOURCE_CODES 指向了目录里没有的型号: {unknown}")
     document = {
-        "version": 5,
+        "version": 6,
         "checked_at": CHECKED_AT,
         "sources": [
             "https://www.amazfit.jp/",

--- a/src-tauri/crates/core/src/device_catalog.rs
+++ b/src-tauri/crates/core/src/device_catalog.rs
@@ -368,16 +368,38 @@ mod tests {
         })
         .expect("10682625 应当能匹配到 T-Rex 3 Pro");
         assert_eq!(found.entry.catalog_id, "amazfit-t-rex-3-pro-48-44mm");
+    }
 
-        // 相邻的 10682624 仍然只有一份报告，不能跟着邻接性溜进去。
-        assert!(
-            match_catalog(&CatalogMatchInput {
-                device_source_codes: vec![10_682_624],
-                ..CatalogMatchInput::default()
+    #[test]
+    fn september_11_device_contributions_match_without_guessing_conflicts() {
+        for (code, catalog_id) in [
+            (10_551_553, "amazfit-t-rex-3-pro-48-44mm"),
+            (10_682_624, "amazfit-t-rex-3-pro-48-44mm"),
+            (11_141_377, "amazfit-balance-3"),
+            (10_092_803, "amazfit-active-2-44mm"),
+            (8_323_329, "amazfit-active-42mm"),
+            (10_486_019, "amazfit-balance-2-xt"),
+            (9_978_112, "amazfit-cheetah-2-ultra"),
+        ] {
+            let matched = match_catalog(&CatalogMatchInput {
+                device_source_codes: vec![code],
+                ..Default::default()
             })
-            .is_none(),
-            "10682624 还只有一份报告，不该匹配到任何型号"
-        );
+            .expect("accepted contribution must identify a device");
+            assert_eq!(matched.entry.catalog_id, catalog_id);
+        }
+        for code in [
+            92, 102, 104, 254, 8_126_720, 9_765_121, 11_469_059, 11_092_224, 10_682_627,
+        ] {
+            assert!(
+                match_catalog(&CatalogMatchInput {
+                    device_source_codes: vec![code],
+                    ..Default::default()
+                })
+                .is_none(),
+                "unsupported or duplicate-only evidence for {code}"
+            );
+        }
     }
 
     /// Balance 2 XT 能被搜到、能被手动指认，哪怕它还没有产品图。
@@ -399,8 +421,7 @@ mod tests {
             entry.canonical_device_key.as_deref(),
             Some("amazfit-balance-2")
         );
-        // 还没有人从这款表上提交过报告，所以一个编号都不该挂在它名下。
-        assert!(entry.device_source_codes.is_empty());
+        assert_eq!(entry.device_source_codes, vec![10_486_019]);
 
         let matched = match_catalog(&CatalogMatchInput {
             device_names: vec!["Amazfit Balance 2 XT"],

--- a/src-tauri/crates/core/src/export_fit.rs
+++ b/src-tauri/crates/core/src/export_fit.rs
@@ -104,14 +104,26 @@ fn encode_workout(workout: &Value) -> Result<Option<(Vec<u8>, usize)>, String> {
             .or_else(|| workout.get("workout_type")),
     ));
 
-    let start_unix = points
+    let sample_start = points
         .first()
         .map(|(timestamp, _)| *timestamp)
         .expect("points 非空");
-    let end_unix = points
+    let sample_end = points
         .last()
         .map(|(timestamp, _)| *timestamp)
         .expect("points 非空");
+
+    // Retain the full recorded activity span even if the first/last sample is
+    // missing. Cloud moving_seconds describes this span, not just sample coverage.
+    let (start_unix, end_unix) = match (
+        parse_unix(text(workout.get("start_time"))),
+        parse_unix(text(workout.get("end_time"))),
+    ) {
+        (Some(start), Some(end)) if start <= sample_start && end >= sample_end && end > start => {
+            (start, end)
+        }
+        _ => (sample_start, sample_end),
+    };
 
     let mut messages = Vec::new();
 
@@ -148,24 +160,37 @@ fn encode_workout(workout: &Value) -> Result<Option<(Vec<u8>, usize)>, String> {
 
     // 暂停区间：进入暂停写 timer stop，恢复写 timer start。这和 GPX 导出在
     // 暂停两侧切 trkseg 是同一份依据，只是换成 FIT 的说法。
-    let pauses = pause_intervals(workout);
+    let pauses = pause_intervals(workout, start_unix, end_unix);
+    let pause_events: Vec<_> = pauses
+        .iter()
+        .flat_map(|&(start, end)| {
+            [
+                (start, typedef::EventType::STOP),
+                (end, typedef::EventType::START),
+            ]
+        })
+        .collect();
 
     let mut record_count = 0usize;
     let mut pause_cursor = 0usize;
     for (unix, point) in &points {
-        while pause_cursor < pauses.len() && pauses[pause_cursor].0 <= *unix {
-            let (stop_at, resume_at) = pauses[pause_cursor];
-            messages.push(timer_event(stop_at, typedef::EventType::STOP));
-            messages.push(timer_event(resume_at, typedef::EventType::START));
+        while pause_cursor < pause_events.len() && pause_events[pause_cursor].0 <= *unix {
+            let (at, event_type) = pause_events[pause_cursor];
+            messages.push(timer_event(at, event_type));
             pause_cursor += 1;
         }
         messages.push(record_message(*unix, point, sport));
         record_count += 1;
     }
 
+    for &(at, event_type) in &pause_events[pause_cursor..] {
+        messages.push(timer_event(at, event_type));
+    }
+
     messages.push(timer_event(end_unix, typedef::EventType::STOP));
 
     let elapsed_seconds = (end_unix - start_unix).max(0) as f64;
+    let moving_seconds = timer_seconds(workout, start_unix, end_unix);
     // 手表自己记的圈优先于我们按公里切的分段。
     //
     // 「我经常按圈键，如果你的 .fit 里能带上圈数据，那会是我的首选」——
@@ -221,7 +246,7 @@ fn encode_workout(workout: &Value) -> Result<Option<(Vec<u8>, usize)>, String> {
         u32_field(mesgdef::Activity::TIMESTAMP, fit_timestamp(end_unix)),
         u32_field(
             mesgdef::Activity::TOTAL_TIMER_TIME,
-            (elapsed_seconds * 1000.0) as u32,
+            (moving_seconds * 1000.0) as u32,
         ),
         u16_field(mesgdef::Activity::NUM_SESSIONS, 1),
         enum_field(mesgdef::Activity::TYPE, typedef::Activity::MANUAL.0),
@@ -478,6 +503,7 @@ fn push_laps(
             .get("duration_seconds")
             .and_then(Value::as_f64)
             .unwrap_or((end - start).max(0) as f64);
+        let moving_seconds = (duration - paused_seconds(workout, start, end)).max(0.0);
 
         let mut fields = vec![
             u16_field(mesgdef::Lap::MESSAGE_INDEX, count),
@@ -495,7 +521,7 @@ fn push_laps(
             ),
             u32_field(
                 mesgdef::Lap::TOTAL_TIMER_TIME,
-                (duration * 1000.0).max(0.0) as u32,
+                (moving_seconds * 1000.0) as u32,
             ),
         ];
 
@@ -510,9 +536,9 @@ fn push_laps(
         // 这个字段而不是自己从 record 里算，于是分段表整列显示 0。
         if let (Some(distance), true) = (
             split.get("distance_m").and_then(Value::as_f64),
-            duration > 0.0,
+            moving_seconds > 0.0,
         ) {
-            if let Some(speed) = encode_speed(distance / duration) {
+            if let Some(speed) = encode_speed(distance / moving_seconds) {
                 fields.push(u16_field(mesgdef::Lap::AVG_SPEED, speed));
             }
         }
@@ -577,6 +603,7 @@ fn push_whole_activity_lap(
     points: &[(i64, Point)],
 ) {
     let duration_ms = (elapsed_seconds * 1000.0).max(0.0) as u32;
+    let moving_seconds = timer_seconds(workout, start_unix, end_unix);
     let mut fields = vec![
         u16_field(mesgdef::Lap::MESSAGE_INDEX, 0),
         u32_field(mesgdef::Lap::TIMESTAMP, fit_timestamp(end_unix)),
@@ -594,7 +621,10 @@ fn push_whole_activity_lap(
             typedef::LapTrigger::SESSION_END.0,
         ),
         u32_field(mesgdef::Lap::TOTAL_ELAPSED_TIME, duration_ms),
-        u32_field(mesgdef::Lap::TOTAL_TIMER_TIME, duration_ms),
+        u32_field(
+            mesgdef::Lap::TOTAL_TIMER_TIME,
+            (moving_seconds * 1000.0) as u32,
+        ),
     ];
 
     // 起点坐标同 session：取第一个真有定位的点，室内运动本来就没有。
@@ -617,8 +647,8 @@ fn push_whole_activity_lap(
             mesgdef::Lap::TOTAL_DISTANCE,
             (distance * 100.0) as u32,
         ));
-        if elapsed_seconds > 0.0 {
-            if let Some(speed) = encode_speed(distance / elapsed_seconds) {
+        if moving_seconds > 0.0 {
+            if let Some(speed) = encode_speed(distance / moving_seconds) {
                 fields.push(u16_field(mesgdef::Lap::AVG_SPEED, speed));
             }
         }
@@ -677,6 +707,7 @@ fn push_session(
     lap_count: u16,
     points: &[(i64, Point)],
 ) {
+    let moving_seconds = timer_seconds(workout, start_unix, end_unix);
     let mut fields = vec![
         u16_field(mesgdef::Session::MESSAGE_INDEX, 0),
         u32_field(mesgdef::Session::TIMESTAMP, fit_timestamp(end_unix)),
@@ -691,7 +722,7 @@ fn push_session(
         ),
         u32_field(
             mesgdef::Session::TOTAL_TIMER_TIME,
-            (elapsed_seconds * 1000.0) as u32,
+            (moving_seconds * 1000.0) as u32,
         ),
         u16_field(mesgdef::Session::FIRST_LAP_INDEX, 0),
         u16_field(mesgdef::Session::NUM_LAPS, lap_count),
@@ -717,8 +748,8 @@ fn push_session(
             ));
             // 同 lap：距离 ÷ 时间，两个操作数都是刚写进这个文件的实测值。
             // 少了这一条，导入方的「平均速度 / 平均配速」整个是空的。
-            if elapsed_seconds > 0.0 {
-                if let Some(speed) = encode_speed(distance / elapsed_seconds) {
+            if moving_seconds > 0.0 {
+                if let Some(speed) = encode_speed(distance / moving_seconds) {
                     fields.push(u16_field(mesgdef::Session::AVG_SPEED, speed));
                 }
             }
@@ -961,17 +992,43 @@ fn hr_zone_field(workout: &Value) -> Option<Vec<u32>> {
 }
 
 /// `(暂停开始, 恢复)` 的秒级时间戳对，按开始时间排序。
-fn pause_intervals(workout: &Value) -> Vec<(i64, i64)> {
+fn pause_intervals(workout: &Value, from: i64, to: i64) -> Vec<(i64, i64)> {
     let mut intervals: Vec<(i64, i64)> = array(workout, "pauses")
         .iter()
         .filter_map(|pause| {
             let start = parse_unix(text(pause.get("start_time")))?;
             let end = parse_unix(text(pause.get("end_time")))?;
-            Some((start, end))
+            let start = start.max(from);
+            let end = end.min(to);
+            (end > start).then_some((start, end))
         })
         .collect();
     intervals.sort_unstable();
-    intervals
+    let mut merged: Vec<(i64, i64)> = Vec::new();
+    for (start, end) in intervals {
+        if let Some(last) = merged.last_mut().filter(|last| start <= last.1) {
+            last.1 = last.1.max(end);
+        } else {
+            merged.push((start, end));
+        }
+    }
+    merged
+}
+
+fn paused_seconds(workout: &Value, start: i64, end: i64) -> f64 {
+    pause_intervals(workout, start, end)
+        .iter()
+        .map(|(from, to)| (to - from) as f64)
+        .sum()
+}
+
+fn timer_seconds(workout: &Value, start: i64, end: i64) -> f64 {
+    let elapsed = (end - start).max(0) as f64;
+    workout
+        .get("moving_seconds")
+        .and_then(Value::as_f64)
+        .filter(|seconds| seconds.is_finite() && *seconds >= 0.0 && *seconds <= elapsed)
+        .unwrap_or_else(|| (elapsed - paused_seconds(workout, start, end)).max(0.0))
 }
 
 fn timer_event(unix: i64, event_type: typedef::EventType) -> Message {
@@ -1826,6 +1883,63 @@ mod tests {
         let start = Some(i64::from(typedef::EventType::START.0));
         let stop = Some(i64::from(typedef::EventType::STOP.0));
         assert_eq!(types, vec![start, stop, start, stop]);
+        let session = messages_of(&fit, typedef::MesgNum::SESSION)[0];
+        assert_eq!(
+            int_of(session, mesgdef::Session::TOTAL_ELAPSED_TIME),
+            Some(600_000)
+        );
+        assert_eq!(
+            int_of(session, mesgdef::Session::TOTAL_TIMER_TIME),
+            Some(420_000)
+        );
+        let lap = messages_of(&fit, typedef::MesgNum::LAP)[0];
+        assert_eq!(int_of(lap, mesgdef::Lap::TOTAL_TIMER_TIME), Some(420_000));
+        let activity = messages_of(&fit, typedef::MesgNum::ACTIVITY)[0];
+        assert_eq!(
+            int_of(activity, mesgdef::Activity::TOTAL_TIMER_TIME),
+            Some(420_000)
+        );
+    }
+
+    #[test]
+    fn overlapping_and_out_of_bounds_pauses_are_counted_once() {
+        let workout = json!({"pauses": [
+            {"start_time": "2026-09-11T00:01:00Z", "end_time": "2026-09-11T00:04:00Z"},
+            {"start_time": "2026-09-11T00:02:00Z", "end_time": "2026-09-11T00:05:00Z"},
+            {"start_time": "2026-09-10T23:59:00Z", "end_time": "2026-09-11T00:00:30Z"},
+            {"start_time": "2026-09-11T00:09:30Z", "end_time": "2026-09-11T00:12:00Z"},
+            {"start_time": "2026-09-11T00:08:00Z", "end_time": "2026-09-11T00:07:00Z"}
+        ]});
+        let start = parse_unix("2026-09-11T00:00:00Z").unwrap();
+        assert_eq!(timer_seconds(&workout, start, start + 600), 300.0);
+    }
+
+    #[test]
+    fn cloud_moving_time_and_full_activity_bounds_survive_sparse_samples() {
+        let export = export_with(json!({"workouts": [{
+            "workout_id": "moving-time", "effective_type": "run",
+            "start_time": "2026-09-11T00:00:00Z", "end_time": "2026-09-11T00:10:00Z",
+            "moving_seconds": 420, "distance_meters": 1400,
+            "samples": [
+                {"timestamp": "2026-09-11T00:00:10Z", "heart_rate": 100},
+                {"timestamp": "2026-09-11T00:08:00Z", "heart_rate": 110}
+            ],
+            "route": [], "pauses": [], "splits": []
+        }]}));
+        let (files, _) = to_fit(&export).unwrap();
+        let fit = decode(&files[0].1);
+        let session = messages_of(&fit, typedef::MesgNum::SESSION)[0];
+        assert_eq!(
+            int_of(session, mesgdef::Session::TOTAL_ELAPSED_TIME),
+            Some(600_000)
+        );
+        assert_eq!(
+            int_of(session, mesgdef::Session::TOTAL_TIMER_TIME),
+            Some(420_000)
+        );
+        assert_eq!(int_of(session, mesgdef::Session::AVG_SPEED), Some(3333));
+        let lap = messages_of(&fit, typedef::MesgNum::LAP)[0];
+        assert_eq!(int_of(lap, mesgdef::Lap::TOTAL_TIMER_TIME), Some(420_000));
     }
 
     /// 云端给了爬升就用云端的，别再拿分段之和覆盖它。

--- a/src/assets/devices/catalog.json
+++ b/src/assets/devices/catalog.json
@@ -44,6 +44,7 @@
       "checked_at": "2026-08-15",
       "image_key": "amazfit-balance-3",
       "device_source_codes": [
+        11141377,
         11141379,
         11145472
       ]
@@ -149,6 +150,7 @@
       "checked_at": "2026-08-15",
       "image_key": "amazfit-cheetah-2-ultra",
       "device_source_codes": [
+        9978112,
         9978113
       ]
     },
@@ -334,7 +336,9 @@
       "image_key": "amazfit-t-rex-3-pro-48-44mm",
       "device_source_codes": [
         10551552,
+        10551553,
         10551555,
+        10682624,
         10682625
       ]
     },
@@ -449,6 +453,7 @@
       "device_source_codes": [
         10092800,
         10092801,
+        10092803,
         10092807
       ]
     },
@@ -746,7 +751,9 @@
       "asset_hash": "sha256:04AD7D302028FBE17109D3EDCC214DA12C085B2E2F2AF12DCE5C7094256373D2",
       "checked_at": "2026-08-15",
       "image_key": "amazfit-active-42mm",
-      "device_source_codes": []
+      "device_source_codes": [
+        8323329
+      ]
     },
     {
       "catalog_id": "amazfit-bip-5-46mm",
@@ -1860,7 +1867,9 @@
       "image_key": null,
       "status": "active",
       "supported": true,
-      "device_source_codes": []
+      "device_source_codes": [
+        10486019
+      ]
     },
     {
       "catalog_id": "amazfit-smart-scale",

--- a/src/lib/__tests__/workoutTiming.test.ts
+++ b/src/lib/__tests__/workoutTiming.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { workoutTiming } from '../workoutTiming';
+
+const time = (minutes: number) => new Date(Date.UTC(2026, 8, 11, 0, minutes)).toISOString();
+const pause = (from: number, to: number) => ({ start_time: time(from), end_time: time(to), kind: 'manual' });
+
+describe('workout timing', () => {
+  it('prefers cloud moving time when detailed pause intervals are missing or incomplete', () => {
+    expect(workoutTiming(time(0), time(30), 5000, [], 1500)?.movingPace).toBe(5);
+    expect(workoutTiming(time(0), time(30), 5000, [pause(10, 11)], 1500)?.pausedMinutes).toBe(5);
+    expect(workoutTiming(time(0), time(30), 5000, [pause(10, 15)], 1900)?.movingMinutes).toBe(25);
+    expect(workoutTiming(time(0), time(30), 5000, [], 0)?.movingPace).toBeNull();
+  });
+  it('separates traffic-light pauses from elapsed time and pace', () => {
+    expect(workoutTiming(time(0), time(30), 5000, [pause(10, 15)])).toEqual({
+      elapsedMinutes: 30, pausedMinutes: 5, movingMinutes: 25, movingPace: 5, elapsedPace: 6,
+    });
+  });
+  it('unions overlapping, duplicate and clipped intervals', () => {
+    expect(workoutTiming(time(0), time(30), 5000, [
+      pause(10, 15), pause(12, 20), pause(10, 15), pause(-5, 2), pause(28, 35),
+      pause(4, 3), pause(40, 45), { start_time: 'invalid', end_time: time(15), kind: 'manual' },
+    ])?.pausedMinutes).toBe(14);
+  });
+  it('does not invent pace without distance or positive moving time', () => {
+    expect(workoutTiming(time(0), time(30), null, [])?.movingPace).toBeNull();
+    expect(workoutTiming(time(0), time(30), 5000, [pause(-1, 40)])?.movingPace).toBeNull();
+    expect(workoutTiming(time(30), time(0), 5000, [])).toBeNull();
+    expect(workoutTiming('invalid', time(30), 5000, [])).toBeNull();
+  });
+});

--- a/src/lib/workoutTiming.ts
+++ b/src/lib/workoutTiming.ts
@@ -1,0 +1,37 @@
+import type { WorkoutPause } from '../types';
+
+/** Use the union of recorded pauses within the workout, never sample gaps. */
+export function workoutTiming(
+  startTime: string,
+  endTime: string,
+  distanceMeters: number | null | undefined,
+  pauses: WorkoutPause[],
+  reportedMovingSeconds?: number | null,
+) {
+  const start = Date.parse(startTime);
+  const end = Date.parse(endTime);
+  if (!Number.isFinite(start) || !Number.isFinite(end) || end <= start) return null;
+  const intervals = pauses
+    .map(pause => [Math.max(start, Date.parse(pause.start_time)), Math.min(end, Date.parse(pause.end_time))])
+    .filter(([from, to]) => Number.isFinite(from) && Number.isFinite(to) && to! > from!)
+    .sort((a, b) => a[0]! - b[0]!);
+  let pausedMs = 0;
+  let coveredUntil = start;
+  for (const [from, to] of intervals) {
+    pausedMs += Math.max(0, to! - Math.max(from!, coveredUntil));
+    coveredUntil = Math.max(coveredUntil, to!);
+  }
+  const elapsedMinutes = (end - start) / 60_000;
+  const hasReportedTime = typeof reportedMovingSeconds === 'number'
+    && Number.isFinite(reportedMovingSeconds) && reportedMovingSeconds >= 0
+    && reportedMovingSeconds <= elapsedMinutes * 60;
+  const movingMinutes = hasReportedTime ? reportedMovingSeconds / 60 : elapsedMinutes - pausedMs / 60_000;
+  const pausedMinutes = elapsedMinutes - movingMinutes;
+  const distanceKm = typeof distanceMeters === 'number' && Number.isFinite(distanceMeters)
+    && distanceMeters > 0 ? distanceMeters / 1000 : null;
+  return {
+    elapsedMinutes, pausedMinutes, movingMinutes,
+    movingPace: distanceKm && movingMinutes > 0 ? movingMinutes / distanceKm : null,
+    elapsedPace: distanceKm ? elapsedMinutes / distanceKm : null,
+  };
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -281,6 +281,8 @@ export interface Workout {
   start_time: string;
   end_time: string;
   distance_meters?: number;
+  /** Cloud run_time in seconds; excludes pauses. */
+  moving_seconds?: number | null;
   calories?: number;
   avg_hr?: number;
   max_hr?: number;

--- a/src/views/WorkoutDetail.vue
+++ b/src/views/WorkoutDetail.vue
@@ -26,6 +26,7 @@ import {
 import { zeppSemanticColors } from '../lib/echartsTheme';
 import { formatPaceSeconds } from '../lib/metricSeries';
 import { workoutDisplayLabel, workoutDisplayType } from '../lib/workouts';
+import { workoutTiming } from '../lib/workoutTiming';
 import { deviceImageFor } from '../lib/deviceCatalog';
 import type { DeviceProfile, SportOption, Workout, WorkoutInsight, WorkoutSeries, WorkoutSeriesSample, WorkoutRoutePoint } from '../types';
 import { defineMessages, intlLocale, useMessages } from '../i18n';
@@ -71,6 +72,10 @@ const messages = defineMessages(
     metricDuration: '运动时间',
     metricAvgHr: '平均心率',
     metricAvgPace: '平均配速',
+    metricMovingTime: '运动用时',
+    metricPausedTime: '暂停用时',
+    metricMovingPace: '运动配速',
+    metricElapsedPace: '含暂停配速',
     metricAscent: '累计爬升',
     metricTrainingLoad: '训练负荷',
     metricTrainingEffect: '有氧训练效果',
@@ -210,6 +215,10 @@ Answer in Markdown.`,
     metricDuration: 'Moving time',
     metricAvgHr: 'Avg heart rate',
     metricAvgPace: 'Avg pace',
+    metricMovingTime: 'Moving time',
+    metricPausedTime: 'Paused time',
+    metricMovingPace: 'Moving pace',
+    metricElapsedPace: 'Elapsed pace',
     metricAscent: 'Ascent',
     metricTrainingLoad: 'Training load',
     metricTrainingEffect: 'Aerobic effect',
@@ -507,11 +516,20 @@ const deviceKind = computed(() => device.value.kind || 'unknown');
 const hasDistance = computed(() => isFiniteNumber(workout.value?.distance_meters)
   && (workout.value?.distance_meters ?? 0) > 0);
 
+const timing = computed(() => workout.value && (series.value || workout.value.moving_seconds != null)
+  ? workoutTiming(workout.value.start_time, workout.value.end_time, workout.value.distance_meters, series.value?.pauses ?? [], workout.value.moving_seconds)
+  : null);
+
 const heroMetrics = computed(() => {
   const item = workout.value;
   if (!item) return [];
   const summary = series.value?.summary;
   const resolvedPace = paceLabel.value !== t.value.notProvided ? paceLabel.value : paceText(summary?.average_pace);
+  const hasPauses = timing.value && timing.value.pausedMinutes > 0;
+  const timingMetrics = hasPauses ? [
+    { label: t.value.metricMovingTime, value: formatClock(timing.value!.movingMinutes), tone: 'training', icon: 'auto-sync' as DesignIconName },
+    { label: t.value.metricPausedTime, value: formatClock(timing.value!.pausedMinutes), tone: 'training', icon: 'auto-sync' as DesignIconName },
+  ] : [];
   /* 强度那一组。Zepp 云端不提供组数、次数和重量——`workouts` 表和它的
      四张子表里都没有这几列，原始报文里也没有。所以这里显示的是**它
      确实给了的**负荷指标，而不是把 per-set 数据编出来。 */
@@ -523,6 +541,7 @@ const heroMetrics = computed(() => {
   if (!hasDistance.value) {
     return [
       { label: t.value.metricDuration, value: formatClock(durationMinutes.value), tone: 'training', icon: 'auto-sync' as DesignIconName },
+      ...timingMetrics,
       { label: t.value.metricAvgHr, value: numberValue(item.avg_hr), unit: isFiniteNumber(item.avg_hr) ? 'bpm' : undefined, tone: 'heart', icon: 'heart-rate' as DesignIconName },
       { label: t.value.metricMaxHr, value: numberValue(item.max_hr), unit: isFiniteNumber(item.max_hr) ? 'bpm' : undefined, tone: 'heart', icon: 'heart-rate' as DesignIconName },
       { label: t.value.metricCalories, value: numberValue(item.calories), unit: isFiniteNumber(item.calories) ? t.value.unitKcal : undefined, tone: 'distance', icon: 'body-activity' as DesignIconName },
@@ -533,8 +552,10 @@ const heroMetrics = computed(() => {
   return [
     { label: t.value.metricDistance, value: distanceLabel.value, tone: 'distance', icon: 'outdoor-run' as DesignIconName },
     { label: t.value.metricDuration, value: formatClock(durationMinutes.value), tone: 'training', icon: 'auto-sync' as DesignIconName },
+    ...timingMetrics,
     { label: t.value.metricAvgHr, value: numberValue(item.avg_hr), unit: isFiniteNumber(item.avg_hr) ? 'bpm' : undefined, tone: 'heart', icon: 'heart-rate' as DesignIconName },
-    { label: t.value.metricAvgPace, value: resolvedPace, tone: 'pace', icon: 'body-activity' as DesignIconName },
+    { label: hasPauses ? t.value.metricMovingPace : t.value.metricAvgPace, value: hasPauses ? paceText(timing.value!.movingPace) : resolvedPace, tone: 'pace', icon: 'body-activity' as DesignIconName },
+    ...(hasPauses ? [{ label: t.value.metricElapsedPace, value: paceText(timing.value!.elapsedPace), tone: 'pace', icon: 'body-activity' as DesignIconName }] : []),
     { label: t.value.metricAscent, value: isFiniteNumber(summary?.elevation_gain_m) ? numberValue(toElevation(summary.elevation_gain_m)) : t.value.notProvided, unit: isFiniteNumber(summary?.elevation_gain_m) ? elevationUnitLabel() : undefined, tone: 'altitude', icon: 'health-watch' as DesignIconName },
     { label: 'VO₂ Max', value: numberValue(item.vo2max), tone: 'vo2', icon: 'vo2-max' as DesignIconName },
     { label: t.value.metricTrainingLoad, value: numberValue(item.training_load), tone: 'training', icon: 'training-load' as DesignIconName },


### PR DESCRIPTION
Workout feedback showed that the detail page and FIT exports counted pauses as exercise time, even though the cloud moving duration was already stored. This change uses that duration when valid, falls back to merged and bounded recorded pauses, and exposes moving/paused time plus both pace definitions. FIT session/activity totals retain the full workout span with sparse samples; lap timer totals also exclude pauses.

Seven device-source mappings are admitted from corroborating submission contexts. Conflicting, low-band and duplicate-only contributions remain unknown. The dated triage ledger records all 56 currently pending reports, distinguishes unreleased fixes from evidence requests, and documents the existing issue dispositions.

Validation: 114 frontend tests, 22 focused FIT tests, complete Rust workspace tests, Clippy, frontend build, i18n, version and documentation checks. Production Tauri EXE verification is being completed; no public release is created by this PR.
