### PR TITLE
fix: stress chart title, settings dropdowns, and OS-locale calendar

### DIFF
--- a/src/components/DatePicker.vue
+++ b/src/components/DatePicker.vue
@@ -1,0 +1,330 @@
+<script setup lang="ts">
+/**
+ * 自绘日期选择器。月份名、星期名、一周起点跟**系统地区**，不跟界面语言。
+ *
+ * 不用原生 `<input type="date">`：WebView2 那块日历样式不受控，弹层也盖
+ * 不住本应用的对话框。地区合同和原生控件一样——界面只有中/英/西三份，
+ * 系统地区却有很多，不能把日历折进那三份里。
+ */
+import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue';
+import { defineMessages, useMessages } from '../i18n';
+import {
+  calendarCells,
+  calendarMonthTitle,
+  calendarWeekdayNames,
+} from '../lib/calendarLocale';
+import { displayDateTimeFormatter, parseDisplayDate } from '../lib/dateTime';
+import { localDateString } from '../lib/format';
+import { popoverStyle } from '../lib/popoverPosition';
+import Icon from './Icon.vue';
+
+const props = withDefaults(defineProps<{
+  modelValue: string | null;
+  min?: string;
+  max?: string;
+  disabled?: boolean;
+  placeholder?: string;
+  ariaLabel?: string;
+}>(), {
+  min: undefined,
+  max: undefined,
+  disabled: false,
+  placeholder: '',
+  ariaLabel: undefined,
+});
+
+const emit = defineEmits<{ (event: 'update:modelValue', value: string): void }>();
+
+const messages = defineMessages(
+  { placeholder: '选择日期', aria: '选择日期', prev: '上个月', next: '下个月' },
+  { placeholder: 'Pick a date', aria: 'Choose a date', prev: 'Previous month', next: 'Next month' },
+  { placeholder: 'Elige una fecha', aria: 'Elegir fecha', prev: 'Mes anterior', next: 'Mes siguiente' },
+);
+const t = useMessages(messages);
+
+const open = ref(false);
+const pickerYear = ref(new Date().getFullYear());
+const pickerMonth = ref(new Date().getMonth());
+const root = ref<HTMLElement | null>(null);
+const triggerRef = ref<HTMLElement | null>(null);
+const calendarRef = ref<HTMLElement | null>(null);
+const calendarStyle = ref<Record<string, string>>({});
+
+const CALENDAR_WIDTH = 280;
+const CALENDAR_MAX_HEIGHT = 320;
+
+const displayValue = computed(() => {
+  if (!props.modelValue) return props.placeholder || t.value.placeholder;
+  const date = parseDisplayDate(props.modelValue);
+  if (Number.isNaN(date.getTime())) return props.modelValue;
+  return displayDateTimeFormatter({
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(date);
+});
+
+const monthTitle = computed(() => calendarMonthTitle(pickerYear.value, pickerMonth.value));
+const weekdayNames = computed(() => calendarWeekdayNames());
+const cells = computed(() => calendarCells(pickerYear.value, pickerMonth.value));
+const today = computed(() => localDateString(new Date()));
+
+const outOfRange = (dateStr: string): boolean => {
+  if (!dateStr) return true;
+  if (props.min && dateStr < props.min) return true;
+  if (props.max && dateStr > props.max) return true;
+  return false;
+};
+
+const measure = () => {
+  const trigger = triggerRef.value;
+  if (!trigger) return;
+  const rect = trigger.getBoundingClientRect();
+  calendarStyle.value = popoverStyle(
+    { top: rect.top, bottom: rect.bottom, left: rect.left, width: rect.width },
+    { width: window.innerWidth, height: window.innerHeight },
+    { maxHeight: CALENDAR_MAX_HEIGHT, width: CALENDAR_WIDTH },
+  ) as unknown as Record<string, string>;
+};
+
+const syncMonthToValue = () => {
+  const date = props.modelValue ? parseDisplayDate(props.modelValue) : new Date();
+  const valid = !Number.isNaN(date.getTime());
+  const source = valid ? date : new Date();
+  pickerYear.value = source.getFullYear();
+  pickerMonth.value = source.getMonth();
+};
+
+const openPicker = () => {
+  if (props.disabled) return;
+  syncMonthToValue();
+  measure();
+  open.value = true;
+  void nextTick(measure);
+};
+
+const closePicker = (restoreFocus = false) => {
+  open.value = false;
+  if (restoreFocus) triggerRef.value?.focus();
+};
+
+const toggle = () => (open.value ? closePicker() : openPicker());
+
+const prevMonth = () => {
+  if (pickerMonth.value === 0) {
+    pickerMonth.value = 11;
+    pickerYear.value -= 1;
+  } else {
+    pickerMonth.value -= 1;
+  }
+};
+
+const nextMonth = () => {
+  if (pickerMonth.value === 11) {
+    pickerMonth.value = 0;
+    pickerYear.value += 1;
+  } else {
+    pickerMonth.value += 1;
+  }
+};
+
+const choose = (dateStr: string) => {
+  if (!dateStr || outOfRange(dateStr)) return;
+  emit('update:modelValue', dateStr);
+  closePicker(true);
+};
+
+const onKeydown = (event: KeyboardEvent) => {
+  if (event.key !== 'Escape' || !open.value) return;
+  event.preventDefault();
+  event.stopPropagation();
+  closePicker(true);
+};
+
+const onPointerDown = (event: PointerEvent) => {
+  if (!open.value) return;
+  const target = event.target as Node;
+  if (root.value?.contains(target)) return;
+  if (calendarRef.value?.contains(target)) return;
+  closePicker();
+};
+
+const reposition = () => {
+  if (!open.value) return;
+  measure();
+};
+
+watch(open, (isOpen) => {
+  if (isOpen) {
+    window.addEventListener('pointerdown', onPointerDown, true);
+    window.addEventListener('scroll', reposition, true);
+    window.addEventListener('resize', reposition);
+    window.addEventListener('keydown', onKeydown, true);
+  } else {
+    window.removeEventListener('pointerdown', onPointerDown, true);
+    window.removeEventListener('scroll', reposition, true);
+    window.removeEventListener('resize', reposition);
+    window.removeEventListener('keydown', onKeydown, true);
+  }
+});
+onBeforeUnmount(() => {
+  window.removeEventListener('pointerdown', onPointerDown, true);
+  window.removeEventListener('scroll', reposition, true);
+  window.removeEventListener('resize', reposition);
+  window.removeEventListener('keydown', onKeydown, true);
+});
+</script>
+
+<template>
+  <div ref="root" :class="['date-picker', { 'is-open': open, 'is-disabled': disabled }]">
+    <button
+      type="button"
+      class="date-picker-trigger"
+      ref="triggerRef"
+      :disabled="disabled"
+      :aria-label="ariaLabel || t.aria"
+      :aria-expanded="open"
+      aria-haspopup="dialog"
+      @click="toggle"
+    >
+      <span :class="['date-picker-value', { placeholder: !modelValue }]">{{ displayValue }}</span>
+      <Icon name="clock" :size="14" class="date-picker-icon" />
+    </button>
+
+    <Teleport to="body">
+      <div
+        v-if="open"
+        ref="calendarRef"
+        class="date-picker-popover"
+        :style="calendarStyle"
+        role="dialog"
+        :aria-label="ariaLabel || t.aria"
+        @pointerdown.stop
+        @mousedown.prevent
+      >
+        <div class="date-picker-header">
+          <button type="button" class="date-picker-nav" :aria-label="t.prev" @click="prevMonth">
+            <Icon name="arrow-left" :size="12" />
+          </button>
+          <span class="date-picker-title">{{ monthTitle }}</span>
+          <button type="button" class="date-picker-nav" :aria-label="t.next" @click="nextMonth">
+            <Icon name="arrow-right" :size="12" />
+          </button>
+        </div>
+        <div class="date-picker-weekdays">
+          <span v-for="(name, index) in weekdayNames" :key="`${name}-${index}`">{{ name }}</span>
+        </div>
+        <div class="date-picker-grid">
+          <button
+            v-for="(cell, index) in cells"
+            :key="cell.dateStr || `empty-${index}`"
+            type="button"
+            :disabled="!cell.day || outOfRange(cell.dateStr)"
+            :class="['date-picker-day', {
+              'is-empty': !cell.day,
+              'is-selected': cell.dateStr === modelValue,
+              'is-today': cell.dateStr === today,
+            }]"
+            @click="choose(cell.dateStr)"
+          >{{ cell.day || '' }}</button>
+        </div>
+      </div>
+    </Teleport>
+  </div>
+</template>
+
+<style>
+.date-picker-popover {
+  z-index: 2200;
+  overflow-y: auto;
+  padding: 10px;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-sm);
+  background: var(--surface-raised);
+  box-shadow: 0 18px 44px rgba(4, 6, 8, .55);
+}
+.date-picker-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+.date-picker-title {
+  color: var(--ink);
+  font-size: var(--fs-sm);
+  font-weight: 600;
+}
+.date-picker-nav {
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border: 0;
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--muted);
+  cursor: pointer;
+}
+.date-picker-nav:hover { color: var(--accent); }
+.date-picker-weekdays {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  margin-bottom: 4px;
+  color: var(--subtle);
+  font-size: var(--fs-2xs);
+  text-align: center;
+}
+.date-picker-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 2px;
+}
+.date-picker-day {
+  display: grid;
+  place-items: center;
+  height: 32px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--ink);
+  font-size: var(--fs-xs);
+  font-family: var(--font-mono);
+  cursor: pointer;
+}
+.date-picker-day:hover:not(:disabled) { background: var(--surface-hover); }
+.date-picker-day.is-today:not(.is-selected) { box-shadow: inset 0 0 0 1px var(--line-control); }
+.date-picker-day.is-selected { background: var(--accent); color: var(--accent-ink); font-weight: 700; }
+.date-picker-day.is-empty,
+.date-picker-day:disabled { cursor: default; color: var(--subtle); }
+.date-picker-day.is-empty { visibility: hidden; }
+</style>
+
+<style scoped>
+.date-picker { min-width: 0; width: 100%; }
+.date-picker-trigger {
+  display: flex;
+  width: 100%;
+  min-height: 44px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 6px 10px;
+  border: 1px solid var(--line-control);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--ink);
+  font: inherit;
+  font-size: var(--fs-md);
+  text-align: left;
+  cursor: pointer;
+}
+.date-picker-trigger:hover:not(:disabled) { border-color: var(--line-control); }
+.date-picker-trigger:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+.is-open .date-picker-trigger { border-color: var(--accent); }
+.is-disabled .date-picker-trigger,
+.date-picker-trigger:disabled { opacity: .55; cursor: not-allowed; }
+.date-picker-value { min-width: 0; overflow-wrap: anywhere; }
+.date-picker-value.placeholder { color: var(--subtle); }
+.date-picker-icon { flex: 0 0 auto; color: var(--muted); }
+</style>

