### PR TITLE
test: isolate replay action state

### DIFF
--- a/src-tauri/crates/core/src/storage/provenance.rs
+++ b/src-tauri/crates/core/src/storage/provenance.rs
@@ -1275,11 +1275,14 @@ mod tests {
         )
         .unwrap();
         let health = db.data_health(90, 0).unwrap();
-        let ids: Vec<&str> = health
-            .actions
-            .iter()
-            .map(|action| action.id.as_str())
-            .collect();
+        // REPLAY_IN_PROGRESS describes the whole process, not this in-memory
+        // database. Another parallel test can legitimately hold the replay
+        // guard while this assertion runs, so pin that independent input to
+        // the idle state this unit test is meant to exercise.
+        let mut database = health.database.clone();
+        database.replay_in_progress = false;
+        let actions = suggested_actions(&database, &health.timings, &health.streams);
+        let ids: Vec<&str> = actions.iter().map(|action| action.id.as_str()).collect();
         assert!(ids.contains(&"reauth"));
         assert!(
             !ids.contains(&"reprocess"),


### PR DESCRIPTION
## Why\n\nThe post-merge Windows verification exposed a parallel-test race. REPLAY_IN_PROGRESS is process-global, so the provenance action test could observe another test's legitimate replay guard and incorrectly expect no eprocess action. This does not change product behavior.\n\n## Fix\n\nPin the replay input to the idle state that this unit test is specifically exercising before calling suggested_actions. The existing assertions remain intact.\n\n## Validation\n\n- cargo fmt --all -- --check\n- five repeated full zeppbridge-core library test runs passed (293 passed, 1 fixture test ignored per run)\n- cargo clippy -p zeppbridge-core --all-targets -- -D warnings\n