### PR TITLE
fix: HAR import user id, and keep the macOS library out of the .app bundle

### DIFF
--- a/src-tauri/crates/core/src/auth/har.rs
+++ b/src-tauri/crates/core/src/auth/har.rs
@@ -38,7 +38,8 @@ pub fn extract_from_har(har_path: &Path) -> Result<AuthInfo> {
 }
 
 fn extract_credentials_from_entries(entries: &[Value]) -> Result<AuthInfo> {
-    let user_id_re = Regex::new(r"/users/(\d+)/")
+    // watchface.zepp.com 发的是 `/users/<id>`，后面没有斜杠，也可能直接接 `?`。
+    let user_id_re = Regex::new(r"/users/(\d+)(?:[/?#]|$)")
         .map_err(|e| ZeppBridgeError::ConfigError(format!("正则表达式编译失败: {e}")))?;
 
     let mut app_token: Option<String> = None;
@@ -217,5 +218,49 @@ mod tests {
 
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("未找到user_id"));
+    }
+
+    #[test]
+    fn extracts_user_id_without_trailing_slash() {
+        // watchface.zepp.com 导出的 HAR 就是这个样子。
+        let har_json = serde_json::json!({
+            "log": {
+                "entries": [
+                    {
+                        "request": {
+                            "url": "https://api-mifit-us3.zepp.com/users/7654321",
+                            "headers": [{"name": "apptoken", "value": "tok"}]
+                        }
+                    }
+                ]
+            }
+        });
+
+        let entries = har_json["log"]["entries"].as_array().unwrap();
+        let result = extract_credentials_from_entries(entries).unwrap();
+
+        assert_eq!(result.user_id, "7654321");
+        assert_eq!(result.region_host, "https://api-mifit-us3.zepp.com");
+    }
+
+    #[test]
+    fn extracts_user_id_followed_by_query_string() {
+        let har_json = serde_json::json!({
+            "log": {
+                "entries": [
+                    {
+                        "request": {
+                            "url": "https://api-mifit-us3.zepp.com/users/7654321?r=1",
+                            "headers": [{"name": "apptoken", "value": "tok"}]
+                        }
+                    }
+                ]
+            }
+        });
+
+        let entries = har_json["log"]["entries"].as_array().unwrap();
+        let result = extract_credentials_from_entries(entries).unwrap();
+
+        assert_eq!(result.user_id, "7654321");
     }
 }

--- a/src-tauri/crates/core/src/paths.rs
+++ b/src-tauri/crates/core/src/paths.rs
@@ -64,6 +64,15 @@ pub fn resolve_data_dir() -> io::Result<PathBuf> {
         return Ok(base);
     }
 
+    // macOS：`/Applications` 对 admin 组可写，所以「写得进去」不代表该写。
+    // `.app` 包在更新或重装时会被整体替换，数据放在里面就会跟着消失。
+    #[cfg(target_os = "macos")]
+    if !is_build_artifact_dir(exe_dir) && is_inside_app_bundle(exe_dir) {
+        let base = user_data_dir()?;
+        ensure_writable_dir(&base)?;
+        return Ok(base);
+    }
+
     let data_dir = if is_build_artifact_dir(exe_dir) {
         repository_data_dir().unwrap_or_else(|| exe_dir.join("data"))
     } else {
@@ -153,6 +162,17 @@ fn user_data_dir() -> io::Result<PathBuf> {
     let project = directories::ProjectDirs::from("com", "zeppbridge", "ZeppBridge")
         .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "无法确定用户数据目录"))?;
     Ok(project.data_dir().join("data"))
+}
+
+/// 可执行文件是不是在某个 `*.app/Contents/MacOS` 里。
+#[cfg(target_os = "macos")]
+fn is_inside_app_bundle(dir: &Path) -> bool {
+    dir.ends_with("Contents/MacOS")
+        && dir
+            .parent()
+            .and_then(Path::parent)
+            .and_then(Path::extension)
+            .is_some_and(|ext| ext == "app")
 }
 
 /// 这个目录是不是「操作系统或包管理器拥有的共享前缀」。


### PR DESCRIPTION

Two small fixes for the issues I filed today, both hit while setting the app up on macOS.

### 1. HAR import could never find the user id (#79)

`extract_credentials_from_entries` matched `/users/(\d+)/`, with a trailing slash. The requests `watchface.zepp.com` actually makes look like this:

```
GET https://api-mifit-us3.zepp.com/users/<id>          ← no trailing slash
GET https://api-mifit-us3.zepp.com/custom/diy/dial/supports?userid=<id>
```

So `user_id` stayed `None`, and the UI reported the generic `err.core.config` — "Something in the configuration needs changing first" — which gives no hint about what went wrong. The regex now accepts the id at the end of the path or before `?`/`#`, and two tests cover both shapes.

This matters more than it looks: with a Google account, the in-app web sign-in stalls on the passkey step (the limitation already in the CHANGELOG), so HAR import is the realistic path in, and it failed at the last step.

### 2. On macOS the library was written inside the .app bundle (#80)

`paths.rs` assumes `/Applications` is not writable. It is: it is group-writable by `admin`, and the first account on a Mac is an admin. So `ensure_writable_dir` succeeded and the database, `auth.json` and `devices.json` were created in `ZeppBridge.app/Contents/MacOS/data` — where the README says Application Support should be.

The consequence is that replacing the bundle takes the library with it: dragging a newer `.dmg` over the old app, deleting the app, and — as far as I can tell — the updater swapping the `.app`.

This adds a macOS branch: when the executable sits in `*.app/Contents/MacOS`, go straight to Application Support, the same way the Linux shared-prefix branch already does.

**One thing I did not write, and would rather you decide:** existing macOS users already have a library inside their bundle. This change alone makes the app look empty for them on the next launch. A one-time migration (move `Contents/MacOS/data` to Application Support at startup if the destination is empty) belongs with it — I left it out because it touches upgrade behaviour and you may prefer a different shape for it. I am happy to add it in this PR if you tell me how you want it.

### Checks

`cargo test -p zeppbridge-core` passes, including the two new HAR tests. Built and running on macOS 26.6, Apple Silicon.