--- a/src/components/HistoryArchivePanel.vue
+++ b/src/components/HistoryArchivePanel.vue
@@ -11,6 +11,7 @@
  * 「我 2023 年的数据到底有没有」。
  */
 import { computed, onMounted, ref, watch } from 'vue';
+import DatePicker from './DatePicker.vue';
 import SelectMenu from './SelectMenu.vue';
 import { useSyncController } from '../composables/useSyncController';
 import { backend, isDesktop, toUserMessage } from '../lib/bridge';
@@ -534,7 +535,7 @@ const resetLedger = async () => {
     </div>
     <div v-if="startChoice === 'custom'" class="field-row">
       <span class="kv-label">{{ t.customDateLabel }}</span>
-      <input v-model="customFrom" type="date" :aria-label="t.customDateAria" />
+      <DatePicker v-model="customFrom" :aria-label="t.customDateAria" />
     </div>
 
     <div v-if="estimate" class="estimate-block">
@@ -691,6 +692,7 @@ h2 { margin: 0 0 14px; font-size: var(--fs-xl); font-weight: 700; color: var(--i
   font-size: var(--fs-sm);
 }
 .field-row .select-menu { min-width: 220px; flex: 0 0 auto; }
+.field-row .date-picker { min-width: 180px; flex: 1 1 auto; max-width: 280px; }
 .kv-label { flex: 0 0 96px; color: var(--muted); font-size: var(--fs-sm); }
 .retain-note { margin: 6px 0 8px; color: var(--muted); font-size: var(--fs-sm); line-height: 1.6; }
 .inline-actions { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 12px; }

--- a/src/components/LifeEventEditor.vue
+++ b/src/components/LifeEventEditor.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue';
+import DatePicker from './DatePicker.vue';
 import ModalDialog from './ModalDialog.vue';
 import { useLifeEvents } from '../composables/useLifeEvents';
 import { tauriApi } from '../composables/useTauriApi';
@@ -39,8 +40,12 @@ async function remove() {
         <label>{{ t.name }}<input v-model="draft.title" required maxlength="120" :placeholder="t.placeholder" data-event-title></label>
         <label>{{ t.category }}<select v-model="draft.category"><option v-for="category in eventCategories" :key="category" :value="category">{{ t.categories[category] }}</option></select></label>
         <div class="event-dates">
-          <label>{{ t.start }}<input v-model="draft.startDate" type="date" required data-event-start></label>
-          <label v-if="!ongoing">{{ t.end }}<input v-model="draft.endDate" type="date" :min="draft.startDate" required data-event-end></label>
+          <label>{{ t.start }}
+            <DatePicker v-model="draft.startDate" :aria-label="t.start" data-event-start />
+          </label>
+          <label v-if="!ongoing">{{ t.end }}
+            <DatePicker v-model="draft.endDate" :min="draft.startDate" :aria-label="t.end" data-event-end />
+          </label>
         </div>
         <label class="check"><input v-model="ongoing" type="checkbox">{{ t.ongoing }}</label>
         <label>{{ t.notes }}<textarea v-model="draft.notes" maxlength="4000" rows="4" data-event-notes /></label>

--- a/src/lib/__tests__/calendarLocale.test.ts
+++ b/src/lib/__tests__/calendarLocale.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { setLocale } from '../../i18n';
+import {
+  calendarCells,
+  calendarMonthTitle,
+  calendarWeekdayNames,
+  calendarWeekStart,
+} from '../calendarLocale';
+
+const CJK = /[一-鿿]/;
+
+afterEach(() => setLocale('zh'));
+
+describe('calendar locale follows the OS region, not the in-app language', () => {
+  it('does not change when the UI language is switched', () => {
+    setLocale('en');
+    const withEnglishUi = calendarMonthTitle(2026, 8);
+    setLocale('zh');
+    const withChineseUi = calendarMonthTitle(2026, 8);
+    expect(withEnglishUi).toBe(withChineseUi);
+  });
+
+  it('prints an English month title for en-US', () => {
+    const title = calendarMonthTitle(2026, 8, 'en-US');
+    expect(title.toLowerCase()).toContain('september');
+    expect(title).toContain('2026');
+    expect(title).not.toMatch(CJK);
+  });
+
+  it('prints a Chinese month title for zh-CN', () => {
+    const title = calendarMonthTitle(2026, 8, 'zh-CN');
+    expect(title).toMatch(/年/);
+    expect(title).toMatch(/9/);
+    expect(title).toContain('2026');
+  });
+
+  it('prints a German month title for de-DE, which the UI does not offer', () => {
+    const title = calendarMonthTitle(2026, 2, 'de-DE');
+    expect(title.toLowerCase()).toContain('märz');
+    expect(title).not.toMatch(CJK);
+  });
+
+  it('keeps en-US weekday names free of CJK', () => {
+    const names = calendarWeekdayNames('en-US');
+    expect(names).toHaveLength(7);
+    expect(names.join(' ')).not.toMatch(CJK);
+    expect(names.some((name) => /sun/i.test(name))).toBe(true);
+  });
+
+  it('starts the US week on Sunday and the Chinese/German week on Monday', () => {
+    expect(calendarWeekStart('en-US')).toBe(0);
+    expect(calendarWeekStart('zh-CN')).toBe(1);
+    expect(calendarWeekStart('de-DE')).toBe(1);
+  });
+
+  it('pads the grid so the first of the month lands on the region week start', () => {
+    // 2026-09-01 is a Tuesday (getDay() === 2). Sunday-first → two blanks.
+    const english = calendarCells(2026, 8, 'en-US');
+    expect(english.slice(0, 2).every((cell) => cell.day === null)).toBe(true);
+    expect(english[2]).toEqual({ day: 1, dateStr: '2026-09-01' });
+
+    // Monday-first → one blank.
+    const chinese = calendarCells(2026, 8, 'zh-CN');
+    expect(chinese[0]?.day).toBeNull();
+    expect(chinese[1]).toEqual({ day: 1, dateStr: '2026-09-01' });
+  });
+});

--- a/src/lib/calendarLocale.ts
+++ b/src/lib/calendarLocale.ts
@@ -1,0 +1,92 @@
+/**
+ * 日历上的月份名、星期名、一周从哪天起。
+ *
+ * **跟系统地区，不跟界面语言。** 界面只有中/英/西三份，系统地区却有很多：
+ * 德语 Windows 上用英文界面的人，日历仍该是 März / Mo Di Mi，而不是
+ * 被折成 English。原生 `<input type="date">` 就是这个合同，自绘日历沿用。
+ *
+ * 可选的 `localeTag` 只给测试用。界面调用一律不传，读 `navigator`。
+ *
+ * 日期数字怎么排（年/月/日）是另一件事，由 `displayDateTimeFormatter` 和
+ * 设置里的日期顺序偏好管。这里只决定日历上的**字**。
+ */
+
+interface LocaleWeekInfo {
+  firstDay: number;
+}
+
+export const systemLocaleTag = (): string | undefined => {
+  if (typeof navigator === 'undefined') return undefined;
+  return navigator.languages?.[0] || navigator.language || undefined;
+};
+
+const resolveTag = (localeTag?: string): string | undefined =>
+  localeTag || systemLocaleTag();
+
+const weekInfoOf = (tag: string): LocaleWeekInfo | undefined => {
+  try {
+    const info = (new Intl.Locale(tag) as Intl.Locale & { weekInfo?: LocaleWeekInfo }).weekInfo;
+    return info;
+  } catch {
+    return undefined;
+  }
+};
+
+const isCjkLocale = (tag: string | undefined): boolean =>
+  Boolean(tag && /^(zh|ja|ko)\b/i.test(tag));
+
+/** JS `Date#getDay`：0 是星期日。 */
+export const calendarWeekStart = (localeTag?: string): number => {
+  const tag = resolveTag(localeTag);
+  const first = tag ? weekInfoOf(tag)?.firstDay : undefined;
+  if (typeof first === 'number') return first === 7 ? 0 : first;
+  // weekInfo 缺失时：美式英语周日，其余按 ISO 周一。
+  if (tag && /^en\b/i.test(tag) && !/-(GB|IE|AU|NZ|ZA|IN)/i.test(tag)) return 0;
+  return 1;
+};
+
+export const calendarMonthTitle = (
+  year: number,
+  monthIndex: number,
+  localeTag?: string,
+): string =>
+  new Intl.DateTimeFormat(resolveTag(localeTag), { year: 'numeric', month: 'long' })
+    .format(new Date(year, monthIndex, 1));
+
+export const calendarWeekdayNames = (localeTag?: string): string[] => {
+  const tag = resolveTag(localeTag);
+  const sunday = new Date(2026, 0, 4);
+  const formatter = new Intl.DateTimeFormat(tag, {
+    weekday: isCjkLocale(tag) ? 'narrow' : 'short',
+  });
+  const start = calendarWeekStart(tag);
+  return Array.from({ length: 7 }, (_unused, offset) => {
+    const day = (start + offset) % 7;
+    return formatter.format(new Date(2026, 0, sunday.getDate() + day));
+  });
+};
+
+export interface CalendarCell {
+  day: number | null;
+  dateStr: string;
+}
+
+export const calendarCells = (
+  year: number,
+  monthIndex: number,
+  localeTag?: string,
+): CalendarCell[] => {
+  const firstWeekday = new Date(year, monthIndex, 1).getDay();
+  const leading = (firstWeekday - calendarWeekStart(localeTag) + 7) % 7;
+  const daysInMonth = new Date(year, monthIndex + 1, 0).getDate();
+  const cells: CalendarCell[] = [];
+  for (let index = 0; index < leading; index += 1) {
+    cells.push({ day: null, dateStr: '' });
+  }
+  for (let day = 1; day <= daysInMonth; day += 1) {
+    const month = String(monthIndex + 1).padStart(2, '0');
+    const dayPart = String(day).padStart(2, '0');
+    cells.push({ day, dateStr: `${year}-${month}-${dayPart}` });
+  }
+  return cells;
+};

--- a/src/views/BodyStatus.vue
+++ b/src/views/BodyStatus.vue
@@ -32,6 +32,7 @@ const messages = defineMessages(
     title: '身体状态',
     intro: '恢复、压力、血氧、HRV、呼吸率、静息心率、体重体成分与饮食摄入的本机趋势。全部读自已同步的记录。',
     rangeAria: '时间范围',
+    trendRangeLabel: '趋势范围',
     desktopOnly: '请使用桌面应用；浏览器预览不会读取账户数据。',
     loadFailed: '身体状态数据暂时不可用',
     retry: '重试',
@@ -111,6 +112,7 @@ const messages = defineMessages(
     title: 'Body status',
     intro: 'Local trends for readiness, stress, blood oxygen, HRV, respiratory rate, resting heart rate, body composition and food intake. All read from synced records.',
     rangeAria: 'Time range',
+    trendRangeLabel: 'Trend range',
     desktopOnly: 'Use the desktop app. This browser preview reads no account data.',
     loadFailed: 'Body status data is unavailable right now',
     retry: 'Try again',
@@ -122,7 +124,7 @@ const messages = defineMessages(
     stressLabel: 'Stress',
     stressHint: 'All-day average; the shaded band is that day\'s measured range',
     curveCardAria: '24-hour stress',
-    curveTitle: 'Last 24 hours',
+    curveTitle: 'Last 24 hours of stress',
     curveSub: 'The watch measures every five minutes; individual readings in time order',
     curveChartAria: 'Stress over the last 24 hours',
     curveNoSamples: 'No stress readings in the last 24 hours, so there is no curve to draw. That is what an unworn watch, or all-day monitoring switched off, looks like.',
@@ -190,6 +192,7 @@ const messages = defineMessages(
     title: 'Estado corporal',
     intro: 'Tendencias locales de recuperación, estrés, oxígeno en sangre, VFC, frecuencia respiratoria, frecuencia cardíaca en reposo, composición corporal y alimentación. Todo leído de los registros sincronizados.',
     rangeAria: 'Rango de tiempo',
+    trendRangeLabel: 'Rango de tendencia',
     desktopOnly: 'Usa la app de escritorio. Esta vista previa en el navegador no lee datos de la cuenta.',
     loadFailed: 'Los datos del estado corporal no están disponibles en este momento',
     retry: 'Reintentar',
@@ -201,7 +204,7 @@ const messages = defineMessages(
     stressLabel: 'Estrés',
     stressHint: 'Promedio de todo el día; la banda sombreada es el rango medido ese día',
     curveCardAria: 'Estrés de 24 horas',
-    curveTitle: 'Últimas 24 horas',
+    curveTitle: 'Últimas 24 horas de estrés',
     curveSub: 'El reloj mide cada cinco minutos; lecturas individuales en orden cronológico',
     curveChartAria: 'Estrés de las últimas 24 horas',
     curveNoSamples: 'No hay lecturas de estrés en las últimas 24 horas, así que no hay curva que trazar. Así se ve un reloj que no se usó, o con el monitoreo de todo el día desactivado.',
@@ -791,22 +794,9 @@ watch(dataRevision, () => { void load(); });
       :eyebrow="t.eyebrow"
       :title="t.title"
       :intro="t.intro"
-    >
-      <div class="range-switch" role="radiogroup" :aria-label="t.rangeAria">
-        <button
-          v-for="range in ranges"
-          :key="range.days"
-          type="button"
-          role="radio"
-          :aria-checked="rangeDays === range.days"
-          :class="['range-pill', { 'is-on': rangeDays === range.days }]"
-          @click="rangeDays = range.days"
-        >{{ range.label }}</button>
-      </div>
-    </PageHeader>
+    />
 
     <LifeEventShortcut :days="rangeDays" />
-    <CoverageNotice :requested-days="rangeDays" />
 
     <div v-if="error" class="inline-alert" role="alert">
       <Icon name="warning" :size="14" />{{ error }}
@@ -817,10 +807,6 @@ watch(dataRevision, () => { void load(); });
       <SkeletonBlock v-for="index in 6" :key="index" height="268px" />
     </div>
     <template v-else>
-      <p v-if="!anyData && !error" class="inline-alert" role="status">
-        <Icon name="info" :size="14" />
-        {{ t.noneInRange }}
-      </p>
       <section class="surface-card day-card" :aria-label="t.curveCardAria">
         <header class="day-head">
           <div>
@@ -847,6 +833,28 @@ watch(dataRevision, () => { void load(); });
         </p>
         <p class="curve-note">{{ t.curveNote }}</p>
       </section>
+
+      <!-- 24 小时压力曲线不跟这个开关走。放在曲线下面，才不会让人以为
+           切 7 天 / 1 个月会改那张大图。 -->
+      <div class="range-toolbar">
+        <p class="range-label">{{ t.trendRangeLabel }}</p>
+        <div class="range-switch" role="radiogroup" :aria-label="t.rangeAria">
+          <button
+            v-for="range in ranges"
+            :key="range.days"
+            type="button"
+            role="radio"
+            :aria-checked="rangeDays === range.days"
+            :class="['range-pill', { 'is-on': rangeDays === range.days }]"
+            @click="rangeDays = range.days"
+          >{{ range.label }}</button>
+        </div>
+      </div>
+      <CoverageNotice :requested-days="rangeDays" />
+      <p v-if="!anyData && !error" class="inline-alert" role="status">
+        <Icon name="info" :size="14" />
+        {{ t.noneInRange }}
+      </p>
 
       <div class="card-grid">
         <MetricTrendCard
@@ -934,6 +942,14 @@ watch(dataRevision, () => { void load(); });
 
 <style scoped>
 .body-page.page { display: grid; gap: var(--space-4); align-content: start; }
+.range-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.range-label { margin: 0; color: var(--ink); font-size: var(--fs-sm); font-weight: 600; }
 .range-switch { display: flex; gap: var(--space-1); padding: 4px; border-radius: var(--radius-sm); background: var(--surface-raised); }
 .range-pill {
   min-height: 30px;

--- a/src/views/Explore.vue
+++ b/src/views/Explore.vue
@@ -18,6 +18,11 @@ import { useSyncController } from '../composables/useSyncController';
 import { isTauri, tauriApi, toUserMessage } from '../composables/useTauriApi';
 import { useLifeEvents } from '../composables/useLifeEvents';
 import { useAiHandoff } from '../composables/useAiHandoff';
+import {
+  calendarCells,
+  calendarMonthTitle,
+  calendarWeekdayNames,
+} from '../lib/calendarLocale';
 import { localDateString } from '../lib/format';
 import { popoverStyle } from '../lib/popoverPosition';
 import { rangeOptions } from '../lib/rangeOptions';
@@ -430,36 +435,11 @@ const nextMonth = () => {
   }
 };
 
-/* 月份和星期名交给 Intl，不再写死中文数组：英文界面上「2026年 8月」
-   既不是英文也不是任何人的日期写法。 */
-const calendarTitle = computed(() => displayDateTimeFormatter({
-  year: 'numeric', month: 'long',
-}).format(new Date(pickerYear.value, pickerMonth.value, 1)));
-
-const weekdayNames = computed(() => {
-  // 2026-01-04 是星期日，从它数七天就是一周的表头。
-  const sunday = new Date(2026, 0, 4);
-  const formatter = displayDateTimeFormatter({
-    weekday: locale.value === 'zh' ? 'narrow' : 'short',
-  });
-  return Array.from({ length: 7 }, (_unused, offset) =>
-    formatter.format(new Date(2026, 0, sunday.getDate() + offset)));
-});
-
-const calendarDays = computed(() => {
-  const firstDay = new Date(pickerYear.value, pickerMonth.value, 1).getDay();
-  const daysInMonth = new Date(pickerYear.value, pickerMonth.value + 1, 0).getDate();
-  const days = [];
-  // 空白占位
-  for (let i = 0; i < firstDay; i++) {
-    days.push({ day: null, dateStr: '' });
-  }
-  for (let i = 1; i <= daysInMonth; i++) {
-    const dateStr = `${pickerYear.value}-${String(pickerMonth.value + 1).padStart(2, '0')}-${String(i).padStart(2, '0')}`;
-    days.push({ day: i, dateStr });
-  }
-  return days;
-});
+/* 月份名、星期名、一周起点跟系统地区，不跟界面语言。界面只有三份，
+   系统地区有很多；德语 Windows 上的英文界面仍该看到 März，而不是 September。 */
+const calendarTitle = computed(() => calendarMonthTitle(pickerYear.value, pickerMonth.value));
+const weekdayNames = computed(() => calendarWeekdayNames());
+const calendarDays = computed(() => calendarCells(pickerYear.value, pickerMonth.value));
 
 const selectCalendarDay = (dateStr: string) => {
   if (!dateStr) return;

--- a/src/views/Settings.i18n.ts
+++ b/src/views/Settings.i18n.ts
@@ -14,6 +14,7 @@ export const settingsMessages = defineMessages(
     intro: '管理认证方式、同步行为、隐私与默认导出偏好，确保本地数据安全。',
     retry: '重试',
     distanceUnitLabel: '距离单位',
+    displayPrefsTitle: '语言与格式',
 
     // ── 1. 认证方式 ──
     authTitle: '1. 认证方式',
@@ -416,6 +417,7 @@ export const settingsMessages = defineMessages(
     intro: 'Authentication, sync behavior, privacy, and the export defaults — all in one place.',
     retry: 'Try again',
     distanceUnitLabel: 'Distance unit',
+    displayPrefsTitle: 'Language and formats',
 
     // ── 1. Authentication ──
     authTitle: '1. Authentication',
@@ -818,6 +820,7 @@ If you need anything from me (which client I use, where the file lives), just as
     intro: 'Autenticación, sincronización, privacidad y opciones de exportación, todo en un solo lugar.',
     retry: 'Reintentar',
     distanceUnitLabel: 'Unidad de distancia',
+    displayPrefsTitle: 'Idioma y formatos',
 
     // ── 1. Authentication ──
     authTitle: '1. Autenticación',

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -1,5 +1,15 @@
 <script setup lang="ts">
-import { TIME_FORMATS, DATE_ORDERS, timeFormat, dateOrder, setTimeFormat, setDateOrder, dateTimeLabels } from '../lib/dateTime';
+import {
+  TIME_FORMATS,
+  DATE_ORDERS,
+  timeFormat,
+  dateOrder,
+  setTimeFormat,
+  setDateOrder,
+  dateTimeLabels,
+  type TimeFormat,
+  type DateOrder,
+} from '../lib/dateTime';
 import { displayDateTimeFormatter } from '../lib/dateTime';
 
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
@@ -35,6 +45,7 @@ import {
   distanceUnit,
   distanceUnitOptionLabel,
   setDistanceUnit,
+  type DistanceUnit,
 } from '../lib/units';
 import { errorTextFor } from '../i18n/errors';
 import { backendText } from '../i18n/backendText';
@@ -194,6 +205,19 @@ const copyMcpConfig = async () => {
     mcpMessage.value = t.value.mcpConfigCopyFailed;
   }
 };
+
+const localeOptions = computed(() =>
+  LOCALES.map((value) => ({ value, label: LOCALE_LABELS[value] })));
+const distanceUnitOptions = computed(() =>
+  DISTANCE_UNITS.map((value) => ({ value, label: distanceUnitOptionLabel(value) })));
+const timeFormatOptions = computed(() =>
+  TIME_FORMATS.map((value) => ({ value, label: dateTimeLabels.value[value] })));
+const dateOrderOptions = computed(() =>
+  DATE_ORDERS.map((value) => ({ value, label: dateTimeLabels.value[value] })));
+const chooseLocale = (value: string | number) => setLocale(String(value) as 'zh' | 'en' | 'es');
+const chooseDistanceUnit = (value: string | number) => setDistanceUnit(String(value) as DistanceUnit);
+const chooseTimeFormat = (value: string | number) => setTimeFormat(String(value) as TimeFormat);
+const chooseDateOrder = (value: string | number) => setDateOrder(String(value) as DateOrder);
 
 const RETENTION_CHOICES = computed(() =>
   [30, 90, 180, 365].map((days) => ({ value: days, label: t.value.days(days) })));
@@ -936,37 +960,49 @@ const runCapabilityProbe = async () => {
         <h1 id="settings-title">{{ t.title }}</h1>
         <p class="page-intro">{{ t.intro }}</p>
       </div>
+    </header>
+
+    <section class="settings-card display-prefs" aria-labelledby="display-prefs-title">
+      <h2 id="display-prefs-title">{{ t.displayPrefsTitle }}</h2>
       <!-- 语言开关标签是双语的，而且不跟着界面语言变：一个看不懂中文的人
            必须能在中文界面上找到它，反过来也一样。 -->
-      <div class="locale-switch">
-        <p class="advanced-label">语言 · Language</p>
-        <div class="scale-options" role="radiogroup" aria-label="语言 · Language">
-          <button
-            v-for="option in LOCALES"
-            :key="option"
-            type="button"
-            role="radio"
-            :aria-checked="locale === option"
-            @click="setLocale(option)"
-          >{{ LOCALE_LABELS[option] }}</button>
-        </div>
+      <div class="field-row">
+        <span class="kv-label">语言 · Language</span>
+        <SelectMenu
+          :model-value="locale"
+          :options="localeOptions"
+          aria-label="语言 · Language"
+          @update:model-value="chooseLocale"
+        />
       </div>
-      <!-- 单位就放在语言旁边：问「怎么把 km 换成 miles」的人（Reddit
-           u/Andrew-Scoggins）第一个会找的就是这里。导出永远是公制，界面才跟着这个走。 -->
-      <div class="locale-switch">
-        <p class="advanced-label">{{ t.distanceUnitLabel }}</p>
-        <div class="scale-options" role="radiogroup" :aria-label="t.distanceUnitLabel">
-          <button
-            v-for="option in DISTANCE_UNITS"
-            :key="option"
-            type="button"
-            role="radio"
-            :aria-checked="distanceUnit === option"
-            @click="setDistanceUnit(option)"
-          >{{ distanceUnitOptionLabel(option) }}</button>
-        </div>
+      <div class="field-row">
+        <span class="kv-label">{{ t.distanceUnitLabel }}</span>
+        <SelectMenu
+          :model-value="distanceUnit"
+          :options="distanceUnitOptions"
+          :aria-label="t.distanceUnitLabel"
+          @update:model-value="chooseDistanceUnit"
+        />
       </div>
-    </header>
+      <div class="field-row">
+        <span class="kv-label">{{ dateTimeLabels.time }}</span>
+        <SelectMenu
+          :model-value="timeFormat"
+          :options="timeFormatOptions"
+          :aria-label="dateTimeLabels.time"
+          @update:model-value="chooseTimeFormat"
+        />
+      </div>
+      <div class="field-row">
+        <span class="kv-label">{{ dateTimeLabels.date }}</span>
+        <SelectMenu
+          :model-value="dateOrder"
+          :options="dateOrderOptions"
+          :aria-label="dateTimeLabels.date"
+          @update:model-value="chooseDateOrder"
+        />
+      </div>
+    </section>
 
     <div v-if="statusError" class="alert danger" role="alert">
       <Icon name="warning" :size="15" />{{ statusError }}
@@ -978,16 +1014,6 @@ const runCapabilityProbe = async () => {
     <div v-if="loginError" class="alert danger" role="alert"><Icon name="warning" :size="15" />{{ loginError }}</div>
     <div v-if="dataMessage" class="alert success"><Icon name="circle-check" :size="15" />{{ dataMessage }}</div>
     <div v-if="dataError" class="alert danger" role="alert"><Icon name="warning" :size="15" />{{ dataError }}</div>
-
-    <section class="settings-card" aria-labelledby="date-time-title">
-      <h2 id="date-time-title">{{ dateTimeLabels.time }} / {{ dateTimeLabels.date }}</h2>
-      <div class="scale-options" role="radiogroup" :aria-label="dateTimeLabels.time">
-        <button v-for="option in TIME_FORMATS" :key="option" type="button" role="radio" :aria-checked="timeFormat === option" @click="setTimeFormat(option)">{{ dateTimeLabels[option] }}</button>
-      </div>
-      <div class="scale-options" role="radiogroup" :aria-label="dateTimeLabels.date">
-        <button v-for="option in DATE_ORDERS" :key="option" type="button" role="radio" :aria-checked="dateOrder === option" @click="setDateOrder(option)">{{ dateTimeLabels[option] }}</button>
-      </div>
-    </section>
 
     <!-- 1. 认证方式 -->
     <section class="settings-card" aria-labelledby="auth-title">
@@ -1748,10 +1774,8 @@ const runCapabilityProbe = async () => {
 .build-stamp { color: var(--subtle); font-size: var(--fs-xs); font-family: var(--font-mono); }
 .page { width: 100%; min-width: 0; margin: 0; display: grid; gap: 14px; }
 .page-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; flex-wrap: wrap; margin-bottom: 0; min-width: 0; }
-.locale-switch { flex: 0 0 auto; text-align: right; }
-.locale-switch .advanced-label { margin-bottom: 6px; }
-.locale-switch .scale-options { justify-content: flex-end; }
-.locale-switch .scale-options button { min-width: 62px; }
+.display-prefs .kv-label { flex: 0 1 168px; }
+.display-prefs .select-menu { min-width: 200px; flex: 1 1 200px; max-width: 280px; }
 h1, h2, h3, p { margin-top: 0; }
 h1 { font-size: 26.5px; font-weight: 700; color: var(--ink); }
 h2 { margin-bottom: 14px; font-size: var(--fs-xl); font-weight: 700; color: var(--ink); }


### PR DESCRIPTION
Reddit feedback (T1beriu) plus the Add Event calendar screenshot.

## Body Status
- English title is now **Last 24 hours of stress** (Spanish: **Últimas 24 horas de estrés**). Chinese was already `最近 24 小时压力`.
- The 7 days / 1 month / 6 months switch sits **under** the 24-hour chart, labelled Trend range, so it no longer looks like it controls that chart. The curve stays fixed at 24 hours.

## Settings
Language, distance unit, time format, and date format are `SelectMenu` dropdowns (same control as workout type correction), not side-by-side pills.

## Add Event calendar
Not hardcoded Chinese. The old native `<input type="date">` follows the **OS region** (WebView2 ignores `<html lang>`), which is why a Chinese Windows install showed `一 二 三` in an English UI.

Replaced with the dark calendar already used on the export page. Month names, weekdays, and week start still follow the **system region**, not the three UI languages — a German Windows user on the English UI should still see März / Mo Di Mi.

Also used on the history-archive custom date field.

## Checks
- `vue-tsc --noEmit`
- `npm test` (133, including new calendar locale cases)
- `npm run i18n:check`
- Browser preview: settings dropdowns, English stress title + moved range switch, Add Event calendar on this machine (zh-CN OS → `2026年9月` / `一–日`)