### PR TITLE
docs: add Spanish 2.3.0 greeting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## 2.3.0
 
+> **Hola, ya sé hablar español.**
+
 ### Added / 新增
 
 - **ZeppBridge now speaks Spanish.** The desktop interface, detail pages, workout catalogue, tray menu, weekly reports and user-facing unit labels are available in Spanish alongside Chinese and English.


### PR DESCRIPTION
Adds the requested Spanish greeting as the first and most prominent line of the 2.3.0 changelog. The same sentence will be the first line of the annotated tag and therefore the GitHub Release body and in-app updater note.\n\nValidation: all 144 repository documentation links passed in a clean source view; diff whitespace check passed.