### PR TITLE
chore(release): prepare v2.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## Unreleased / 未发布
 
+## 2.2.4
+
+### Fixed / 修复
+
 - **Paused workouts show moving and paused time separately.** Workout details show moving pace alongside pace including pauses; FIT session, lap and activity timer totals exclude recorded pauses. Overlapping intervals count once and intervals are clipped to the activity or lap.
 - **含暂停的运动可分别查看运动用时、暂停用时、运动配速和含暂停配速。** FIT 的运动、圈与活动计时同步扣除已记录的暂停，重复、重叠与越界区间不会重复扣时。
 - Added seven evidence-backed deviceSource mappings for T-Rex 3 Pro, Balance 3, Balance 2 XT, Active, Active 2 and Cheetah 2 Ultra. Refresh the device list to update a previously cached unknown model. User model corrections retain priority.

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -1,6 +1,6 @@
 # ZeppBridge architecture summary
 
-This page describes the product boundaries and current implementation of v2.2.3.
+This page describes the product boundaries and current implementation of v2.2.4.
 For the usage entry point see the project [README](../../README.md); for
 engineering gates see the [development guide](../development/development.md).
 

--- a/docs/reference/architecture.zh-CN.md
+++ b/docs/reference/architecture.zh-CN.md
@@ -2,7 +2,7 @@
 
 [English](architecture.md)
 
-本文描述 v2.2.3 的产品边界与当前实现。使用入口见项目 [README](../../README.zh-CN.md)，工程门禁见 [开发文档](../development/development.zh-CN.md)。
+本文描述 v2.2.4 的产品边界与当前实现。使用入口见项目 [README](../../README.zh-CN.md)，工程门禁见 [开发文档](../development/development.zh-CN.md)。
 
 ## 产品边界
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zeppbridge",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zeppbridge",
-      "version": "2.2.3",
+      "version": "2.2.4",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zeppbridge",
   "private": true,
-  "version": "2.2.3",
+  "version": "2.2.4",
   "type": "module",
   "engines": {
     "node": ">=22"

--- a/packaging/flatpak/com.zeppbridge.app.metainfo.xml
+++ b/packaging/flatpak/com.zeppbridge.app.metainfo.xml
@@ -79,6 +79,7 @@
   <content_rating type="oars-1.1"/>
 
   <releases>
+    <release version="2.2.4" date="2026-09-11"/>
     <release version="2.2.3" date="2026-09-10"/>
     <release version="2.2.1" date="2026-09-07"/>
     <release version="2.2.0" date="2026-09-03"/>

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6232,7 +6232,7 @@ dependencies = [
 
 [[package]]
 name = "zeppbridge"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6261,7 +6261,7 @@ dependencies = [
 
 [[package]]
 name = "zeppbridge-cli"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "chrono",
  "serde",
@@ -6272,7 +6272,7 @@ dependencies = [
 
 [[package]]
 name = "zeppbridge-core"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6299,7 +6299,7 @@ dependencies = [
 
 [[package]]
 name = "zeppbridge-mcp"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "chrono",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,7 +31,7 @@ zeppbridge-core = { path = "crates/core" }
 
 [package]
 name = "zeppbridge"
-version = "2.2.3"
+version = "2.2.4"
 description = "本地优先的 Zepp 健康数据桥"
 authors = ["ZeppBridge"]
 edition = "2021"

--- a/src-tauri/crates/cli/Cargo.toml
+++ b/src-tauri/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeppbridge-cli"
-version = "2.2.3"
+version = "2.2.4"
 description = "ZeppBridge 命令行：给 Task Scheduler / cron / agent 用的无交互入口"
 edition = "2021"
 

--- a/src-tauri/crates/core/Cargo.toml
+++ b/src-tauri/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeppbridge-core"
-version = "2.2.3"
+version = "2.2.4"
 description = "ZeppBridge 的共享数据核心：模型、存储、迁移、归一化、查询、导出与写入协调"
 edition = "2021"
 

--- a/src-tauri/crates/mcp/Cargo.toml
+++ b/src-tauri/crates/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeppbridge-mcp"
-version = "2.2.3"
+version = "2.2.4"
 description = "ZeppBridge MCP 服务：只读、stdio、不监听任何端口"
 edition = "2021"
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ZeppBridge",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "identifier": "com.zeppbridge.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/App.vue
+++ b/src/App.vue
@@ -83,7 +83,7 @@ const t = useMessages(messages);
 
 // 桌面端从 Tauri 运行时读取版本（与 tauri.conf.json 单一来源），
 // 浏览器预览环境回退到下面的常量（与 package.json 保持同步）。
-const FALLBACK_APP_VERSION = '2.2.3';
+const FALLBACK_APP_VERSION = '2.2.4';
 /* 构建标识。同一个版本号会构建很多次，光看版本号分不清手上是哪一个。 */
 const BUILD_STAMP = __BUILD_STAMP__;
 const APP_VERSION = ref(FALLBACK_APP_VERSION);


### PR DESCRIPTION
## Summary

- advance the desktop, CLI, MCP, updater, docs and Flatpak metadata to 2.2.4
- publish the merged macOS credential fallback and workout moving-time/device catalog fixes
- preserve an empty Unreleased section for the next change

## Validation

- npm run version:check
- npm run package:release
- local release/ZeppBridge.exe 2.2.4 launched and user-approved
- NSIS, MSI and updater signature produced successfully